### PR TITLE
updates to README linking to docs and getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,19 @@ well-suited for [gRPC][grpc]. Follow our progress towards production-readiness h
 
 ## Documentation
 
-View [Conduit docs][conduit-docs] for more a more comprehensive guide to getting started.
+View [Conduit docs][conduit-docs] for more a more comprehensive guide to getting started with Conduit.
 
 ___
 
 ## Getting started with Conduit
 
-### Install the Conduit CLI
-`curl https://run.conduit.io/install | sh `
+### Install the Conduit CLI `curl https://run.conduit.io/install | sh `
 
 ### Copy `/Users/username/.conduit/bin/conduit` into your PATH
 
 ### Run `conduit install | kubectl apply -f -` to install Conduit
 
-### Check to make sure you're running the latest version _(0.1.0)_ of Conduit:
-`conduit version`
+### Check to make sure you're running the latest version _(0.1.0)_ of Conduit: `conduit version`
 
 ### Open the local version the Conduit controller with `conduit dashboard`
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,48 @@
 ![conduit][logo]
 
-[![Build Status][ci-badge]][ci]
-[![GitHub license][license-badge]](LICENSE)
-[![Slack Status][slack-badge]][slack]
+[![Build Status][ci-badge]][ci] GitHub license][license-badge]](LICENSE) Slack
+[![Status][slack-badge]][slack]
 
-:balloon: Welcome to Conduit! :wave:
+:balloon Welcome to Conduit! wave
 
-Conduit is an ultralight service mesh for Kubernetes from the makers of [Linkerd][l5d]. It
-features a native proxy, written in [Rust][rust], that boasts the performance of C without
-all the heartbleed.
+Conduit is an ultralight service mesh for Kubernetes from the makers of
+[Linkerd][l5d]. It features a native proxy, written in [Rust][rust], that boasts
+the performance of C without all the heartbleed.
 
-Conduit is **experimental**. Currently, it _only supports HTTP/2_ and is especially
-well-suited for [gRPC][grpc]. Follow our progress towards production-readiness here and on
-[Twitter][Twitter].
+Conduit is **experimental**. Currently, it _only supports HTTP/2_ and is
+especially well-suited for [gRPC][grpc]. Follow our progress towards production-
+readiness here and on [Twitter][twitter].
 
 <!-- TODO add roadmap link -->
 
 ## Documentation
 
-View [Conduit docs][conduit-docs] for more a more comprehensive guide to getting started with Conduit.
+View [Conduit docs][conduit-docs] for more a more comprehensive guide to 
+getting started.
 
-___
 
 ## Getting started with Conduit
 
-### Install the Conduit CLI `curl https://run.conduit.io/install | sh `
+1. Install the Conduit CLI `curl https://run.conduit.io/install | sh `
 
-### Copy `/Users/username/.conduit/bin/conduit` into your PATH
+2. Copy `/Users/username/.conduit/bin/conduit` into your PATH
 
-### Run `conduit install | kubectl apply -f -` to install Conduit
+3. Run `conduit install | kubectl apply -f -` to install Conduit
 
-### Check to make sure you're running the latest version _(0.1.0)_ of Conduit: `conduit version`
+4. Check to make sure you're running the latest version _(0.1.0)_ of Conduit 
+with `conduit version`
 
-### Open the local version the Conduit controller with `conduit dashboard`
+5. Open the local version the Conduit controller with `conduit dashboard`
 
-_To install a demo application on your Conduit install, visit [Conduit docs][conduit-demo].
-___
+6. (Optional) To install a demo application for your Conduit instance, visit
+[this section on Conduit docs][conduit-demo]
+
 
 ## Code of Conduct
 
-This project is for everyone. We ask that our users and contributors take a few minutes to review our [code of conduct][coc].
+This project is for everyone. We ask that our users and contributors take a few
+minutes to review our [code of conduct][coc].
+
 
 ## License
 
@@ -51,21 +54,24 @@ License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
 
