### PR TITLE
Fix simulate-proxy script

### DIFF
--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -52,7 +52,7 @@ func randomLatencies(count uint32) (latencies []*pb.Latency) {
 		latencyValue := uint32(rand.Int31n(int32(time.Second / (time.Millisecond * 10))))
 		latency := pb.Latency{
 			Latency: latencyValue,
-			Count:   count,
+			Count:   1,
 		}
 		latencies = append(latencies, &latency)
 	}

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -49,10 +49,10 @@ func randomLatencies(count uint32) (latencies []*pb.Latency) {
 	for i := uint32(0); i < count; i++ {
 
 		// The latency value with precision to 100µs.
-		latencyValue := uint32(rand.Int31n(int32(time.Second/(time.Millisecond * 10))))
+		latencyValue := uint32(rand.Int31n(int32(time.Second / (time.Millisecond * 10))))
 		latency := pb.Latency{
 			Latency: latencyValue,
-			Count: rand.Uint32(),
+			Count:   count,
 		}
 		latencies = append(latencies, &latency)
 	}


### PR DESCRIPTION
Problem:
Simulate proxy would seemingly hang when used.
In simulate-proxy we were using `rand.Uint32()` to generate Count. This is way too big (in telemetry/server.go we call `latencyStat.observe()` Count times, so this loop was taking fovever). 

Solution:
Use a count of 1 (as the surrounding loop will generate `count` requests)

Validation:
Script now works without hanging.