### PR TITLE
Move default private connect timeout to `Config`

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -32,7 +32,7 @@ pub struct Config {
     pub public_connect_timeout: Option<Duration>,
 
     /// The maximum amount of time to wait for a connection to the private peer.
-    pub private_connect_timeout: Option<Duration>,
+    pub private_connect_timeout: Duration,
 
     /// The path to "/etc/resolv.conf"
     pub resolv_conf_path: PathBuf,
@@ -143,6 +143,7 @@ const DEFAULT_REPORT_TIMEOUT_SECS: u64 = 10; // TODO: is this a reasonable defau
 const DEFAULT_PRIVATE_LISTENER: &str = "tcp://127.0.0.1:4140";
 const DEFAULT_PUBLIC_LISTENER: &str = "tcp://0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTENER: &str = "tcp://0.0.0.0:4190";
+const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
 const DEFAULT_CONTROL_URL: &str = "tcp://proxy-api.conduit.svc.cluster.local:8086";
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
@@ -186,7 +187,9 @@ impl<'a> TryFrom<&'a Strings> for Config {
             },
             private_forward: private_forward?,
             public_connect_timeout: public_connect_timeout?.map(Duration::from_millis),
-            private_connect_timeout: private_connect_timeout?.map(Duration::from_millis),
+            private_connect_timeout:
+                Duration::from_millis(private_connect_timeout?
+                                          .unwrap_or(DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS)),
             resolv_conf_path: resolv_conf_path?
                 .unwrap_or(DEFAULT_RESOLV_CONF.into())
                 .into(),

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -46,7 +46,7 @@ use std::io;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use tokio_core::net::TcpListener;
 use tokio_core::reactor::{Core, Handle};
@@ -177,11 +177,8 @@ impl Main {
         let inbound = {
             let ctx = ctx::Proxy::inbound(&process_ctx);
 
-            let timeout = config
-                .private_connect_timeout
-                .unwrap_or_else(|| Duration::from_millis(20));
             let bind = bind.clone()
-                .with_connect_timeout(timeout)
+                .with_connect_timeout(config.private_connect_timeout)
                 .with_ctx(ctx.clone());
 
             let default_addr = config.private_forward.map(|a| a.into());
@@ -245,8 +242,8 @@ impl Main {
                         .expect("bad news in telemetry town");
 
                     let client = control_bg.bind(
-                        telemetry, 
-                        control_host_and_port, 
+                        telemetry,
+                        control_host_and_port,
                         dns_config,
                         config.report_timeout,
                         &executor


### PR DESCRIPTION
Previously the default value of this setting was in lib.rs instead of
being automatically set in `Config` like all the other defaults, which
was inconsistent and confusing.

Fix this by moving the defaulting logic to `Config`.

Validated by running the test suite.