### PR TITLE
conduit inject: Configure proxy to log at "info" level

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -243,7 +243,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 			},
 		},
 		Env: []v1.EnvVar{
-			v1.EnvVar{Name: "CONDUIT_PROXY_LOG", Value: "trace,h2=debug,mio=info,tokio_core=info"},
+			v1.EnvVar{Name: "CONDUIT_PROXY_LOG", Value: "warn,conduit_proxy=info"},
 			v1.EnvVar{
 				Name:  "CONDUIT_PROXY_CONTROL_URL",
 				Value: fmt.Sprintf("tcp://proxy-api.%s.svc.cluster.local:%d", controlPlaneNamespace, proxyAPIPort),


### PR DESCRIPTION
Previously `conduit inject` was configuring the proxy to log a lot of
detail, most of which is probably shouldn't be relevant to Conduit
users.

Configure the proxy to log at the "info" level instead for the proxy
itself, and the "warn" level for internal components of the proxy.

Validated by manually doing a `conduit inject`, triggering some
traffic, and inspecting the logs.

Fixes #57