### PR TITLE
Remove namespace property from the Conduit web app

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -210,7 +210,6 @@ spec:
         - "-static-dir=/dist"
         - "-template-dir=/templates"
         - "-uuid={{.UUID}}"
-        - "-namespace={{.Namespace}}"
 
 ### Prometheus ###
 ---

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -156,7 +156,7 @@ export default class ServiceMesh extends React.Component {
   processComponents(pods) {
     let podIndex = _(pods)
       .filter(p => p.controlPlane)
-      .groupBy(p => {return p.deployment.substring(p.deployment.indexOf('/')+1)})
+      .groupBy(p => _.last(_.split(p.deployment, "/")))
       .value();
 
     return _(componentNames)

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -137,7 +137,6 @@ export default class ServiceMesh extends React.Component {
   }
 
   processDeploys(pods) {
-    let ns = this.props.namespace + "/";
     return _(pods)
       .reject(p => _.isEmpty(p.deployment) || p.controlPlane)
       .groupBy("deployment")
@@ -155,10 +154,9 @@ export default class ServiceMesh extends React.Component {
   }
 
   processComponents(pods) {
-    let ns = this.props.namespace + "/";
     let podIndex = _(pods)
-      .filter(p => _.startsWith(p.deployment, ns))
-      .groupBy(p => _.replace(p.deployment, ns, ""))
+      .filter(p => p.controlPlane)
+      .groupBy(p => {return p.deployment.substring(p.deployment.indexOf('/')+1)})
       .value();
 
     return _(componentNames)
@@ -258,13 +256,13 @@ export default class ServiceMesh extends React.Component {
         {this.unaddedDeploymentCount() === 0 ?
           <div className="complete-mesh-message">
             All deployments have been added to the service mesh.
-          </div> 
-          : this.unaddedDeploymentCount() === 1 ? 
+          </div>
+          : this.unaddedDeploymentCount() === 1 ?
               <div className="incomplete-mesh-message">
-                1 deployment has not been added to the service mesh. 
+                1 deployment has not been added to the service mesh.
                 <div className="instructions">Add the remaining deployment to the deployment.yml file</div>
                 <div className="instructions">Then run <code>conduit inject deployment.yml | kubectl apply -f - </code> to add the deployment to the service mesh</div>
-              </div> 
+              </div>
           : <div className="incomplete-mesh-message">
               {this.unaddedDeploymentCount()} deployments have not been added to the service mesh.
               <div className="instructions">Add one or more deployments to the deployment.yml file</div>

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -89,7 +89,7 @@ export const processMetrics = (rawMetrics, rawTs, targetEntity) => {
   return _.sortBy(metrics, "name");
 }
 
-export const emptyMetric = name => {
+export const emptyMetric = (name, added) => {
   return {
     name: name,
     timeseries: {
@@ -108,7 +108,7 @@ export const emptyMetric = name => {
       latency: 0
     },
     latency: 0,
-    added: false
+    added: added
   }
 }
 

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -34,8 +34,8 @@ ReactDOM.render((
           <div className="main-content">
             <Switch>
               <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
-              <Route path={`${pathPrefix}/servicemesh`} render={() => <ServiceMesh pathPrefix={pathPrefix} releaseVersion={appData.releaseVersion} namespace={appData.namespace} />} />
-              <Route path={`${pathPrefix}/deployments`} render={() => <Deployments pathPrefix={pathPrefix} namespace={appData.namespace}/>} />
+              <Route path={`${pathPrefix}/servicemesh`} render={() => <ServiceMesh pathPrefix={pathPrefix} releaseVersion={appData.releaseVersion} />} />
+              <Route path={`${pathPrefix}/deployments`} render={() => <Deployments pathPrefix={pathPrefix}/>} />
               <Route path={`${pathPrefix}/deployment`} render={(props) => <Deployment pathPrefix={pathPrefix} location={props.location}/>} />
               <Route path={`${pathPrefix}/pod`} render={(props) => <PodDetail pathPrefix={pathPrefix} location={props.location}/>} />
               <Route path={`${pathPrefix}/routes`} render={() => <Routes pathPrefix={pathPrefix}/>} />

--- a/web/main.go
+++ b/web/main.go
@@ -23,7 +23,6 @@ func main() {
 	apiAddr := flag.String("api-addr", ":8085", "address of public api")
 	templateDir := flag.String("template-dir", "templates", "directory to search for template files")
 	staticDir := flag.String("static-dir", "app/dist", "directory to search for static files")
-	namespace := flag.String("namespace", "conduit", "namespace in which Conduit is installed")
 	uuid := flag.String("uuid", "", "unqiue Conduit install id")
 	reload := flag.Bool("reload", true, "reloading set to true or false")
 	logLevel := flag.String("log-level", "info", "log level, must be one of: panic, fatal, error, warn, info, debug")
@@ -58,7 +57,7 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	server := srv.NewServer(*addr, *templateDir, *staticDir, *namespace, *uuid, *webpackDevServer, *reload, client)
+	server := srv.NewServer(*addr, *templateDir, *staticDir, *uuid, *webpackDevServer, *reload, client)
 
 	go func() {
 		log.Info("starting HTTP server on", *addr)

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -16,13 +16,12 @@ type (
 		render    renderTemplate
 		serveFile serveFile
 		apiClient pb.ApiClient
-		namespace string
 		uuid      string
 	}
 )
 
 func (h *handler) handleIndex(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
-	params := appParams{Namespace: h.namespace, UUID: h.uuid}
+	params := appParams{UUID: h.uuid}
 
 	version, err := h.apiClient.Version(req.Context(), &pb.Empty{}) // TODO: remove and call /api/version from web app
 	if err != nil {

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -40,7 +40,6 @@ type (
 	}
 	appParams struct {
 		Data         *pb.VersionInfo
-		Namespace    string
 		UUID         string
 		Error        bool
 		ErrorMessage string
@@ -52,7 +51,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.router.ServeHTTP(w, req)
 }
 
-func NewServer(addr, templateDir, staticDir, namespace, uuid, webpackDevServer string, reload bool, apiClient pb.ApiClient) *http.Server {
+func NewServer(addr, templateDir, staticDir, uuid, webpackDevServer string, reload bool, apiClient pb.ApiClient) *http.Server {
 	counter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "http_requests_total",
@@ -79,7 +78,6 @@ func NewServer(addr, templateDir, staticDir, namespace, uuid, webpackDevServer s
 		apiClient: apiClient,
 		render:    server.RenderTemplate,
 		serveFile: server.serveFile,
-		namespace: namespace,
 		uuid:      uuid,
 	}
 

--- a/web/templates/app.tmpl.html
+++ b/web/templates/app.tmpl.html
@@ -1,5 +1,5 @@
 {{ define "content" }}
-  <div class="main" id="main" data-release-version="{{.Data.ReleaseVersion}}" data-go-version="{{.Data.GoVersion}}" data-namespace="{{.Namespace}}" data-uuid="{{.UUID}}">
+  <div class="main" id="main" data-release-version="{{.Data.ReleaseVersion}}" data-go-version="{{.Data.GoVersion}}" data-uuid="{{.UUID}}">
     {{ if .Error }}
       <p>Failed to call public API: {{ .ErrorMessage }}</p>
     {{ end }}


### PR DESCRIPTION
The servicemesh and deployments page in the Conduit web app rely on a namespace property that describes where conduit components reside in k8s. The web app uses this property to filter pods from k8s into lists that contain pods that are and aren't in the conduit namespace. The public API already does this filtering so the namespace property is no longer needed in the web app. This change has been tested in a minikube instance locally and uses the hello-world grpc example to verify the change is correct.