### PR TITLE
conduit inject: Enable auto name completion in proxy

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -263,6 +263,10 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 				Name:      "CONDUIT_PROXY_POD_NAMESPACE",
 				ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 			},
+			v1.EnvVar{
+				Name:      "CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN",
+				Value:     "Kubernetes",
+			},
 		},
 	}
 


### PR DESCRIPTION
Previously `conduit inject` did not enable automatic name completion in
the proxy. As a result services couldn't connect to services outside
the "default" namespace without qualifying the service name with (at
least) the namespace. This is arguably safer but it isn't compatible
with the way things work in Kubernetes when the proxy isn't used.

Enable name auto-completion in the proxy so that the proxy will add
the current pod's namespace to any unqualified service name. This
depends on the feature being added to the proxy (PR #59).

Due to some issues with how zones are dealt with in the project, the
zone component isn't provided; it turns out that it doesn't matter
whether we provide the zone in the current implementation. Dealing
with the zone better will be added later.

Validated by deploying the emojivoto service with its configuration
updated to use unqualified names (`sed "s/\\.emojivoto//g"`). Before
this change this modified configuration would fail; now it succeeds.

Fixes #9.