### PR TITLE
Set the zone in controller & proxies to "cluster.local"

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -143,6 +143,7 @@ spec:
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
+        - "-kubernetes-dns-zone={{.Zone}}"
         - "destination"
         - "-addr=:8089"
         - "-metrics-addr=:9999"
@@ -354,6 +355,7 @@ data:
 
 type installConfig struct {
 	Namespace          string
+	Zone               string
 	ControllerImage    string
 	WebImage           string
 	PrometheusImage    string
@@ -379,6 +381,10 @@ var installCmd = &cobra.Command{
 	Short: "Output Kubernetes configs to install Conduit",
 	Long:  "Output Kubernetes configs to install Conduit.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: Set the zone correctly. Currently we assume "cluster.local" in
+		// a few places but that doesn't seem like a valid assumption.
+		const zone = "cluster.local"
+
 		if err := validate(); err != nil {
 			log.Fatal(err.Error())
 		}
@@ -388,6 +394,7 @@ var installCmd = &cobra.Command{
 		}
 		template.Execute(os.Stdout, installConfig{
 			Namespace:          controlPlaneNamespace,
+			Zone:               zone,
 			ControllerImage:    fmt.Sprintf("%s/controller:%s", dockerRegistry, version),
 			WebImage:           fmt.Sprintf("%s/web:%s", dockerRegistry, version),
 			PrometheusImage:    "prom/prometheus:v1.8.1",

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -17,6 +17,7 @@ func main() {
 	addr := flag.String("addr", ":8089", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9999", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
+	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
 	flag.Parse()
 
 	log.SetLevel(log.DebugLevel) // TODO: make configurable
@@ -26,7 +27,7 @@ func main() {
 
 	done := make(chan struct{})
 
-	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, done)
+	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, *k8sDNSZone, done)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -12,10 +12,12 @@ import (
 	"github.com/runconduit/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"reflect"
 )
 
 type (
 	server struct {
+		k8sDNSZoneLabels []string
 		endpoints *k8s.EndpointsWatcher
 	}
 )
@@ -30,7 +32,7 @@ type (
 //
 // Addresses for the given destination are fetched from the Kubernetes Endpoints
 // API.
-func NewServer(addr, kubeconfig string, done chan struct{}) (*grpc.Server, net.Listener, error) {
+func NewServer(addr, kubeconfig string, k8sDNSZone string, done chan struct{}) (*grpc.Server, net.Listener, error) {
 	clientSet, err := k8s.NewClientSet(kubeconfig)
 	if err != nil {
 		return nil, nil, err
@@ -39,9 +41,7 @@ func NewServer(addr, kubeconfig string, done chan struct{}) (*grpc.Server, net.L
 	endpoints := k8s.NewEndpointsWatcher(clientSet)
 	go endpoints.Run()
 
-	srv := &server{
-		endpoints: endpoints,
-	}
+	srv := newServer(k8sDNSZone, endpoints)
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -57,6 +57,20 @@ func NewServer(addr, kubeconfig string, done chan struct{}) (*grpc.Server, net.L
 	}()
 
 	return s, lis, nil
+}
+
+// Split out from NewServer make it easy to write unit tests.
+func newServer(k8sDNSZone string, endpoints *k8s.EndpointsWatcher) *server {
+	var k8sDNSZoneLabels []string
+	if k8sDNSZone == "" {
+		k8sDNSZoneLabels = []string{}
+	} else {
+		k8sDNSZoneLabels = strings.Split(k8sDNSZone, ".")
+	}
+	return &server{
+		k8sDNSZoneLabels: k8sDNSZoneLabels,
+		endpoints: endpoints,
+	}
 }
 
 func (s *server) Get(dest *common.Destination, stream pb.Destination_GetServer) error {
@@ -83,20 +97,25 @@ func (s *server) Get(dest *common.Destination, stream pb.Destination_GetServer) 
 			return err
 		}
 	}
-	// service.namespace.svc.cluster.local
-	hostLabels := strings.Split(host, ".")
 
-	if len(hostLabels) < 2 {
-		err := fmt.Errorf("not a service: %s", host)
+	id, err := s.localKubernetesServiceIdFromDNSName(host)
+	if err != nil {
 		log.Error(err)
 		return err
 	}
 
-	service := hostLabels[0]
-	namespace := hostLabels[1]
+	if id != nil {
+		return s.resolveKubernetesService(*id, port, stream)
+	}
 
-	id := namespace + "/" + service
+	// TODO: Resolve name using DNS similar to Kubernetes' ClusterFirst
+	// resolution.
+	err = fmt.Errorf("cannot resolve service that isn't a local Kubernetes service: %s", host)
+	log.Error(err)
+	return err
+}
 
+func (s *server) resolveKubernetesService(id string, port int, stream pb.Destination_GetServer) error {
 	listener := endpointListener{stream: stream}
 
 	s.endpoints.Subscribe(id, uint32(port), listener)
@@ -106,6 +125,32 @@ func (s *server) Get(dest *common.Destination, stream pb.Destination_GetServer) 
 	s.endpoints.Unsubscribe(id, uint32(port), listener)
 
 	return nil
+}
+
+func (s *server) localKubernetesServiceIdFromDNSName(host string) (*string, error) {
+	hostLabels := strings.Split(host, ".")
+
+	// Verify that `host` ends with .svc.$zone.
+	if len(hostLabels) <= 1 + len(s.k8sDNSZoneLabels) {
+		return nil, nil
+	}
+	n := len(hostLabels) - len(s.k8sDNSZoneLabels)
+	if !reflect.DeepEqual(hostLabels[n:], s.k8sDNSZoneLabels) {
+		return nil, nil
+	}
+	if hostLabels[n - 1] != "svc" {
+		return nil, nil
+	}
+
+	// Extract the service name and namespace.
+	if n != 3 {
+		return nil, fmt.Errorf("not a service: %s", host)
+	}
+	service := hostLabels[0]
+	namespace := hostLabels[1]
+
+	id := namespace + "/" + service
+	return &id, nil
 }
 
 type endpointListener struct {

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -84,16 +84,16 @@ func (s *server) Get(dest *common.Destination, stream pb.Destination_GetServer) 
 		}
 	}
 	// service.namespace.svc.cluster.local
-	domains := strings.Split(host, ".")
+	hostLabels := strings.Split(host, ".")
 
-	if len(domains) < 2 {
+	if len(hostLabels) < 2 {
 		err := fmt.Errorf("not a service: %s", host)
 		log.Error(err)
 		return err
 	}
 
-	service := domains[0]
-	namespace := domains[1]
+	service := hostLabels[0]
+	namespace := hostLabels[1]
 
 	id := namespace + "/" + service
 

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -1,0 +1,51 @@
+package destination
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"fmt"
+)
+
+func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
+	ns_name := "ns/name"
+
+	testCases := []struct {
+		k8sDNSZone string
+		host       string
+		result     *string
+		result_err bool
+	}{
+		{"cluster.local", "name", nil, false},
+		{"cluster.local", "name.ns", nil, false},
+		{"cluster.local", "name.ns.svc", nil, false},
+		{"cluster.local", "name.ns.pod", nil, false},
+		{"cluster.local", "name.ns.other", nil, false},
+		{"cluster.local", "name.ns.svc.cluster", nil, false},
+		{"cluster.local", "name.ns.svc.cluster.local", &ns_name, false},
+		{"cluster.local", "name.ns.pod.cluster.local", nil, false},
+		{"cluster.local", "name.ns.other.cluster.local", nil, false},
+		{"cluster.local", "name.ns.cluster.local", nil, false},
+		{"cluster.local", "name.ns.svc.cluster", nil, false},
+		{"cluster.local", "name.ns.svc.local", nil, false},
+		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
+		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
+		{"cluster.local", "something.name.ns.svc.cluster.local", nil, true},
+		{"k8s.example.com", "name.ns.svc.cluster.local", nil, false},
+		{"k8s.example.com", "name.ns.svc.k8s.example.com", &ns_name, false},
+		{"k8s.example.com", "name.ns.svc.k8s.example.org", nil, false},
+		{"cluster.local", "name.ns.svc.k8s.example.com", nil, false},
+		{"", "name.ns.svc", &ns_name, false},
+		{"", "name.ns.svc.cluster.local", nil, false},
+		{"example", "name.ns.svc.example", &ns_name, false},
+		{"example", "name.ns.svc.example.com", nil, false},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d: (%s, %s)", i, tc.k8sDNSZone, tc.host), func(t *testing.T) {
+			srv := newServer(tc.k8sDNSZone, nil)
+			result, err := srv.localKubernetesServiceIdFromDNSName(tc.host)
+			assert.Equal(t, tc.result, result)
+			assert.Equal(t, tc.result_err, err != nil)
+		})
+	}
+}

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -17,6 +17,7 @@ use tower_reconnect::Reconnect;
 use url::HostAndPort;
 
 use dns;
+use fully_qualified_authority::FullyQualifiedAuthority;
 use transport::LookupAddressAndConnect;
 use timeout::Timeout;
 
@@ -57,7 +58,7 @@ pub fn new() -> (Control, Background) {
 // ===== impl Control =====
 
 impl Control {
-    pub fn resolve<B>(&self, auth: &http::uri::Authority, bind: B) -> Watch<B> {
+    pub fn resolve<B>(&self, auth: &FullyQualifiedAuthority, bind: B) -> Watch<B> {
         self.disco.resolve(auth, bind)
     }
 }

--- a/proxy/src/fully_qualified_authority.rs
+++ b/proxy/src/fully_qualified_authority.rs
@@ -1,0 +1,236 @@
+use bytes::BytesMut;
+
+use std::ascii::AsciiExt;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use http::uri::Authority;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct FullyQualifiedAuthority(Authority);
+
+impl FullyQualifiedAuthority {
+    /// Normalizes the name according to Kubernetes service naming conventions.
+    /// Case folding is not done; that is done internally inside `Authority`.
+    ///
+    /// This assumes the authority is syntactically valid.
+    pub fn new(authority: &Authority, default_namespace: Option<&str>,
+               default_zone: Option<&str>)
+               -> FullyQualifiedAuthority {
+        // Don't change IP-address-based authorities.
+        if IpAddr::from_str(authority.host()).is_ok() {
+            return FullyQualifiedAuthority(authority.clone())
+        };
+
+        // TODO: `Authority` doesn't have a way to get the serialized form of the
+        // port, so do it ourselves.
+        let (name, colon_port) = {
+            let authority = authority.as_str();
+            match authority.rfind(':') {
+                Some(p) => authority.split_at(p),
+                None => (authority, ""),
+            }
+        };
+
+        // A fully qualified name ending with a dot is normalized by removing the
+        // dot and doing nothing else.
+        if name.ends_with('.') {
+            let authority = authority.clone().into_bytes();
+            let normalized = authority.slice(0, authority.len() - 1);
+            return FullyQualifiedAuthority(Authority::from_shared(normalized).unwrap());
+        }
+        let mut parts = name.split('.');
+
+        // `Authority` guarantees the name has at least one part.
+        assert!(parts.next().is_some());
+
+        // Rewrite "$name" -> "$name.$default_namespace".
+        let has_explicit_namespace = parts.next().is_some();
+        let namespace_to_append = if !has_explicit_namespace {
+            default_namespace
+        } else {
+            None
+        };
+
+        // Rewrite "$name.$namespace" -> "$name.$namespace.svc".
+        let (has_svc, append_svc) = if let Some(part) = parts.next() {
+            (part.eq_ignore_ascii_case("svc"), false)
+        } else {
+            let has_namespace =
+                has_explicit_namespace || namespace_to_append.is_some();
+            (has_namespace, has_namespace)
+        };
+
+        // Rewrite "$name.$namespace.svc" -> "$name.$namespace.svc.$zone".
+        let zone_to_append = if has_svc && parts.next().is_none() {
+            default_zone
+        } else {
+            None
+        };
+
+        let mut additional_len = 0;
+        if let Some(namespace) = namespace_to_append {
+            additional_len += 1 + namespace.len(); // "." + namespace
+        }
+        if append_svc {
+            additional_len += 4; // ".svc"
+        }
+        if let Some(zone) = zone_to_append {
+            additional_len += 1 + zone.len(); // "." + zone
+        }
+
+        // If we're not going to change anything then don't allocate anything.
+        if additional_len == 0 {
+            return FullyQualifiedAuthority(authority.clone());
+        }
+
+        // `authority.as_str().len()` includes the length of `colon_port`.
+        let mut normalized =
+            BytesMut::with_capacity(authority.as_str().len() + additional_len);
+        normalized.extend_from_slice(name.as_bytes());
+        if let Some(namespace) = namespace_to_append {
+            normalized.extend_from_slice(b".");
+            normalized.extend_from_slice(namespace.as_bytes());
+        }
+        if append_svc {
+            normalized.extend_from_slice(b".svc");
+        }
+        if let Some(zone) = zone_to_append {
+            normalized.extend_from_slice(b".");
+            normalized.extend_from_slice(zone.as_bytes());
+        }
+        normalized.extend_from_slice(colon_port.as_bytes());
+
+        FullyQualifiedAuthority(Authority::from_shared(normalized.freeze()).unwrap())
+    }
+
+    pub fn without_trailing_dot(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_normalized_authority() {
+        fn f(input: &str, default_namespace: Option<&str>,
+             default_zone: Option<&str>)
+             -> String {
+            use bytes::Bytes;
+            use http::uri::Authority;
+
+            let input = Authority::from_shared(Bytes::from(input.as_bytes())).unwrap();
+            let output = super::FullyQualifiedAuthority::new(
+                &input, default_namespace, default_zone);
+            output.without_trailing_dot().into()
+        }
+
+        assert_eq!("name",
+                   f("name", None, None));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace", None, None));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace.svc", None, None));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster", None, None));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local", None, None));
+
+        assert_eq!("name.namespace.svc",
+                   f("name", Some("namespace"), None));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace", Some("namespace"), None));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace.svc", Some("namespace"), None));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster", Some("namespace"), None));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local", Some("namespace"), None));
+
+        assert_eq!("name",
+                   f("name", None, Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace", None, Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc", None, Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster", None, Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local", None, Some("cluster.local")));
+
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local", Some("namespace"), Some("cluster.local")));
+
+        // Fully-qualified names end with a dot and aren't modified except by removing the dot.
+        assert_eq!("name",
+                   f("name.", None, None));
+        assert_eq!("name.namespace",
+                   f("name.namespace.", None, None));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace.svc.", None, None));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster.", None, None));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local.", None, None));
+        assert_eq!("name",
+                   f("name.", Some("namespace"), None));
+        assert_eq!("name.namespace",
+                   f("name.namespace.", Some("namespace"), None));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace.svc.", Some("namespace"), None));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster.", Some("namespace"), None));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local.", Some("namespace"), None));
+        assert_eq!("name",
+                   f("name.", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace",
+                   f("name.namespace.", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc",
+                   f("name.namespace.svc.", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster",
+                   f("name.namespace.svc.cluster.", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local",
+                   f("name.namespace.svc.cluster.local.", Some("namespace"), Some("cluster.local")));
+
+        // Ports are preserved.
+        assert_eq!("name.namespace.svc.cluster.local:1234",
+                   f("name:1234", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local:1234",
+                   f("name.namespace:1234", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local:1234",
+                   f("name.namespace.svc:1234", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster:1234",
+                   f("name.namespace.svc.cluster:1234", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.svc.cluster.local:1234",
+                   f("name.namespace.svc.cluster.local:1234", Some("namespace"), Some("cluster.local")));
+
+        // "SVC" is recognized as being equivalent to "svc"
+        assert_eq!("name.namespace.SVC.cluster.local",
+                   f("name.namespace.SVC", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.SVC.cluster",
+                   f("name.namespace.SVC.cluster", Some("namespace"), Some("cluster.local")));
+        assert_eq!("name.namespace.SVC.cluster.local",
+                   f("name.namespace.SVC.cluster.local", Some("namespace"), Some("cluster.local")));
+
+        // IPv4 addresses are left unchanged.
+        assert_eq!("1.2.3.4",
+                   f("1.2.3.4", Some("namespace"), Some("cluster.local")));
+        assert_eq!("1.2.3.4:1234",
+                   f("1.2.3.4:1234", Some("namespace"), Some("cluster.local")));
+
+        // IPv6 addresses are left unchanged.
+        assert_eq!("[::1]",
+                   f("[::1]", Some("namespace"), Some("cluster.local")));
+        assert_eq!("[::1]:1234",
+                   f("[::1]:1234", Some("namespace"), Some("cluster.local")));
+    }
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -62,6 +62,7 @@ pub mod control;
 pub mod convert;
 mod ctx;
 mod dns;
+mod fully_qualified_authority;
 mod inbound;
 mod logging;
 mod map_err;
@@ -204,10 +205,16 @@ impl Main {
                 .map_or_else(|| bind.clone(), |t| bind.clone().with_connect_timeout(t))
                 .with_ctx(ctx.clone());
 
+            let outgoing = Outbound::new(
+                bind,
+                control,
+                config.default_destination_namespace().cloned(),
+                config.default_destination_zone().cloned());
+
             let fut = serve(
                 outbound_listener,
                 h2::server::Builder::default(),
-                Outbound::new(bind, control),
+                outgoing,
                 ctx,
                 sensors,
                 &executor,


### PR DESCRIPTION

Previously the zone was not set.

Already we assume that "cluster.local" works, so for now just
hard-code "cluster.local" so that names of the form
"foo.ns.svc.cluster.local" can resolve when the fixes for destination
name resolution are also applied.

TODO: Validate.