### PR TITLE
Allow Deployments page to handle larger numbers of deployments

### DIFF
--- a/web/app/css/line-graph.css
+++ b/web/app/css/line-graph.css
@@ -21,10 +21,3 @@
 .line-p99 {
   stroke: var(--latency-p99);
 }
-
-.line-graph {
-  & .loading-message {
-    font-size: 12px;
-    fill: var(--coldgrey);
-  }
-}

--- a/web/app/css/line-graph.css
+++ b/web/app/css/line-graph.css
@@ -21,3 +21,10 @@
 .line-p99 {
   stroke: var(--latency-p99);
 }
+
+.line-graph {
+  & .loading-message {
+    font-size: 12px;
+    fill: var(--coldgrey);
+  }
+}

--- a/web/app/js/components/BarChart.jsx
+++ b/web/app/js/components/BarChart.jsx
@@ -73,7 +73,7 @@ export default class LineGraph extends React.Component {
   chartData() {
     let data = this.props.data;
     _.each(data, d => {
-      let p = new Percentage(d.rollup.requestRate, d.rollup.totalRequests);
+      let p = new Percentage(d.requestRate, d.totalRequests);
       d.shareOfRequests = p.get();
       d.pretty = p.prettyRate();
     });
@@ -83,7 +83,7 @@ export default class LineGraph extends React.Component {
   updateScales() {
     let data = this.chartData();
     this.xScale.domain(_.map(data, d => d.name));
-    this.yScale.domain([0, d3.max(data, d => d.rollup.requestRate)]);
+    this.yScale.domain([0, d3.max(data, d => d.requestRate)]);
   }
 
   initializeScales() {
@@ -105,14 +105,14 @@ export default class LineGraph extends React.Component {
       .attr("class", "bar")
       .attr("x", d => this.xScale(d.name))
       .attr("width", () =>  this.xScale.bandwidth())
-      .attr("y", d => this.yScale(d.rollup.requestRate))
-      .attr("height", d => this.state.height - this.yScale(d.rollup.requestRate))
+      .attr("y", d => this.yScale(d.requestRate))
+      .attr("height", d => this.state.height - this.yScale(d.requestRate))
       .on("mousemove", d => {
         this.tooltip
           .style("left", d3.event.pageX - 50 + "px")
           .style("top", d3.event.pageY - 70 + "px")
           .style("display", "inline-block") // show tooltip
-          .text(`${d.name}: ${metricToFormatter["REQUEST_RATE"](d.rollup.requestRate)} (${d.pretty} of total)`);
+          .text(`${d.name}: ${metricToFormatter["REQUEST_RATE"](d.requestRate)} (${d.pretty} of total)`);
       })
       .on("mouseout", () => this.tooltip.style("display", "none"));
 

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -9,7 +9,7 @@ import StatPane from './StatPane.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import UpstreamDownstream from './UpstreamDownstream.jsx';
 import { Col, Row } from 'antd';
-import { processMetrics, processTsWithLatencyBreakdown } from './util/MetricUtils.js';
+import { processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import './../../css/deployment.css';
 import 'whatwg-fetch';
 
@@ -45,9 +45,11 @@ export default class Deployment extends React.Component {
       metricsWindow: "10m",
       deploy: deployment,
       metrics:[],
+      timeseriesByPod: {},
       upstreamMetrics: [],
+      upstreamTsByDeploy: {},
       downstreamMetrics: [],
-      summaryMetrics: {},
+      downstreamTsByDeploy: {},
       pendingRequests: false,
       loaded: false
     };
@@ -77,20 +79,27 @@ export default class Deployment extends React.Component {
     let downstreamTsFetch = fetch(downstreamTimeseriesUrl).then(r => r.json());
 
     Promise.all([deployFetch, podFetch, podTsFetch, upstreamFetch, upstreamTsFetch, downstreamFetch, downstreamTsFetch])
-      .then(([deployMetrics, podRollup, podTimeseries, upstreamRollup, upsreamTimeseries, downstreamRollup, downstreamTimeseries]) => {
-        let deployTimeseries = processTsWithLatencyBreakdown(deployMetrics.metrics);
-        let podMetrics = _.compact(processMetrics(podRollup.metrics, podTimeseries.metrics, "targetPod"));
-        let upstreamMetrics = _.compact(processMetrics(upstreamRollup.metrics, upsreamTimeseries.metrics, "sourceDeploy"));
-        let downstreamMetrics = _.compact(processMetrics(downstreamRollup.metrics, downstreamTimeseries.metrics, "targetDeploy"));
+      .then(([deployMetrics, podRollup, podTimeseries, upstreamRollup, upstreamTimeseries, downstreamRollup, downstreamTimeseries]) => {
+        let tsByDeploy = processTimeseriesMetrics(deployMetrics.metrics, "targetDeploy");
+        let podMetrics = _.compact(processRollupMetrics(podRollup.metrics, "targetPod"));
+        let podTs = processTimeseriesMetrics(podTimeseries.metrics, "targetPod");
 
-        let totalRequestRate = _.sumBy(podMetrics, "rollup.requestRate");
-        _.each(podMetrics, datum => datum.rollup.totalRequests = totalRequestRate);
+        let upstreamMetrics = _.compact(processRollupMetrics(upstreamRollup.metrics, "sourceDeploy"));
+        let upstreamTsByDeploy = processTimeseriesMetrics(upstreamTimeseries.metrics, "sourceDeploy");
+        let downstreamMetrics = _.compact(processRollupMetrics(downstreamRollup.metrics, "targetDeploy"));
+        let downstreamTsByDeploy = processTimeseriesMetrics(downstreamTimeseries.metrics, "targetDeploy");
+
+        let totalRequestRate = _.sumBy(podMetrics, "requestRate");
+        _.each(podMetrics, datum => datum.totalRequests = totalRequestRate);
 
         this.setState({
           metrics: podMetrics,
+          timeseriesByPod: podTs,
+          deployTs: _.get(tsByDeploy, this.state.deploy, {}),
           upstreamMetrics: upstreamMetrics,
+          upstreamTsByDeploy: upstreamTsByDeploy,
           downstreamMetrics: downstreamMetrics,
-          summaryMetrics: deployTimeseries,
+          downstreamTsByDeploy: downstreamTsByDeploy,
           lastUpdated: Date.now(),
           pendingRequests: false,
           loaded: true
@@ -109,7 +118,9 @@ export default class Deployment extends React.Component {
   }
 
   renderSections() {
-    let currentSuccessRate = _.get(_.last(_.get(this.state.summaryMetrics, "SUCCESS_RATE", [])), "value");
+    let srTs = _.get(this.state.deployTs, "SUCCESS_RATE", []);
+    let currentSuccessRate = _.get(_.last(srTs), "value");
+
     return [
       <HealthPane
         key="deploy-health-pane"
@@ -121,14 +132,16 @@ export default class Deployment extends React.Component {
       <StatPane
         key="stat-pane"
         lastUpdated={this.state.lastUpdated}
-        summaryMetrics={this.state.summaryMetrics} />,
+        timeseries={this.state.deployTs} />,
       this.renderMidsection(),
       <UpstreamDownstream
         key="deploy-upstream-downstream"
         entity="deployment"
         lastUpdated={this.state.lastUpdated}
         upstreamMetrics={this.state.upstreamMetrics}
+        upstreamTsByEntity={this.state.upstreamTsByDeploy}
         downstreamMetrics={this.state.downstreamMetrics}
+        downstreamTsByEntity={this.state.downstreamTsByDeploy}
         pathPrefix={this.props.pathPrefix} />
     ];
   }
@@ -156,6 +169,7 @@ export default class Deployment extends React.Component {
               resource="pod"
               lastUpdated={this.state.lastUpdated}
               metrics={this.state.metrics}
+              timeseries={this.state.timeseriesByPod}
               pathPrefix={this.props.pathPrefix} />
           </div>
         </Col>

--- a/web/app/js/components/DeploymentSummary.jsx
+++ b/web/app/js/components/DeploymentSummary.jsx
@@ -20,18 +20,18 @@ export default class DeploymentSummary extends React.Component {
           <div className="summary-info">Last 10 minutes RPS</div>
 
           <LineGraph
-            data={this.props.data.timeseries.requestRate}
+            data={this.props.requestTs}
             lastUpdated={this.props.lastUpdated}
             containerClassName={toClassName(this.props.data.name)} />
 
           <div className="summary-stat">
             <div className="metric-title">Current requests</div>
-            <div className="metric-value">{metricToFormatter["REQUEST_RATE"](this.props.data.rollup.requestRate)}</div>
+            <div className="metric-value">{metricToFormatter["REQUEST_RATE"](this.props.data.requestRate)}</div>
           </div>
 
           <div className="summary-stat">
             <div className="metric-title">Current success</div>
-            <div className="metric-value">{metricToFormatter["SUCCESS_RATE"](this.props.data.rollup.successRate)}</div>
+            <div className="metric-value">{metricToFormatter["SUCCESS_RATE"](this.props.data.successRate)}</div>
           </div>
         </div>
       </div>

--- a/web/app/js/components/Deployments.jsx
+++ b/web/app/js/components/Deployments.jsx
@@ -25,7 +25,6 @@ export default class Deployments extends React.Component {
       lastUpdated: 0,
       limitSparklineData: false,
       pendingRequests: false,
-      pendingTsRequests: false,
       loaded: false
     };
   }
@@ -88,10 +87,6 @@ export default class Deployments extends React.Component {
 
   loadTimeseriesFromServer(meshDeployMetrics, combinedMetrics) {
     let limitSparklineData = _.size(meshDeployMetrics) > maxTsToFetch;
-    if (this.state.pendingTsRequests) {
-      return;
-    }
-    this.setState({ pendingTsRequests: true });
 
     let rollupPath = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}`;
     let timeseriesPath = `${rollupPath}&timeseries=true`;
@@ -100,8 +95,7 @@ export default class Deployments extends React.Component {
       metrics: combinedMetrics,
       limitSparklineData: limitSparklineData,
       loaded: true,
-      pendingRequests: false,
-      pendingTsRequests: false
+      pendingRequests: false
     };
 
     if(limitSparklineData) {
@@ -124,7 +118,7 @@ export default class Deployments extends React.Component {
             lastUpdated: Date.now(),
           }));
         }).catch(() => {
-          this.setState({ pendingTsRequests: false });
+          this.setState({ pendingRequests: false });
         });
     } else {
       // fetch timeseries for all deploys
@@ -137,7 +131,7 @@ export default class Deployments extends React.Component {
             lastUpdated: Date.now()
           }));
         }).catch(() => {
-          this.setState({ pendingTsRequests: false });
+          this.setState({ pendingRequests: false });
         });
     }
   }

--- a/web/app/js/components/HealthPane.jsx
+++ b/web/app/js/components/HealthPane.jsx
@@ -19,15 +19,11 @@ const neutralSr = 0.5;
 
 export default class HealthPane extends React.Component {
   getRequestRate(metrics) {
-    return _.sumBy(metrics, metric => {
-      return _.get(metric, ['rollup', 'requestRate']);
-    });
+    return _.sumBy(metrics, 'requestRate');
   }
 
   getAvgSuccessRate(metrics) {
-    return _.meanBy(metrics, metric => {
-      return _.get(metric, ['rollup', 'successRate']);
-    });
+    return _.meanBy(metrics, 'successRate');
   }
 
   getHealthClassName(successRate) {

--- a/web/app/js/components/LineGraph.jsx
+++ b/web/app/js/components/LineGraph.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import * as d3 from 'd3';
 import './../../css/line-graph.css';
@@ -27,6 +28,12 @@ export default class LineGraph extends React.Component {
     this.xAxis = this.svg.append("g")
       .attr("transform", "translate(0," + this.state.height + ")");
     this.yAxis = this.svg.append("g");
+
+    this.loadingMessage = this.svg
+      .append("text")
+      .attr("transform",
+        "translate(" + (this.state.width / 2 - 30) + "," + (this.state.height / 2) + ")")
+      .attr("class", "loading-message");
 
     this.updateScales();
     this.initializeGraph();
@@ -87,6 +94,11 @@ export default class LineGraph extends React.Component {
   }
 
   initializeGraph() {
+    this.loadingMessage
+      .text("Loading...");
+
+    this.svg.select("path").remove();
+
     let lineChart = this.svg.append("path")
       .attr("class", "chart-line line");
 
@@ -96,7 +108,15 @@ export default class LineGraph extends React.Component {
     this.updateAxes();
   }
 
-  updateGraph(){
+  updateGraph() {
+    if (_.isEmpty(this.props.data)) {
+      this.loadingMessage
+        .text("---")
+        .style("opacity", 1);
+    } else {
+      this.loadingMessage.style("opacity", 0);
+    }
+
     this.svg.select(".line")
       .transition()
       .duration(450)

--- a/web/app/js/components/LineGraph.jsx
+++ b/web/app/js/components/LineGraph.jsx
@@ -94,8 +94,10 @@ export default class LineGraph extends React.Component {
   }
 
   initializeGraph() {
-    this.loadingMessage
-      .text("Loading...");
+    if (_.isEmpty(this.props.data)) {
+      this.loadingMessage
+        .text("Loading...");
+    }
 
     this.svg.select("path").remove();
 

--- a/web/app/js/components/LineGraph.jsx
+++ b/web/app/js/components/LineGraph.jsx
@@ -32,8 +32,7 @@ export default class LineGraph extends React.Component {
     this.loadingMessage = this.svg
       .append("text")
       .attr("transform",
-        "translate(" + (this.state.width / 2 - 30) + "," + (this.state.height / 2) + ")")
-      .attr("class", "loading-message");
+        "translate(" + (this.state.width / 2 - 30) + "," + (this.state.height / 2) + ")");
 
     this.updateScales();
     this.initializeGraph();
@@ -95,8 +94,7 @@ export default class LineGraph extends React.Component {
 
   initializeGraph() {
     if (_.isEmpty(this.props.data)) {
-      this.loadingMessage
-        .text("Loading...");
+      this.loadingMessage.text("---");
     }
 
     this.svg.select("path").remove();
@@ -112,9 +110,7 @@ export default class LineGraph extends React.Component {
 
   updateGraph() {
     if (_.isEmpty(this.props.data)) {
-      this.loadingMessage
-        .text("---")
-        .style("opacity", 1);
+      this.loadingMessage.style("opacity", 1);
     } else {
       this.loadingMessage.style("opacity", 0);
     }

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -39,7 +39,9 @@ export default class PodDetail extends React.Component {
       metricsWindow: "10m",
       pod: pod,
       upstreamMetrics: [],
+      upstreamTsByPod: {},
       downstreamMetrics: [],
+      downstreamTsByPod: {},
       podTs: {},
       pendingRequests: false,
       loaded: false

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -4,7 +4,7 @@ import HealthPane from './HealthPane.jsx';
 import React from 'react';
 import StatPane from './StatPane.jsx';
 import UpstreamDownstream from './UpstreamDownstream.jsx';
-import { processMetrics, processTsWithLatencyBreakdown } from './util/MetricUtils.js';
+import { processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import 'whatwg-fetch';
 
 export default class PodDetail extends React.Component {
@@ -40,7 +40,7 @@ export default class PodDetail extends React.Component {
       pod: pod,
       upstreamMetrics: [],
       downstreamMetrics: [],
-      summaryMetrics: {},
+      podTs: {},
       pendingRequests: false,
       loaded: false
     };
@@ -67,18 +67,23 @@ export default class PodDetail extends React.Component {
     let downstreamTsFetch = fetch(downstreamTimeseriesUrl).then(r => r.json());
 
     Promise.all([podFetch, upstreamFetch, upstreamTsFetch, downstreamFetch, downstreamTsFetch])
-      .then(([podMetrics, upstreamRollup, upsreamTimeseries, downstreamRollup, downstreamTimeseries]) => {
-        let podTimeseries = processTsWithLatencyBreakdown(podMetrics.metrics);
+      .then(([podMetrics, upstreamRollup, upstreamTimeseries, downstreamRollup, downstreamTimeseries]) => {
+        let podTs = processTimeseriesMetrics(podMetrics.metrics, "targetPod");
+        let podTimeseries = _.get(podTs, this.state.pod, {});
 
-        let upstreamMetrics = _.compact(processMetrics(upstreamRollup.metrics, upsreamTimeseries.metrics, "sourcePod"));
-        let downstreamMetrics = _.compact(processMetrics(downstreamRollup.metrics, downstreamTimeseries.metrics, "targetPod"));
+        let upstreamMetrics = _.compact(processRollupMetrics(upstreamRollup.metrics, "sourcePod"));
+        let upstreamTsByPod = processTimeseriesMetrics(upstreamTimeseries.metrics, "sourcePod");
+        let downstreamMetrics = _.compact(processRollupMetrics(downstreamRollup.metrics, "targetPod"));
+        let downstreamTsByPod = processTimeseriesMetrics(downstreamTimeseries.metrics, "targetPod");
 
         this.setState({
           pendingRequests: false,
           lastUpdated: Date.now(),
-          summaryMetrics: podTimeseries,
+          podTs: podTimeseries,
           upstreamMetrics: upstreamMetrics,
+          upstreamTsByPod: upstreamTsByPod,
           downstreamMetrics: downstreamMetrics,
+          downstreamTsByPod: downstreamTsByPod,
           loaded: true
         });
       }).catch(() => {
@@ -87,7 +92,7 @@ export default class PodDetail extends React.Component {
   }
 
   renderSections() {
-    let currentSuccessRate = _.get(_.last(_.get(this.state.summaryMetrics, "SUCCESS_RATE", [])), "value");
+    let currentSuccessRate = _.get(_.last(_.get(this.state.podTs, "SUCCESS_RATE", [])), "value");
     return [
       <HealthPane
         key="pod-health-pane"
@@ -99,19 +104,21 @@ export default class PodDetail extends React.Component {
       <StatPane
         key="pod-stat-pane"
         lastUpdated={this.state.lastUpdated}
-        summaryMetrics={this.state.summaryMetrics} />,
+        timeseries={this.state.podTs} />,
       <UpstreamDownstream
         key="pod-upstream-downstream"
         entity="pod"
         lastUpdated={this.state.lastUpdated}
         upstreamMetrics={this.state.upstreamMetrics}
+        upstreamTsByEntity={this.state.upstreamTsByPod}
         downstreamMetrics={this.state.downstreamMetrics}
+        downstreamTsByEntity={this.state.downstreamTsByPod}
         pathPrefix={this.props.pathPrefix} />
     ];
   }
 
   renderContent() {
-    if (_.isEmpty(this.state.summaryMetrics)) {
+    if (_.isEmpty(this.state.podTs)) {
       return <div>No data</div>;
     } else {
       return this.renderSections();

--- a/web/app/js/components/ScatterPlot.jsx
+++ b/web/app/js/components/ScatterPlot.jsx
@@ -60,7 +60,7 @@ export default class ScatterPlot extends React.Component {
   }
 
   updateScales(data) {
-    this.xScale.domain(d3.extent(data, d => d.latency));
+    this.xScale.domain(d3.extent(data, d => _.get(d, ["latency", "P99", 0, "value"])));
     this.yScale.domain([0, 1]);
 
     this.updateAxes();
@@ -148,18 +148,18 @@ export default class ScatterPlot extends React.Component {
         .attr("class", "dot")
         .attr("r", circleRadius)
       .merge(this.scatterPlot) // newfangled d3 'update' selection
-        .attr("cx", d => this.xScale(d.latency))
-        .attr("cy", d => this.yScale(d.success))
-        .style("fill", d => successRateColorScale(d.success))
-        .style("stroke", d => successRateStrokeColorScale(d.success))
+        .attr("cx", d => this.xScale(_.get(d, ["latency", "P99", 0, "value"])))
+        .attr("cy", d => this.yScale(d.successRate))
+        .style("fill", d => successRateColorScale(d.successRate))
+        .style("stroke", d => successRateStrokeColorScale(d.successRate))
         .on("mousemove", d => {
-          let sr = metricToFormatter["SUCCESS_RATE"](d.success);
-          let latency = metricToFormatter["LATENCY"](d.latency);
+          let sr = metricToFormatter["SUCCESS_RATE"](d.successRate);
+          let latency = metricToFormatter["LATENCY"](_.get(d, ["latency", "P99", 0, "value"]));
           this.tooltip
             .style("left", d3.event.pageX - 50 + "px")
             .style("top", d3.event.pageY - 70 + "px")
             .style("display", "inline-block") // show tooltip
-            .text(`${d.label}: (${latency}, ${sr})`);
+            .text(`${d.name}: (${latency}, ${sr})`);
         })
         .on("mouseout", () => this.tooltip.style("display", "none"));
 
@@ -168,9 +168,9 @@ export default class ScatterPlot extends React.Component {
         .append("text")
         .attr("class", "dot-label")
       .merge(this.labels)
-        .text(d => d.label)
-        .attr("x", d => this.xScale(d.latency) - circleRadius)
-        .attr("y", d => this.yScale(d.success) - 2 * circleRadius)
+        .text(d => d.name)
+        .attr("x", d => this.xScale(_.get(d, ["latency", "P99", 0, "value"])) - circleRadius)
+        .attr("y", d => this.yScale(d.successRate) - 2 * circleRadius)
   }
 
   render() {

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -3,11 +3,11 @@ import CallToAction from './CallToAction.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import DeploymentSummary from './DeploymentSummary.jsx';
 import Metric from './Metric.jsx';
-import { processMetrics } from './util/MetricUtils.js';
 import React from 'react';
 import { rowGutter } from './util/Utils.js';
 import StatusTable from './StatusTable.jsx';
 import { Col, Row, Table } from 'antd';
+import { processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import './../../css/service-mesh.css';
 import 'whatwg-fetch';
 
@@ -44,7 +44,6 @@ const componentDeploys = {
 };
 const componentsToGraph = ["proxy-api", "telemetry", "destination"];
 const noData = {
-  rollup: {},
   timeseries: { requestRate: [], successRate: [] }
 };
 
@@ -89,12 +88,14 @@ export default class ServiceMesh extends React.Component {
 
     Promise.all([rollupRequest, timeseriesRequest, podsRequest])
       .then(([metrics, ts, pods]) => {
-        let m = _.compact(processMetrics(metrics.metrics, ts.metrics, "component"));
-        let d = this.processDeploys(pods.pods);
+        let m = _.compact(processRollupMetrics(metrics.metrics, "component"));
+        let tsByComponent = processTimeseriesMetrics(ts.metrics, "component");
+        let d = this.getDeploymentList(pods.pods);
         let c = this.processComponents(pods.pods);
 
         this.setState({
           metrics: m,
+          timeseriesByComponent: tsByComponent,
           deploys: d,
           components: c,
           lastUpdated: Date.now(),
@@ -136,7 +137,7 @@ export default class ServiceMesh extends React.Component {
     ];
   }
 
-  processDeploys(pods) {
+  getDeploymentList(pods) {
     return _(pods)
       .reject(p => _.isEmpty(p.deployment) || p.controlPlane)
       .groupBy("deployment")
@@ -186,6 +187,7 @@ export default class ServiceMesh extends React.Component {
                   key={data.id}
                   lastUpdated={this.state.lastUpdated}
                   data={data}
+                  requestTs={_.get(this.state.timeseriesByComponent,[meshComponent, "REQUEST_RATE"], [])}
                   noLink={true} />
               </Col>);
             })

--- a/web/app/js/components/StatPane.jsx
+++ b/web/app/js/components/StatPane.jsx
@@ -7,7 +7,6 @@ import { Col, Row } from 'antd';
 
 export default class StatPane extends React.Component {
   render() {
-    let latencyTs = _.groupBy(_.get(this.props.summaryMetrics, "LATENCY", []), 'label');
     return (
       <div>
         <Row gutter={rowGutter}>
@@ -16,21 +15,21 @@ export default class StatPane extends React.Component {
               name="Current request rate"
               metric="REQUEST_RATE"
               lastUpdated={this.props.lastUpdated}
-              timeseries={_.get(this.props.summaryMetrics, "REQUEST_RATE", [])} />
+              timeseries={_.get(this.props.timeseries, "REQUEST_RATE", [])} />
           </Col>
           <Col span={8}>
             <StatPaneStat
               name="Current success rate"
               metric="SUCCESS_RATE"
               lastUpdated={this.props.lastUpdated}
-              timeseries={_.get(this.props.summaryMetrics, "SUCCESS_RATE", [])} />
+              timeseries={_.get(this.props.timeseries, "SUCCESS_RATE", [])} />
           </Col>
         </Row>
         <Row>
           <Col span={24}>
             <div className="latency-chart-container">
               <LatencyOverview
-                data={latencyTs}
+                data={_.get(this.props.timeseries, "LATENCY", {})}
                 lastUpdated={this.props.lastUpdated}
                 showAxes={true}
                 containerClassName="latency-chart-container" />

--- a/web/app/js/components/UpstreamDownstream.jsx
+++ b/web/app/js/components/UpstreamDownstream.jsx
@@ -19,6 +19,7 @@ export default class UpstreamDownstreamTables extends React.Component {
               resource={`upstream_${this.props.entity}`}
               lastUpdated={this.props.lastUpdated}
               metrics={this.props.upstreamMetrics}
+              timeseries={this.props.upstreamTsByEntity}
               pathPrefix={this.props.pathPrefix} />
           </div>
           <div className="upstream-downstream-list">
@@ -31,6 +32,7 @@ export default class UpstreamDownstreamTables extends React.Component {
               resource={`downstream_${this.props.entity}`}
               lastUpdated={this.props.lastUpdated}
               metrics={this.props.downstreamMetrics}
+              timeseries={this.props.downstreamTsByEntity}
               pathPrefix={this.props.pathPrefix} />
           </div>
         </Col>


### PR DESCRIPTION
* Overhaul metrics processing in MetricUtils:
  - splits up rollup and timeseries processing so that we can process those requests separately on various pages (and also simplify the processMetrics function - it was getting too complicated as is)
  - remove various duplicate nested data in the processMetric result
  
* Limit the number of timeseries we request from the server. If there are more deploys than this, hide the sparkline column in the table, and only fetch 3 timeseries (for the three least successful deploys)

* Various small cleanups related to metrics and their processing.

Notes:
- I have messed with all the components metrics. There definitely could be errors. Please let me know if a metric looks off or is missing.
- Tests are forthcoming, now that these functions are more manageable
- Now that I've separated timeseries and rollup requests, the various parts of the page don't update at the same time. This could be disconcerting.
- We can use a similar approach for the other pages 
- I think we still need server side cleanup for the `/metrics` endpoint for  large numbers of deploys. But this branch should help.
- Now, the top graphs appear blank when the timeseries are loading. I'm working on a loading message for the line graph:
![screen shot 2017-12-12 at 11 06 34 am](https://user-images.githubusercontent.com/549258/33903902-b3fbd6e6-df2e-11e7-84d5-e172d635ee63.png)
Because the top three graphs ("least healthy deployments") change, there's sometimes the case where there's still a line from the previous graph rendered. I'm working on cleaning that up now.