### PR TITLE
Miscellaneous small dashboard fixes

### DIFF
--- a/web/app/css/health-pane.css
+++ b/web/app/css/health-pane.css
@@ -8,6 +8,10 @@
     font-weight: var(--font-weight-bold);
   }
 
+  & .float-right .metric-value {
+    float: right;
+  }
+
   & .metric-value {
     font-weight: var(--font-weight-extra-bold);
   }

--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -37,6 +37,11 @@ td .status-dot {
   border-radius: 50%;
   margin-right: var(--base-width);
 
+  &.dot-multiline {
+    margin-top: calc(0.5 * var(--base-width));
+    margin-bottom: calc(0.5 * var(--base-width));
+  }
+
   &.status-dot-good {
     background-color: #27AE60;
   }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -61,6 +61,10 @@ h2, h3, h4, h5, h6 {
   margin-bottom: 30px;
 }
 
+.page-header .subsection-header {
+  margin-bottom: 0px;
+}
+
 .subsection-header {
   text-transform: uppercase;
   font-size: 14px;

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -122,11 +122,13 @@ export default class Deployment extends React.Component {
   }
 
   renderSections() {
+    let currentSuccessRate = _.get(_.last(_.get(this.state.summaryMetrics, "SUCCESS_RATE", [])), "value");
     return [
       <HealthPane
         key="deploy-health-pane"
         entity={this.state.deploy}
         entityType="deployment"
+        currentSr={currentSuccessRate}
         upstreamMetrics={this.state.upstreamMetrics}
         downstreamMetrics={this.state.downstreamMetrics}
       />,

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -208,8 +208,8 @@ export default class Deployment extends React.Component {
         <div className="page-header">
           <div className="subsection-header">Deployment detail</div>
           <h1>{this.state.deploy}</h1>
-          {this.renderContent()}
         </div>
+        {this.renderContent()}
       </div>
     );
   }

--- a/web/app/js/components/HealthPane.jsx
+++ b/web/app/js/components/HealthPane.jsx
@@ -15,6 +15,8 @@ const TrafficIndicator = () => {
   );
 }
 
+const neutralSr = 0.5;
+
 export default class HealthPane extends React.Component {
   getRequestRate(metrics) {
     return _.sumBy(metrics, metric => {
@@ -41,8 +43,7 @@ export default class HealthPane extends React.Component {
   getHealthStats() {
     let inboundSr = this.getAvgSuccessRate(this.props.upstreamMetrics);
     let outboundSr = this.getAvgSuccessRate(this.props.downstreamMetrics);
-    // let sr = _.get(this.props.metrics, [0, 'rollup', 'successRate'], 0);
-    let sr = Math.random() // TODO: get actual metric
+    let sr = _.isUndefined(this.props.currentSr) ? neutralSr : this.props.currentSr;
 
     return {
       inbound: {

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -83,11 +83,13 @@ export default class PodDetail extends React.Component {
   }
 
   renderSections() {
+    let currentSuccessRate = _.get(_.last(_.get(this.state.summaryMetrics, "SUCCESS_RATE", [])), "value");
     return [
       <HealthPane
         key="pod-health-pane"
         entity={this.state.pod}
         entityType="pod"
+        currentSr={currentSuccessRate}
         upstreamMetrics={this.state.upstreamMetrics}
         downstreamMetrics={this.state.downstreamMetrics}
       />,

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -125,8 +125,8 @@ export default class PodDetail extends React.Component {
         <div className="page-header">
           <div className="subsection-header">Pod detail</div>
           <h1>{this.state.pod}</h1>
-          {this.renderContent()}
         </div>
+        {this.renderContent()}
       </div>
     );
   }

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -1,12 +1,29 @@
 import React from 'react';
 import * as d3 from 'd3';
 import { Link } from 'react-router-dom';
-import { Table, Tabs } from 'antd';
+import { Table, Tabs, Tooltip } from 'antd';
 import { toClassName, metricToFormatter } from './util/Utils.js';
 
 const getStatusDotCn = status => {
   return `status-dot-${status === "good" ? "green" : "grey"}`;
 }
+
+const statusDotExplanation = {
+  good: "has been added to the mesh",
+  neutral: "has not been added to the mesh"
+};
+
+const StatusDot = ({status}) => (
+  <Tooltip
+    placement="top"
+    title={`${status.name} ${statusDotExplanation[status.value]}`}
+  >
+    <div
+      className={`status-dot status-dot-${status.value}`}
+      key={status.name}
+    >&nbsp;</div>
+  </Tooltip>
+);
 
 const columns = {
   resourceName: (shouldLink, pathPrefix) => {
@@ -36,11 +53,7 @@ const columns = {
       render: statuses => {
         return _.map(statuses, status => {
           // TODO: handle case where there are too many dots for column
-          return <div
-            className={`status-dot status-dot-${status.value}`}
-            key={status.name}
-            title={status.name}
-          >&nbsp;</div>
+          return <StatusDot status={status} />
         });
       }
     }

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -8,29 +8,37 @@ const getStatusDotCn = status => {
   return `status-dot-${status === "good" ? "green" : "grey"}`;
 }
 
-const statusDotExplanation = {
+const columnConfig = {
   "Pod Status": {
-    good: "is up and running",
-    neutral: "has not been started"
+    width: 200,
+    wrapDotsAt: 7, // dots take up more than one line in the table; space them out
+    dotExplanation: {
+      good: "is up and running",
+      neutral: "has not been started"
+    }
   },
   "Proxy Status": {
-    good: "has been added to the mesh",
-    neutral: "has not been added to the mesh"
+    width: 250,
+    wrapDotsAt: 9,
+    dotExplanation: {
+      good: "has been added to the mesh",
+      neutral: "has not been added to the mesh"
+    }
   }
-};
+}
 
-const StatusDot = ({status, columnName}) => (
+const StatusDot = ({status, multilineDots, columnName}) => (
   <Tooltip
     placement="top"
     title={
       <div>
         <div>{status.name}</div>
-        <div>{_.get(statusDotExplanation, [columnName, status.value])}</div>
+        <div>{_.get(columnConfig, [columnName, "dotExplanation", status.value])}</div>
       </div>
     }
   >
     <div
-      className={`status-dot status-dot-${status.value}`}
+      className={`status-dot status-dot-${status.value} ${multilineDots ? 'dot-multiline': ''}`}
       key={status.name}
     >&nbsp;</div>
   </Tooltip>
@@ -61,11 +69,14 @@ const columns = {
       title: name,
       dataIndex: "statuses",
       key: "statuses",
+      width: columnConfig[name].width,
       render: statuses => {
+        let multilineDots = _.size(statuses) > columnConfig[name].wrapDotsAt;
+
         return _.map(statuses, (status, i) => {
-          // TODO: handle case where there are too many dots for column
           return <StatusDot
             status={status}
+            multilineDots={multilineDots}
             columnName={name}
             key={`${name}-pod-status-${i}`}
           />

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -9,14 +9,25 @@ const getStatusDotCn = status => {
 }
 
 const statusDotExplanation = {
-  good: "has been added to the mesh",
-  neutral: "has not been added to the mesh"
+  "Pod Status": {
+    good: "is up and running",
+    neutral: "has not been started"
+  },
+  "Proxy Status": {
+    good: "has been added to the mesh",
+    neutral: "has not been added to the mesh"
+  }
 };
 
-const StatusDot = ({status}) => (
+const StatusDot = ({status, columnName}) => (
   <Tooltip
     placement="top"
-    title={`${status.name} ${statusDotExplanation[status.value]}`}
+    title={
+      <div>
+        <div>{status.name}</div>
+        <div>{_.get(statusDotExplanation, [columnName, status.value])}</div>
+      </div>
+    }
   >
     <div
       className={`status-dot status-dot-${status.value}`}
@@ -51,9 +62,13 @@ const columns = {
       dataIndex: "statuses",
       key: "statuses",
       render: statuses => {
-        return _.map(statuses, status => {
+        return _.map(statuses, (status, i) => {
           // TODO: handle case where there are too many dots for column
-          return <StatusDot status={status} />
+          return <StatusDot
+            status={status}
+            columnName={name}
+            key={`${name}-pod-status-${i}`}
+          />
         });
       }
     }

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -1,22 +1,75 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
 
-// Grid constants
+/*
+* Display grid constants
+*/
 export const baseWidth = 8; // design base width of 8px
 export const rowGutter = 3 * baseWidth;
 
-// Formatters
-const requestsFormatter = d3.format(",.3");
+/*
+* Number formatters
+*/
 const successRateFormatter = d3.format(".2%");
 const latencyFormatter = d3.format(",");
 
 export const metricToFormatter = {
-  "REQUEST_RATE": m => `${_.isNil(m) ? "---" : requestsFormatter(m)} RPS`,
+  "REQUEST_RATE": m => _.isNil(m) ? "---" : styleNum(m, " RPS", true),
   "SUCCESS_RATE": m => _.isNil(m) ? "---" : successRateFormatter(m),
   "LATENCY": m => `${_.isNil(m) ? "---" : latencyFormatter(m)} ms`
 }
 
-// Classname utilities
+/*
+* Add commas to a number (converting it to a string in the process)
+*/
+export function addCommas(nStr) {
+  nStr += '';
+  let x = nStr.split('.');
+  let x1 = x[0];
+  let x2 = x.length > 1 ? '.' + x[1] : '';
+  let rgx = /(\d+)(\d{3})/;
+  while (rgx.test(x1)) {
+    x1 = x1.replace(rgx, '$1' + ',' + '$2');
+  }
+  return x1 + x2;
+}
+
+/*
+* Round a number to a given number of decimals
+*/
+export const roundNumber = (num, dec) => {
+  return Math.round(num * Math.pow(10,dec)) / Math.pow(10,dec);
+}
+
+/*
+* Shorten and style number
+*/
+export const styleNum = (number, unit = "", truncate = true) => {
+  if (Number.isNaN(number)) {
+    return "N/A";
+  }
+
+  if (truncate && number > 999999999) {
+    number = roundNumber(number / 1000000000.0, 1);
+    return addCommas(number) + "G" + unit;
+  } else if (truncate && number > 999999) {
+    number = roundNumber(number / 1000000.0, 1);
+    return addCommas(number) + "M" + unit;
+  } else if (truncate && number > 999) {
+    number = roundNumber(number / 1000.0, 1);
+    return addCommas(number) + "k" + unit;
+  } else if (number > 999) {
+    number = roundNumber(number, 0);
+    return addCommas(number) + unit;
+  } else {
+    number = roundNumber(number, 2);
+    return addCommas(number) + unit;
+  }
+}
+
+/*
+* Convert a string to a valid css class name
+*/
 export const toClassName = name => {
   if (!name) return "";
   return _.lowerCase(name).replace(/[^a-zA-Z0-9]/g, "_");


### PR DESCRIPTION
Fix various loose ends in the web app:
- Add tooltip explaining dot color in status tables
- Format RPS numbers with commas instead of exponents
- Use actual health stat rather than random stat in health pane
- Fix alignment of metric value in health pane
- Fix page headers where in pod/deployment detail pages, titles looked weird

Notes:
- For the health stat, I'm using the most recent success rate number. Alternatively we could use the rollup over the query period.
- The explanation for the green/grey dots will be "has [not] been added to the mesh" which ~suffices for the data plane and control plane dots, but we could display different messages

![screen shot 2017-12-08 at 12 03 46 pm](https://user-images.githubusercontent.com/549258/33783078-ff08cb5c-dc0f-11e7-88af-392d789a9aed.png)

Before:
![screen shot 2017-12-08 at 12 05 39 pm](https://user-images.githubusercontent.com/549258/33783120-2b0b24de-dc10-11e7-8df7-8d466ae6f84c.png)


After:
![screen shot 2017-12-08 at 12 02 01 pm](https://user-images.githubusercontent.com/549258/33783083-0583164a-dc10-11e7-9905-a58509b8ffd3.png)

