### PR TITLE
Add inject flag for skipping outbound ports

### DIFF
--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -13,7 +13,8 @@ var incomingProxyPort int
 var outgoingProxyPort int
 var proxyUserId int
 var portsToRedirect []int
-var portsToIgnore []int
+var inboundPortsToIgnore []int
+var outboundPortsToIgnore []int
 var simulateOnly bool
 
 var RootCmd = &cobra.Command{
@@ -42,7 +43,8 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&outgoingProxyPort, "outgoing-proxy-port", "o", -1, "Port to redirect outgoing traffic")
 	RootCmd.PersistentFlags().BoolVar(&simulateOnly, "simulate", false, "Don't execute any command, just print what would be executed")
 	RootCmd.PersistentFlags().IntSliceVarP(&portsToRedirect, "ports-to-redirect", "r", make([]int, 0), "Port to redirect to proxy, if no port is specified then ALL ports are redirected")
-	RootCmd.PersistentFlags().IntSliceVarP(&portsToIgnore, "ports-to-ignore", "i", make([]int, 0), "Port to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
+	RootCmd.PersistentFlags().IntSliceVar(&inboundPortsToIgnore, "inbound-ports-to-ignore", make([]int, 0), "Inound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
+	RootCmd.PersistentFlags().IntSliceVar(&outboundPortsToIgnore, "outbound-ports-to-ignore", make([]int, 0), "Outbound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
 	RootCmd.PersistentFlags().IntVarP(&proxyUserId, "proxy-uid", "u", -1, "User ID that the proxy is running under. Any traffic coming from this user will be ignored to avoid infinite redirection loops.")
 }
 
@@ -66,7 +68,8 @@ func buildFirewallConfiguration() iptables.FirewallConfiguration {
 	}
 
 	firewallConfiguration.PortsToRedirectInbound = portsToRedirect
-	firewallConfiguration.PortsToIgnore = portsToIgnore
+	firewallConfiguration.InboundPortsToIgnore = inboundPortsToIgnore
+	firewallConfiguration.OutboundPortsToIgnore = outboundPortsToIgnore
 	firewallConfiguration.ProxyInboundPort = incomingProxyPort
 	firewallConfiguration.ProxyOutgoingPort = outgoingProxyPort
 	firewallConfiguration.ProxyUid = proxyUserId

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -43,7 +43,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&outgoingProxyPort, "outgoing-proxy-port", "o", -1, "Port to redirect outgoing traffic")
 	RootCmd.PersistentFlags().BoolVar(&simulateOnly, "simulate", false, "Don't execute any command, just print what would be executed")
 	RootCmd.PersistentFlags().IntSliceVarP(&portsToRedirect, "ports-to-redirect", "r", make([]int, 0), "Port to redirect to proxy, if no port is specified then ALL ports are redirected")
-	RootCmd.PersistentFlags().IntSliceVar(&inboundPortsToIgnore, "inbound-ports-to-ignore", make([]int, 0), "Inound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
+	RootCmd.PersistentFlags().IntSliceVar(&inboundPortsToIgnore, "inbound-ports-to-ignore", make([]int, 0), "Inbound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
 	RootCmd.PersistentFlags().IntSliceVar(&outboundPortsToIgnore, "outbound-ports-to-ignore", make([]int, 0), "Outbound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.")
 	RootCmd.PersistentFlags().IntVarP(&proxyUserId, "proxy-uid", "u", -1, "User ID that the proxy is running under. Any traffic coming from this user will be ignored to avoid infinite redirection loops.")
 }

--- a/proxy-init/integration_test/iptables/http_test.go
+++ b/proxy-init/integration_test/iptables/http_test.go
@@ -114,8 +114,13 @@ func TestPodWithSomePortsIgnored(t *testing.T) {
 	t.Run("doesnt redirect when through port that is ignored", func(t *testing.T) {
 		marksParallelIfConfigured(t)
 		response := expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIp, ignoredContainerPort)
+
+		if response == "proxy" {
+			t.Fatalf("Expected connection through ignored port to directly hit service, but hit [%s]", response)
+		}
+
 		if !strings.Contains(response, ignoredContainerPort) {
-			t.Fatalf("Expected iptables to ignore connection to %s, got back %s", ignoredContainerPort, response)
+			t.Fatalf("Expected to be able to connect to %s without redirects, but got back %s", ignoredContainerPort, response)
 		}
 	})
 }
@@ -144,8 +149,8 @@ func TestPodMakesOutboundConnection(t *testing.T) {
 
 	t.Run("connecting to another pod from proxy container does not get redirected to proxy", func(t *testing.T) {
 		marksParallelIfConfigured(t)
-		targetPodIp := podWithNoRulesIp
 		targetPodName := podWithNoRulesName
+		targetPodIp := podWithNoRulesIp
 
 		response := makeCallFromContainerToAnother(t, proxyPodIp, proxyContainerPort, targetPodIp, notTheProxyContainerPort)
 

--- a/proxy-init/integration_test/iptables/iptablestest-lab.yaml
+++ b/proxy-init/integration_test/iptables/iptablestest-lab.yaml
@@ -167,7 +167,7 @@ spec:
       - name: conduit-init
         image: gcr.io/runconduit/proxy-init:latest
         imagePullPolicy: Never
-        args: ["-p", "8080",  "-o", "8080", "-u", "2102", "-i", "7070"]
+        args: ["-p", "8080",  "-o", "8080", "-u", "2102", "--inbound-ports-to-ignore", "7070"]
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
Add the `--skip-outbound-ports` flag to `conduit inject`.  This flag accepts a comma separated list of ports.  When the application sends traffic to one of these ports, the sidecar proxy will be bypassed and the traffic will be sent directly to the original destination.  This is useful for when an application sends traffic that the Conduit proxy does not support such as HTTP/1.1 or raw TCP.  