### PR TITLE
Stop ignoring the most significant labels of Destination names

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -17,6 +17,7 @@ func main() {
 	addr := flag.String("addr", ":8089", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9999", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
+	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
 	flag.Parse()
 
 	log.SetLevel(log.DebugLevel) // TODO: make configurable
@@ -26,7 +27,7 @@ func main() {
 
 	done := make(chan struct{})
 
-	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, done)
+	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, *k8sDNSZone, done)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -87,16 +87,16 @@ func (s *server) Get(dest *common.Destination, stream pb.Destination_GetServer) 
 		}
 	}
 	// service.namespace.svc.cluster.local
-	domains := strings.Split(host, ".")
+	hostLabels := strings.Split(host, ".")
 
-	if len(domains) < 2 {
+	if len(hostLabels) < 2 {
 		err := fmt.Errorf("not a service: %s", host)
 		log.Error(err)
 		return err
 	}
 
-	service := domains[0]
-	namespace := domains[1]
+	service := hostLabels[0]
+	namespace := hostLabels[1]
 
 	id := namespace + "/" + service
 

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -248,10 +248,10 @@ func splitDNSName(dnsName string) ([]string, error) {
 }
 
 func maybeStripSuffixLabels(input []string, suffix []string) ([]string, bool) {
-	if len(input) <= 1+len(suffix) {
+	n := len(input) - len(suffix)
+	if n < 0 {
 		return input, false
 	}
-	n := len(input) - len(suffix)
 	if !reflect.DeepEqual(input[n:], suffix) {
 		return input, false
 	}

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -138,6 +138,10 @@ func (s *server) resolveKubernetesService(id string, port int, stream pb.Destina
 	return nil
 }
 
+// localKubernetesServiceIdFromDNSName returns the name of the service in
+// "namespace-name/service-name" form if `host` is a DNS name in a form used
+// for local Kubernetes services. It returns nil if `host` isn't in such a
+// form.
 func (s *server) localKubernetesServiceIdFromDNSName(host string) (*string, error) {
 	hostLabels, err := splitDNSName(host)
 	if err != nil {

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -233,6 +233,9 @@ func toAddrSet(endpoints []common.TcpAddress) *pb.AddrSet {
 }
 
 func splitDNSName(dnsName string) ([]string, error) {
+	// TODO: Validate that `dnsName` is a valid DNS name:
+	// https://github.com/runconduit/conduit/issues/170.
+
 	// If the name is fully qualified, strip off the final dot.
 	if strings.HasSuffix(dnsName, ".") {
 		dnsName = dnsName[:len(dnsName)-1]
@@ -242,7 +245,8 @@ func splitDNSName(dnsName string) ([]string, error) {
 
 	// Rejects any empty labels, which is especially important to do for
 	// the beginning and the end because we do matching based on labels'
-	// relative positions.
+	// relative positions. For example, we need to reject ".example.com"
+	// instead of splitting it into ["", "example", "com"].
 	for _, l := range labels {
 		if l == "" {
 			return []string{}, errors.New("Empty label in DNS name: " + dnsName)

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -18,11 +18,12 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 		{"cluster.local", "", nil, true},
 		{"cluster.local", "name", nil, false},
 		{"cluster.local", "name.ns", nil, false},
-		{"cluster.local", "name.ns.svc", nil, false},
+		{"cluster.local", "name.ns.svc", &ns_name, false},
 		{"cluster.local", "name.ns.pod", nil, false},
 		{"cluster.local", "name.ns.other", nil, false},
 		{"cluster.local", "name.ns.svc.cluster", nil, false},
 		{"cluster.local", "name.ns.svc.cluster.local", &ns_name, false},
+		{"cluster.local", "name.ns.svc.other.local", nil, false},
 		{"cluster.local", "name.ns.pod.cluster.local", nil, false},
 		{"cluster.local", "name.ns.other.cluster.local", nil, false},
 		{"cluster.local", "name.ns.cluster.local", nil, false},
@@ -31,14 +32,22 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
 		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
 		{"cluster.local", "something.name.ns.svc.cluster.local", nil, true},
-		{"k8s.example.com", "name.ns.svc.cluster.local", nil, false},
+		{"k8s.example.com", "name.ns.svc.cluster.local", &ns_name, false},
+		{"k8s.example.com", "name.ns.svc.cluster.local.k8s.example.com", nil, false},
 		{"k8s.example.com", "name.ns.svc.k8s.example.com", &ns_name, false},
 		{"k8s.example.com", "name.ns.svc.k8s.example.org", nil, false},
 		{"cluster.local", "name.ns.svc.k8s.example.com", nil, false},
 		{"", "name.ns.svc", &ns_name, false},
-		{"", "name.ns.svc.cluster.local", nil, false},
+		{"", "name.ns.svc.cluster.local", &ns_name, false},
+		{"", "name.ns.svc.cluster.local.", &ns_name, false},
+		{"", "name.ns.svc.other.local", nil, false},
 		{"example", "name.ns.svc.example", &ns_name, false},
+		{"example", "name.ns.svc.example.", &ns_name, false},
 		{"example", "name.ns.svc.example.com", nil, false},
+		{"example", "name.ns.svc.cluster.local", &ns_name, false},
+
+		// XXX: See the comment about this issue in localKubernetesServiceIdFromDNSName.
+		{"cluster.local", "name.ns.svc.", &ns_name, false},
 	}
 
 	for i, tc := range testCases {

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -1,0 +1,52 @@
+package destination
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
+	ns_name := "ns/name"
+
+	testCases := []struct {
+		k8sDNSZone string
+		host       string
+		result     *string
+		resultErr  bool
+	}{
+		{"cluster.local", "", nil, true},
+		{"cluster.local", "name", nil, false},
+		{"cluster.local", "name.ns", nil, false},
+		{"cluster.local", "name.ns.svc", nil, false},
+		{"cluster.local", "name.ns.pod", nil, false},
+		{"cluster.local", "name.ns.other", nil, false},
+		{"cluster.local", "name.ns.svc.cluster", nil, false},
+		{"cluster.local", "name.ns.svc.cluster.local", &ns_name, false},
+		{"cluster.local", "name.ns.pod.cluster.local", nil, false},
+		{"cluster.local", "name.ns.other.cluster.local", nil, false},
+		{"cluster.local", "name.ns.cluster.local", nil, false},
+		{"cluster.local", "name.ns.svc.cluster", nil, false},
+		{"cluster.local", "name.ns.svc.local", nil, false},
+		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
+		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
+		{"cluster.local", "something.name.ns.svc.cluster.local", nil, true},
+		{"k8s.example.com", "name.ns.svc.cluster.local", nil, false},
+		{"k8s.example.com", "name.ns.svc.k8s.example.com", &ns_name, false},
+		{"k8s.example.com", "name.ns.svc.k8s.example.org", nil, false},
+		{"cluster.local", "name.ns.svc.k8s.example.com", nil, false},
+		{"", "name.ns.svc", &ns_name, false},
+		{"", "name.ns.svc.cluster.local", nil, false},
+		{"example", "name.ns.svc.example", &ns_name, false},
+		{"example", "name.ns.svc.example.com", nil, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d: (%s, %s)", i, tc.k8sDNSZone, tc.host), func(t *testing.T) {
+			srv := newServer(tc.k8sDNSZone, nil)
+			result, err := srv.localKubernetesServiceIdFromDNSName(tc.host)
+			assert.Equal(t, tc.result, result)
+			assert.Equal(t, tc.resultErr, err != nil)
+		})
+	}
+}


### PR DESCRIPTION
Previously the destinations service was ignoring all the labels in a
destination name after the first two labels. Thus, for example,
"name.ns.another.domain.example.com" would be
considered the same as "name.ns.svc.cluster.local". This was very
wrong.

Match destination names taking into consideration every label in the
destination name.

Provisions have been made for the case where the controller and the
proxies are configured with the zone name to use. However, currently
neither the controller nor the proxies are actually configured with the
zone, so the implementation was made to work in the current
configuration too.

Unit tests are included for the new mapping rules.
