### PR TITLE
Readability improvements on Bar Chart

### DIFF
--- a/web/app/css/bar-chart.css
+++ b/web/app/css/bar-chart.css
@@ -19,7 +19,7 @@
   }
 
   & .bar-chart-tooltip {
-    min-height: 16px;
+    min-height: 32px;
     font-weight: var(--font-weight-bold);
   }
 }

--- a/web/app/js/components/BarChart.jsx
+++ b/web/app/js/components/BarChart.jsx
@@ -8,6 +8,8 @@ import './../../css/bar-chart.css';
 const defaultSvgWidth = 595;
 const defaultSvgHeight = 150;
 const margin = { top: 0, right: 0, bottom: 20, left: 0 };
+const horizontalLabelLimit = 4; // number of bars beyond which to tilt axis labels
+const labelLimit = 40; // beyond this, stop labelling bars entirely
 
 export default class LineGraph extends React.Component {
   constructor(props) {
@@ -57,6 +59,19 @@ export default class LineGraph extends React.Component {
   getChartDimensions() {
     let svgWidth = this.props.width || defaultSvgWidth;
     let svgHeight = this.props.height || defaultSvgHeight;
+    let tiltLabels = false;
+    let hideLabels = false;
+
+    if (_.size(this.props.data) > horizontalLabelLimit) {
+      if(_.size(this.props.data) > labelLimit) {
+        // if there are way too many bars, don't label at all
+        hideLabels = true;
+      } else {
+        // if there are many bars, tilt x axis labels
+        margin.bottom += 100;
+        tiltLabels = true;
+      }
+    }
 
     let width = svgWidth - margin.left - margin.right;
     let height = svgHeight - margin.top - margin.bottom;
@@ -66,7 +81,9 @@ export default class LineGraph extends React.Component {
       svgHeight: svgHeight,
       width: width,
       height: height,
-      margin: margin
+      margin: margin,
+      tiltLabels: tiltLabels,
+      hideLabels: hideLabels
     };
   }
 
@@ -112,7 +129,7 @@ export default class LineGraph extends React.Component {
           .style("left", d3.event.pageX - 50 + "px")
           .style("top", d3.event.pageY - 70 + "px")
           .style("display", "inline-block") // show tooltip
-          .text(`${d.name}: ${metricToFormatter["REQUEST_RATE"](d.requestRate)} (${d.pretty} of total)`);
+          .html(`${d.name}:<br /> ${metricToFormatter["REQUEST_RATE"](d.requestRate)} (${d.pretty} of total)`);
       })
       .on("mouseout", () => this.tooltip.style("display", "none"));
 
@@ -121,7 +138,23 @@ export default class LineGraph extends React.Component {
 
   updateAxes() {
     this.xAxis
-      .call(d3.axisBottom(this.xScale)); // add x axis labels
+      .call(d3.axisBottom(this.xScale)) // add x axis labels
+      .selectAll("text")
+      .attr("class", "tick-labels")
+      .attr("transform", () => this.state.tiltLabels ? "rotate(-65)" : "")
+      .style("text-anchor", () => this.state.tiltLabels ? "end" : "")
+      .text(d => {
+        if (this.state.hideLabels) {
+          return;
+        }
+
+        let displayText = d;
+        // truncate long label names
+        if (_.size(displayText) > 20) {
+          displayText = "..." + displayText.substring(displayText.length - 20);
+        }
+        return displayText;
+      });
   }
 
   render() {


### PR DESCRIPTION
## Problem
The bar chart labels would overlap when there were more than 4 bars.
![screen shot 2017-12-12 at 11 55 51 am](https://user-images.githubusercontent.com/549258/33912860-4e434276-df4c-11e7-8930-14459bc9d059.png)

## Solution:
* Truncate long x-axis labels on the bar chart
![screen shot 2017-12-12 at 2 55 32 pm](https://user-images.githubusercontent.com/549258/33912914-8b02a558-df4c-11e7-9a0d-919e81ae0a61.png)

* Tilt axis labels if there are more than 4 bars
![screen shot 2017-12-12 at 2 49 39 pm](https://user-images.githubusercontent.com/549258/33912923-917b90c0-df4c-11e7-957e-412463de9ba4.png)

* Hide axis labels if there are more than 40 bars (you can still access the data via the tooltip; debatable whether we should even show the bar chart at this point).
![screen shot 2017-12-12 at 2 49 20 pm](https://user-images.githubusercontent.com/549258/33912930-98298bb6-df4c-11e7-92ef-e1c5a2288522.png)

* Show the tooltip on two lines, so that you always have a consistent place to look for the name and the data value.

![screen shot 2017-12-12 at 12 10 56 pm](https://user-images.githubusercontent.com/549258/33912986-d6e03fc6-df4c-11e7-8241-92b216162d9e.png)
