### PR TITLE
Proxy: Use production config parsing in tests

### DIFF
--- a/proxy/src/app.rs
+++ b/proxy/src/app.rs
@@ -1,7 +1,9 @@
-use config::{self, Config};
+use config::{self, Config, Env};
+use convert::TryFrom;
 use logging;
 
 pub fn init() -> Result<Config, config::Error> {
     logging::init();
-    Config::load_from_env()
+    let config_strings = Env;
+    Config::try_from(&config_strings)
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -60,7 +60,7 @@ mod bind;
 pub mod config;
 mod connection;
 pub mod control;
-mod convert;
+pub mod convert;
 mod ctx;
 mod dns;
 mod inbound;


### PR DESCRIPTION
Previosuly the testing code for the proxy was sensitive to the values
of environment variables unintentionally, because `Config` looked at
the environment variables. Also, the tests were largely avoiding
testing the production configuration parsing code since they were
doing their own parsing.

Now the tests avoid looking at environment variables other than
`ENV_LOG`, which makes them more resilient. Also the tests now parse
the settings using the same code as production use uses.

I validated this manually.