### PR TITLE
Check kubectl versions before attempting dashboard

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -1,17 +1,15 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"log"
-	"os/exec"
-
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"github.com/runconduit/conduit/cli/shell"
 )
 
 var (
-	proxyPort int32 = -1
+	proxyPort = -1
 )
 
 var dashboardCmd = &cobra.Command{
@@ -23,39 +21,32 @@ var dashboardCmd = &cobra.Command{
 			log.Fatalf("port must be positive, was %d", proxyPort)
 		}
 
-		portArg := fmt.Sprintf("--port=%d", proxyPort)
+		kubectl := shell.MakeKubectl(shell.MakeUnixShell())
 
-		kubectl := exec.Command("kubectl", "proxy", portArg)
-		kubeCtlStdOut, err := kubectl.StdoutPipe()
+		asyncProcessErr, err := kubectl.StartProxy(proxyPort)
+
 		if err != nil {
-			log.Fatalf("Failed to set up pipe for kubectl output: %v", err)
+			log.Fatalf("Failed to start kubectl proxy: %v", err)
 		}
 
-		fmt.Printf("Running `kubectl proxy %s`\n", portArg)
+		url, err := kubectl.UrlFor(controlPlaneNamespace, "/services/web:http/proxy/")
 
-		go func() {
-			// Wait for `kubectl proxy` to output one line, which indicates that the proxy has been set up.
-			kubeCtlStdOutLines := bufio.NewReader(kubeCtlStdOut)
-			firstLine, err := kubeCtlStdOutLines.ReadString('\n')
-			if err != nil {
-				log.Fatalf("Failed to read output from kubectl proxy: %v", err)
-			}
-			fmt.Printf("%s", firstLine)
-
-			// Use "127.0.0.1" instead of "localhost" in case "localhost" resolves to "[::1]" (IPv6) or another
-			// unexpected address.
-			url := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s/services/web:http/proxy/", proxyPort, controlPlaneNamespace)
-
-			fmt.Printf("Opening %v in the default browser\n", url)
-			err = browser.OpenURL(url)
-			if err != nil {
-				log.Fatalf("failed to open URL %s in the default browser: %v", url, err)
-			}
-		}()
-
-		err = kubectl.Run()
 		if err != nil {
-			log.Fatalf("Failed to run %v: %v", kubectl, err)
+			log.Fatalf("Failed to generate URL for dashboard: %v", err)
+		}
+
+		fmt.Printf("Opening [%s] in the default browser\n", url)
+		err = browser.OpenURL(url)
+
+		if err != nil {
+			log.Fatalf("failed to open URL %s in the default browser: %v", url, err)
+		}
+
+		select {
+		case err = <-asyncProcessErr:
+			if err != nil {
+				log.Fatalf("Error starting proxy via kubectl: %v", err)
+			}
 		}
 
 		return nil
@@ -69,5 +60,5 @@ func init() {
 	// This is identical to what `kubectl proxy --help` reports, except
 	// `kubectl proxy` allows `--port=0` to indicate a random port; That's
 	// inconvenient to support so it isn't supported.
-	dashboardCmd.PersistentFlags().Int32VarP(&proxyPort, "port", "p", 8001, "The port on which to run the proxy, which must not be 0.")
+	dashboardCmd.PersistentFlags().IntVarP(&proxyPort, "port", "p", 8001, "The port on which to run the proxy, which must not be 0.")
 }

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -21,7 +21,10 @@ var dashboardCmd = &cobra.Command{
 			log.Fatalf("port must be positive, was %d", proxyPort)
 		}
 
-		kubectl := shell.MakeKubectl(shell.MakeUnixShell())
+		kubectl, err := shell.MakeKubectl(shell.MakeUnixShell())
+		if err != nil {
+			log.Fatalf("Failed to start kubectl: %v", err)
+		}
 
 		asyncProcessErr, err := kubectl.StartProxy(proxyPort)
 

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -26,7 +26,9 @@ var dashboardCmd = &cobra.Command{
 			log.Fatalf("Failed to start kubectl: %v", err)
 		}
 
-		asyncProcessErr, err := kubectl.StartProxy(proxyPort)
+		asyncProcessErr := make(chan error, 1)
+
+		err = kubectl.StartProxy(asyncProcessErr, proxyPort)
 
 		if err != nil {
 			log.Fatalf("Failed to start kubectl proxy: %v", err)
@@ -51,7 +53,7 @@ var dashboardCmd = &cobra.Command{
 				log.Fatalf("Error starting proxy via kubectl: %v", err)
 			}
 		}
-
+		close(asyncProcessErr)
 		return nil
 	},
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -81,7 +80,7 @@ func newApiClient() (pb.ApiClient, error) {
 		}
 		serverURLBase, err := url.Parse(kubeConfig.Host)
 		if err != nil {
-			return nil, fmt.Errorf("invalid host in kubernetes config: %s", kubeConfig.Host))
+			return nil, fmt.Errorf("invalid host in kubernetes config: %s", kubeConfig.Host)
 		}
 		proxyURLRef := url.URL{
 			Path: fmt.Sprintf("api/v1/namespaces/%s/services/http:api:http/proxy/", controlPlaneNamespace),

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -81,7 +81,7 @@ func newApiClient() (pb.ApiClient, error) {
 		}
 		serverURLBase, err := url.Parse(kubeConfig.Host)
 		if err != nil {
-			return nil, errors.New(fmt.Sprintf("invalid host in kubernetes config: %s", kubeConfig.Host))
+			return nil, fmt.Errorf("invalid host in kubernetes config: %s", kubeConfig.Host))
 		}
 		proxyURLRef := url.URL{
 			Path: fmt.Sprintf("api/v1/namespaces/%s/services/http:api:http/proxy/", controlPlaneNamespace),

--- a/cli/shell/kubectl.go
+++ b/cli/shell/kubectl.go
@@ -1,0 +1,86 @@
+package shell
+
+import (
+	"fmt"
+	"errors"
+	"strings"
+	"strconv"
+	"time"
+)
+
+type kubectl struct {
+	sh        Shell
+	ProxyPort int
+}
+
+const (
+	kubectlDefaultProxyPort                   = 8001
+	kubectlDefaultTimeout                     = 10 * time.Second
+	portWhenProxyNotRunning                   = -1
+	magicCharacterThatIndicatesProxyIsRunning = '\n'
+)
+
+func (kctl *kubectl) Version() ([3]int, error) {
+	var version [3]int
+	bytes, err := kctl.sh.CombinedOutput("kubectl", "version", "--client", "--short")
+	versionString := string(bytes)
+	if err != nil {
+		return [3]int{}, errors.New(fmt.Sprintf("Error running kubectl Version. Output: %s Error: %v", versionString, err))
+	}
+
+	if err != nil {
+		return version, err
+	}
+
+	split := strings.Split(strings.TrimPrefix(versionString, "Client Version: v"), ".")
+
+	if len(split) != 3 {
+		return version, errors.New(fmt.Sprintf("Unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split))
+	}
+
+	for i, segment := range split {
+		v, err := strconv.Atoi(strings.TrimSpace(segment))
+		if err != nil {
+			return version, errors.New(fmt.Sprintf("Unknown Version string format from Kubectl: [%s], not an integer: [%s]", versionString, segment))
+		}
+		version[i] = v
+	}
+
+	return version, nil
+}
+
+func (kctl *kubectl) StartProxy() error {
+	if kctl.ProxyPort != portWhenProxyNotRunning {
+		return errors.New(fmt.Sprintf("Kubectl proxy already running on port [%d]", kctl.ProxyPort))
+	}
+	output, err := kctl.sh.AsyncStdout("kubectl", "proxy", "-p", strconv.Itoa(kubectlDefaultProxyPort))
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error starting proxy: %v", err))
+	}
+
+	kubectlOutput, err :=kctl.sh.WaitForCharacter(magicCharacterThatIndicatesProxyIsRunning, output, kubectlDefaultTimeout)
+
+	fmt.Println(kubectlOutput)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error waiting for kubectl to start the proxy. kubetl returned [%s], error: %v", kubectlOutput, err))
+	}
+
+	kctl.ProxyPort = kubectlDefaultProxyPort
+	return err
+}
+
+func (kctl *kubectl) UrlFor(namespace string, extraPathStartingWithSlash string) (string,error) {
+	if kctl.ProxyPort == portWhenProxyNotRunning {
+		return "", errors.New("proxy needs to be started before generating URLs")
+	}
+
+	url := fmt.Sprintf("http://%s:%d/api/v1/namespaces/%s%s", "127.0.0.1", kctl.ProxyPort, namespace, extraPathStartingWithSlash)
+	return url, nil
+}
+
+func MakeKubectl(shell Shell) *kubectl {
+	return &kubectl{
+		sh:        shell,
+		ProxyPort: portWhenProxyNotRunning,
+	}
+}

--- a/cli/shell/kubectl.go
+++ b/cli/shell/kubectl.go
@@ -43,9 +43,11 @@ func (kctl *kubectl) Version() ([3]int, error) {
 		return version, err
 	}
 
-	split := strings.Split(strings.TrimPrefix(versionString, "Client Version: v"), ".")
+	justTheVersionString := strings.TrimPrefix(versionString, "Client Version: v")
+	justTheMajorMinorRevisionNumbers :=  strings.Split(justTheVersionString, "-")[0]
+	split := strings.Split(justTheMajorMinorRevisionNumbers, ".")
 
-	if len(split) != 3 {
+	if len(split) < 3 {
 		return version, errors.New(fmt.Sprintf("Unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split))
 	}
 

--- a/cli/shell/kubectl.go
+++ b/cli/shell/kubectl.go
@@ -38,7 +38,7 @@ func (kctl *kubectl) Version() ([3]int, error) {
 	bytes, err := kctl.sh.CombinedOutput("kubectl", "version", "--client", "--short")
 	versionString := string(bytes)
 	if err != nil {
-		return [3]int{}, errors.New(fmt.Sprintf("Error running kubectl Version. Output: %s Error: %v", versionString, err))
+		return [3]int{}, fmt.Errorf("Error running kubectl Version. Output: %s Error: %v", versionString, err)
 	}
 
 	if err != nil {
@@ -50,13 +50,13 @@ func (kctl *kubectl) Version() ([3]int, error) {
 	split := strings.Split(justTheMajorMinorRevisionNumbers, ".")
 
 	if len(split) < 3 {
-		return version, errors.New(fmt.Sprintf("Unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split))
+		return version, fmt.Errorf("Unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split)
 	}
 
 	for i, segment := range split {
 		v, err := strconv.Atoi(strings.TrimSpace(segment))
 		if err != nil {
-			return version, errors.New(fmt.Sprintf("Unknown Version string format from Kubectl: [%s], not an integer: [%s]", versionString, segment))
+			return version, fmt.Errorf("Unknown Version string format from Kubectl: [%s], not an integer: [%s]", versionString, segment)
 		}
 		version[i] = v
 	}
@@ -68,7 +68,7 @@ func (kctl *kubectl) StartProxy(port int) (chan error, error) {
 	fmt.Printf("Running `kubectl proxy %d`\n", port)
 
 	if kctl.ProxyPort() != portWhenProxyNotRunning {
-		return nil, errors.New(fmt.Sprintf("Kubectl proxy already running on port [%d]", kctl.ProxyPort))
+		return nil, fmt.Errorf("Kubectl proxy already running on port [%d]", kctl.ProxyPort)
 	}
 	output, errorReturnedByProcess := kctl.sh.AsyncStdout("kubectl", "proxy", "-p", strconv.Itoa(port))
 
@@ -76,7 +76,7 @@ func (kctl *kubectl) StartProxy(port int) (chan error, error) {
 
 	fmt.Println(kubectlOutput)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error waiting for kubectl to start the proxy. kubetl returned [%s], error: %v", kubectlOutput, err))
+		return nil, fmt.Errorf("Error waiting for kubectl to start the proxy. kubetl returned [%s], error: %v", kubectlOutput, err)
 	}
 
 	kctl.proxyPort = kubectlDefaultProxyPort
@@ -122,7 +122,7 @@ func MakeKubectl(shell Shell) (Kubectl, error) {
 	}
 
 	if !isCompatibleVersion(minimunKubectlVersionExpected, actualVersion) {
-		return nil, errors.New(fmt.Sprintf("Kubectl is on version %v, but version %v or more recent is required", actualVersion, minimunKubectlVersionExpected))
+		return nil, fmt.Errorf("Kubectl is on version %v, but version %v or more recent is required", actualVersion, minimunKubectlVersionExpected)
 	}
 
 	return kubectl, nil

--- a/cli/shell/kubectl_test.go
+++ b/cli/shell/kubectl_test.go
@@ -54,6 +54,7 @@ func TestKubectlVersion(t *testing.T) {
 			"Client Version: v1.8.4": {1, 8, 4},
 			"Client Version: v1.7.1": {1, 7, 1},
 			"Client Version: v0.0.1": {0, 0, 1},
+			"Client Version: v1.9.0-beta.2": {1,9,0},
 		}
 
 		shell := &mockShell{}

--- a/cli/shell/kubectl_test.go
+++ b/cli/shell/kubectl_test.go
@@ -1,0 +1,199 @@
+package shell
+
+import (
+	"testing"
+	"fmt"
+	"strings"
+	"errors"
+	"bufio"
+	"time"
+)
+
+type mockShell struct {
+	lastNameCalled string
+	lastArgsCalled []string
+	outputToReturn string
+	errToReturn    error
+}
+
+func (sh *mockShell) lastFullCommand() string {
+	return fmt.Sprintf("%s %s", sh.lastNameCalled, strings.Join(sh.lastArgsCalled, " "))
+}
+
+func (sh *mockShell) CombinedOutput(name string, arg ...string) (string, error) {
+	sh.lastNameCalled = name
+	sh.lastArgsCalled = arg
+
+	return sh.outputToReturn, sh.errToReturn
+}
+
+func (sh *mockShell) AsyncStdout(name string, arg ...string) (*bufio.Reader, error) {
+	sh.lastNameCalled = name
+	sh.lastArgsCalled = arg
+
+	return bufio.NewReader(strings.NewReader(sh.outputToReturn)), sh.errToReturn
+}
+
+func (sh *mockShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Reader, timeout time.Duration) (string, error) {
+	return outputReader.ReadString(charToWaitFor)
+}
+
+func TestKubectlVersion(t *testing.T) {
+	t.Run("Returns some Version as a smoke test", func(t *testing.T) {
+		kctl := MakeKubectl(MakeUnixShell())
+		_, err := kctl.Version()
+
+		if err != nil {
+			t.Fatalf("Error running command: %v", err)
+		}
+	})
+
+	t.Run("Correctly parses a Version string", func(t *testing.T) {
+		versions := map[string][3]int{
+			"Client Version: v1.8.4": {1, 8, 4},
+			"Client Version: v1.7.1": {1, 7, 1},
+			"Client Version: v0.0.1": {0, 0, 1},
+		}
+
+		shell := &mockShell{}
+		kctl := MakeKubectl(shell)
+		for k, expectedVersion := range versions {
+			shell.outputToReturn = k
+			actualVersion, err := kctl.Version()
+
+			if err != nil {
+				t.Fatalf("Error parsing string: %v", err)
+			}
+
+			if actualVersion != expectedVersion {
+				t.Fatalf("Expecting %s to be parsed into %v but got %v", k, expectedVersion, actualVersion)
+			}
+		}
+	})
+
+	t.Run("Returns error if Version string looks broken", func(t *testing.T) {
+		versions := []string{
+			"",
+			"Client Version: 1.8.4",
+			"Client Version: 1.8.",
+			"Client Version",
+			"Client Version: Version.Info{Major:\"1\", Minor:\"8\", GitVersion:\"v1.8.4\", GitCommit:\"9befc2b8928a9426501d3bf62f72849d5cbcd5a3\", GitTreeState:\"clean\", BuildDate:\"2017-11-20T05:28:34Z\", GoVersion:\"go1.8.3\", Compiler:\"gc\", Platform:\"darwin/amd64\"}",
+		}
+
+		shell := &mockShell{}
+		kctl := MakeKubectl(shell)
+		for _, expectedVersion := range versions {
+			shell.outputToReturn = expectedVersion
+			_, err := kctl.Version()
+
+			if err == nil {
+				t.Fatalf("Expected error parsing string: %s", expectedVersion)
+			}
+		}
+	})
+}
+
+func TestKubectlProxy(t *testing.T) {
+	t.Run("Starts a proxy when no previous proxy was running", func(t *testing.T) {
+		shell := &mockShell{}
+		shell.outputToReturn = fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning)
+		kctl := MakeKubectl(shell)
+
+		err := kctl.StartProxy()
+
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		if kctl.ProxyPort != kubectlDefaultProxyPort {
+			t.Fatalf("Expecting proxy to be running on [%d] but it's on [%d]", kubectlDefaultProxyPort, kctl.ProxyPort)
+		}
+
+		if shell.lastFullCommand() != "kubectl proxy -p 8001" {
+			t.Fatalf("Expecting kubectl to send correct command to Shell, sent [%s]", shell.lastFullCommand())
+		}
+	})
+
+	t.Run("Returns error if there was already a proxy running, keeps old proxy running", func(t *testing.T) {
+		shell := &mockShell{}
+		shell.outputToReturn = fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning)
+		kctl := MakeKubectl(shell)
+
+		err := kctl.StartProxy()
+
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		err = kctl.StartProxy()
+
+		if err == nil {
+			t.Fatalf("Expected error trying to start proxy again, got nothing")
+		}
+
+		if kctl.ProxyPort != kubectlDefaultProxyPort {
+			t.Fatalf("Expected proxy to keep running on port [%d] but got [%d]", kubectlDefaultProxyPort, kctl.ProxyPort)
+		}
+	})
+
+	t.Run("Returns error if a proxy had already been started by some other process", func(t *testing.T) {
+		shell := &mockShell{}
+		shell.errToReturn = errors.New("F1213 17:30:50.272013   39247 proxy.go:153] listen tcp 127.0.0.1:8001: bind: address already in use")
+		kctl := MakeKubectl(shell)
+
+		err := kctl.StartProxy()
+
+		if err == nil {
+			t.Fatalf("Expected error trying to start proxy again, got nothing")
+		}
+	})
+
+	t.Run("Returns error if cannot detect that proxy has been started", func(t *testing.T) {
+		shell := &mockShell{}
+		shell.outputToReturn = "ANY STRING THAT DOEST CONTAIN THE MAGIC CHARACTER WE ARE LOOKING FOR"
+		kctl := MakeKubectl(shell)
+
+		err := kctl.StartProxy()
+
+		if err == nil {
+			t.Fatalf("Expected error trying to start proxy again, got nothing")
+		}
+	})
+}
+
+func TestUrlFor(t *testing.T) {
+	t.Run("Generates expected URL if proxy is running", func(t *testing.T) {
+		shell := &mockShell{}
+		shell.outputToReturn = fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning)
+		kctl := MakeKubectl(shell)
+
+		err := kctl.StartProxy()
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		expectedNamespace := "expected-namespace"
+		expectedPath := "/expected/path:for/desired/endpoint"
+		expectedUrl := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s%s", kubectlDefaultProxyPort, expectedNamespace, expectedPath)
+
+		actualUrl, err := kctl.UrlFor(expectedNamespace, expectedPath)
+		if err != nil {
+			t.Fatalf("Unexpected error generating URL: %v", err)
+		}
+
+		if actualUrl != expectedUrl {
+			t.Fatalf("Expected generated URL to be [%s] but was [%s]", expectedUrl, actualUrl)
+		}
+	})
+
+	t.Run("Returns error if proxy isn'' running", func(t *testing.T) {
+		shell := &mockShell{}
+		shell.outputToReturn = fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning)
+		kctl := MakeKubectl(shell)
+
+		_, err := kctl.UrlFor("someNamespace", "/somePath")
+		if err == nil {
+			t.Fatalf("Expected error getting URL before starting proxy, got nothing")
+		}
+	})
+}

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -1,0 +1,70 @@
+package shell
+
+import (
+	"os/exec"
+	"bufio"
+	"time"
+	"errors"
+	"fmt"
+	"io"
+)
+
+type Shell interface {
+	CombinedOutput(name string, arg ...string) (string, error)
+	AsyncStdout(name string, arg ...string) (*bufio.Reader, error)
+	WaitForCharacter(charToWaitFor byte, output *bufio.Reader, timeout time.Duration) (string, error)
+}
+
+type unixShell struct{}
+
+func (sh *unixShell) CombinedOutput(name string, arg ...string) (string, error) {
+	command := exec.Command(name, arg...)
+	bytes, err := command.CombinedOutput()
+	if err != nil {
+		return string(bytes), err
+	}
+
+	return string(bytes), nil
+}
+
+func (sh *unixShell) AsyncStdout(name string, arg ...string) (*bufio.Reader, error) {
+	command := exec.Command(name, arg...)
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error executing command in an asynx way: %v", err))
+	}
+	go func() { command.Run() }()
+	return bufio.NewReader(stdout), nil
+}
+
+func (sh *unixShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Reader, timeout time.Duration) (string, error) {
+	output := make(chan string, 1)
+	potentialError := make(chan error, 1)
+
+	go func(output chan string, e chan error) {
+		outputString, err := outputReader.ReadString(charToWaitFor)
+		if err != nil {
+			if err == io.EOF {
+				e <- errors.New(fmt.Sprintf("Reasched end of stream while waiting fdor character [%c] in output [%s] of command: %v", charToWaitFor, outputString, err))
+			} else {
+				e <- errors.New(fmt.Sprintf("Error while reading output from command: %v", err))
+			}
+		}
+
+		output <- outputString
+	}(output, potentialError)
+
+	select {
+	case <-time.After(timeout):
+		return "", errors.New(fmt.Sprintf("Timed-out expoecting token [%c] in reader [%v]", charToWaitFor, outputReader))
+	case e := <-potentialError:
+		return "", e
+	case o := <-output:
+		return o, nil
+	}
+
+}
+
+func MakeUnixShell() Shell {
+	return &unixShell{}
+}

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -4,7 +4,6 @@ import (
 	"os/exec"
 	"bufio"
 	"time"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -32,7 +31,7 @@ func (sh *unixShell) AsyncStdout(name string, arg ...string) (*bufio.Reader, cha
 	command := exec.Command(name, arg...)
 	stdout, err := command.StdoutPipe()
 	if err != nil {
-		errorReturnedByProcess <- errors.New(fmt.Sprintf("Error executing command in an async way: %v", err))
+		errorReturnedByProcess <- fmt.Errorf("Error executing command in an async way: %v", err)
 		return nil, errorReturnedByProcess
 	}
 
@@ -48,9 +47,9 @@ func (sh *unixShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Re
 		outputString, err := outputReader.ReadString(charToWaitFor)
 		if err != nil {
 			if err == io.EOF {
-				e <- errors.New(fmt.Sprintf("Reached end of stream while waiting for character [%c] in output [%s] of command: %v", charToWaitFor, outputString, err))
+				e <- fmt.Errorf("Reached end of stream while waiting for character [%c] in output [%s] of command: %v", charToWaitFor, outputString, err)
 			} else {
-				e <- errors.New(fmt.Sprintf("Error while reading output from command: %v", err))
+				e <- fmt.Errorf("Error while reading output from command: %v", err)
 			}
 		}
 
@@ -59,7 +58,7 @@ func (sh *unixShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Re
 
 	select {
 	case <-time.After(timeout):
-		return "", errors.New(fmt.Sprintf("Timed-out expoecting token [%c] in reader [%v]", charToWaitFor, outputReader))
+		return "", fmt.Errorf("Timed-out expoecting token [%c] in reader [%v]", charToWaitFor, outputReader)
 	case e := <-potentialError:
 		return "", e
 	case o := <-output:

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -1,0 +1,95 @@
+package shell
+
+import (
+	"testing"
+	"strings"
+	"io/ioutil"
+	"time"
+)
+
+func TestCombinedOutput(t *testing.T) {
+	t.Run("Executes command and returns result without error if return code 0", func(t *testing.T) {
+		expectedOutput := "expected"
+		output, err := MakeUnixShell().CombinedOutput("echo", expectedOutput)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if strings.TrimSpace(output) != expectedOutput {
+			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
+		}
+	})
+
+	t.Run("Executes command and returns result and  error if return code>0", func(t *testing.T) {
+		_, err := MakeUnixShell().CombinedOutput("command-that-doesnt", "--exist")
+
+		if err == nil {
+			t.Fatalf("Expecting error, got nothing")
+		}
+	})
+}
+
+func TestAsyncStdout(t *testing.T) {
+	t.Run("Executes command and returns result without error if return code 0", func(t *testing.T) {
+		expectedOutput := "expected"
+		output, err := MakeUnixShell().AsyncStdout("echo", expectedOutput)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		outputBytes, err := ioutil.ReadAll(output)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if strings.TrimSpace(string(outputBytes)) != expectedOutput {
+			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
+		}
+	})
+
+	t.Run("Executes command and returns result and error if did not find expected character", func(t *testing.T) {
+		_, err := MakeUnixShell().AsyncStdout("command-that-doesnt", "--exist")
+
+		if err == nil {
+			t.Fatalf("Expecting error, got nothing")
+		}
+	})
+}
+func TestWaitForCharacter(t *testing.T) {
+
+	t.Run("Executes command and returns result without error if return code 0", func(t *testing.T) {
+		shell := MakeUnixShell()
+		expectedOutput := "expected>"
+		output, err := shell.AsyncStdout("echo", expectedOutput)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		outputString, err := shell.WaitForCharacter('>', output, 100 * time.Millisecond)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if strings.TrimSpace(outputString) != expectedOutput {
+			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
+		}
+	})
+
+	t.Run("Executes command and returns timeout error if expected character never shows up in output", func(t *testing.T) {
+		shell := MakeUnixShell()
+		output, err := shell.AsyncStdout("tail", "-f", "/dev/random")
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		outputString, err := shell.WaitForCharacter('!', output, 100 * time.Millisecond)
+		if err != nil {
+			t.Fatalf("Expecting error, got nothing. output was [%s]", outputString)
+		}
+
+	})
+}


### PR DESCRIPTION
Different versions of kubectl have different outputs for the `$ kubectl proxy` command, which sometimes causes `$ conduit dashboard` to hang. This adds a version check that will make sure that the client is at least at `$version`, currently set to `1.8.4`, before attempting anything.

There's also a refactoring extracting business logic from the UI layer and adding lots of tests for it.

e.g. output:
```bash
 $   go build -o ~/tmp/conduit  cli/main.go  && ~/tmp/conduit dashboard
2017/12/15 23:45:02 Failed to start kubectl: Kubectl is on version [1 4 4], but version [1 8 4] or more recent is required
```