-<!-- refs -->
-[ci]: https://travis-ci.org/runconduit/conduit
-[ci-badge]: https://travis-ci.org/runconduit/conduit.svg?branch=master
-[coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
-[conduit-demo]: https://conduit.io/getting-started/#install-the-demo-app
-[conduit-docs]: https://conduit.io/docs/
-<!-- [examples]: https://github.com/runconduit/conduit-examples -->
-[grpc]: https://grpc.io/
-[l5d]: https://linkerd.io/
-[license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg
-[logo]: https://user-images.githubusercontent.com/240738/33589722-649152de-d92f-11e7-843a-b078ac889a39.png
+<!-- refs --> 
+[ci]: https://travis-ci.org/runconduit/conduit 
+[ci-badge]: https://travis-ci.org/runconduit/conduit.svg?branch=master 
+[coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct 
+[conduit-demo]: https://conduit.io/getting-started/#install-the-demo-app 
+[conduit-docs]: https://conduit.io/docs/ 
+<!-- [examples]: https://github.com/runconduit/conduit-examples --> 
+[grpc]: https://grpc.io/ 
+[l5d]: https://linkerd.io/ 
+[license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg 
+[logo]: https://user-images.githubusercontent.com/240738/33589722-649152de-d92f-11e7-843a-b078ac889a39.png 
 <!-- [releases]: https://github.com/runconduit/conduit -->
-[rust]: https://rust-lang.org/
-[Twitter]: https://twitter.com/runconduit/
-[slack-badge]: http://slack.linkerd.io/badge.svg
+[rust]: https://rust-lang.org/ 
+[twitter]: https://twitter.com/runconduit/
+[slack-badge]: http://slack.linkerd.io/badge.svg 
 [slack]: http://slack.linkerd.io

--- a/README.md
+++ b/README.md
@@ -12,14 +12,36 @@ all the heartbleed.
 
 Conduit is **experimental**. Currently, it _only supports HTTP/2_ and is especially
 well-suited for [gRPC][grpc]. Follow our progress towards production-readiness here and on
-[twitter][twitter].
+[Twitter][Twitter].
 
 <!-- TODO add roadmap link -->
 
+## Documentation
+
+View [Conduit docs][conduit-docs] for more a more comprehensive guide to getting started.
+
+___
+
+## Getting started with Conduit
+
+### Install the Conduit CLI
+`curl https://run.conduit.io/install | sh `
+
+### Copy `/Users/username/.conduit/bin/conduit` into your PATH
+
+### Run `conduit install | kubectl apply -f -` to install Conduit
+
+### Check to make sure you're running the latest version _(0.1.0)_ of Conduit:
+`conduit version`
+
+### Open the local version the Conduit controller with `conduit dashboard`
+
+_To install a demo application on your Conduit install, visit [Conduit docs][conduit-demo].
+___
+
 ## Code of Conduct
 
-This project is for everyone. We ask that our users and contributors take a few
-minutes to review our [code of conduct][coc].
+This project is for everyone. We ask that our users and contributors take a few minutes to review our [code of conduct][coc].
 
 ## License
 
@@ -31,15 +53,14 @@ License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 <!-- refs -->
 [ci]: https://travis-ci.org/runconduit/conduit
 [ci-badge]: https://travis-ci.org/runconduit/conduit.svg?branch=master
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
+[conduit-demo]: https://conduit.io/getting-started/#install-the-demo-app
+[conduit-docs]: https://conduit.io/docs/
 <!-- [examples]: https://github.com/runconduit/conduit-examples -->
 [grpc]: https://grpc.io/
 [l5d]: https://linkerd.io/
@@ -47,6 +68,6 @@ specific language governing permissions and limitations under the License.
 [logo]: https://user-images.githubusercontent.com/240738/33589722-649152de-d92f-11e7-843a-b078ac889a39.png
 <!-- [releases]: https://github.com/runconduit/conduit -->
 [rust]: https://rust-lang.org/
-[twitter]: https://twitter.com/runconduit/
+[Twitter]: https://twitter.com/runconduit/
 [slack-badge]: http://slack.linkerd.io/badge.svg
 [slack]: http://slack.linkerd.io

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 ![conduit][logo]
 
-[![Build Status][ci-badge]][ci] GitHub license][license-badge]](LICENSE) Slack
-[![Status][slack-badge]][slack]
+[![Build Status][ci-badge]][ci]
+[![GitHub license][license-badge]](LICENSE)
+[![Slack Status][slack-badge]][slack]
 
-:balloon Welcome to Conduit! wave
+:balloon: Welcome to Conduit! :wave:
 
-Conduit is an ultralight service mesh for Kubernetes from the makers of
-[Linkerd][l5d]. It features a native proxy, written in [Rust][rust], that boasts
-the performance of C without all the heartbleed.
+Conduit is an ultralight service mesh for Kubernetes from the makers of [Linkerd][l5d]. It
+features a native proxy, written in [Rust][rust], that boasts the performance of C without
+all the heartbleed.
 
-Conduit is **experimental**. Currently, it _only supports HTTP/2_ and is
-especially well-suited for [gRPC][grpc]. Follow our progress towards production-
-readiness here and on [Twitter][twitter].
+Conduit is **experimental**. Currently, it _only supports HTTP/2_ and is especially
+well-suited for [gRPC][grpc]. Follow our progress towards production-readiness here and on
+[Twitter][twitter].
 
 <!-- TODO add roadmap link -->
 
 ## Documentation
 
-View [Conduit docs][conduit-docs] for more a more comprehensive guide to 
+View [Conduit docs][conduit-docs] for more a more comprehensive guide to
 getting started.
 
 
@@ -29,7 +30,7 @@ getting started.
 
 3. Run `conduit install | kubectl apply -f -` to install Conduit
 
-4. Check to make sure you're running the latest version _(0.1.0)_ of Conduit 
+4. Check to make sure you're running the latest version _(0.1.0)_ of Conduit
 with `conduit version`
 
 5. Open the local version the Conduit controller with `conduit dashboard`
@@ -59,19 +60,19 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
-<!-- refs --> 
-[ci]: https://travis-ci.org/runconduit/conduit 
-[ci-badge]: https://travis-ci.org/runconduit/conduit.svg?branch=master 
-[coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct 
-[conduit-demo]: https://conduit.io/getting-started/#install-the-demo-app 
-[conduit-docs]: https://conduit.io/docs/ 
-<!-- [examples]: https://github.com/runconduit/conduit-examples --> 
-[grpc]: https://grpc.io/ 
-[l5d]: https://linkerd.io/ 
-[license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg 
-[logo]: https://user-images.githubusercontent.com/240738/33589722-649152de-d92f-11e7-843a-b078ac889a39.png 
+<!-- refs -->
+[ci]: https://travis-ci.org/runconduit/conduit
+[ci-badge]: https://travis-ci.org/runconduit/conduit.svg?branch=master
+[coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
+[conduit-demo]: https://conduit.io/getting-started/#install-the-demo-app
+[conduit-docs]: https://conduit.io/docs/
+<!-- [examples]: https://github.com/runconduit/conduit-examples -->
+[grpc]: https://grpc.io/
+[l5d]: https://linkerd.io/
+[license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg
+[logo]: https://user-images.githubusercontent.com/240738/33589722-649152de-d92f-11e7-843a-b078ac889a39.png
 <!-- [releases]: https://github.com/runconduit/conduit -->
-[rust]: https://rust-lang.org/ 
+[rust]: https://rust-lang.org/
 [twitter]: https://twitter.com/runconduit/
-[slack-badge]: http://slack.linkerd.io/badge.svg 
+[slack-badge]: http://slack.linkerd.io/badge.svg
 [slack]: http://slack.linkerd.io

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ getting started.
 
 3. Run `conduit install | kubectl apply -f -` to install Conduit
 
-4. Check to make sure you're running the latest version _(0.1.0)_ of Conduit
+4. Check to make sure you're running the [latest version][releases]of Conduit
 with `conduit version`
 
-5. Open the local version the Conduit controller with `conduit dashboard`
+5. Open a local version of the Conduit controller with `conduit dashboard`
 
 6. (Optional) To install a demo application for your Conduit instance, visit
 [this section on Conduit docs][conduit-demo]
@@ -71,7 +71,7 @@ specific language governing permissions and limitations under the License.
 [l5d]: https://linkerd.io/
 [license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg
 [logo]: https://user-images.githubusercontent.com/240738/33589722-649152de-d92f-11e7-843a-b078ac889a39.png
-<!-- [releases]: https://github.com/runconduit/conduit -->
+[releases]: https://github.com/runconduit/conduit/releases
 [rust]: https://rust-lang.org/
 [twitter]: https://twitter.com/runconduit/
 [slack-badge]: http://slack.linkerd.io/badge.svg


### PR DESCRIPTION
– adds basic getting started instructions for installing Conduit 
– adds link to conduit.io/docs for more comprehensive instructions on getting started