### PR TITLE
Fix unit test runner and failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ jobs:
         # TODO decide whether protoc should be committed or not. If so, we shouldn't do
         # this or we should error if it dirties the repo.
         - ./bin/protoc-go.sh
-        - go test ./...  --run "^(integration_test)"
-
+        - go test -v ./...
     - language: node_js
       node_js:
         - "8"

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -7,20 +7,23 @@ import (
 )
 
 func TestSortStatsKeys(t *testing.T) {
-	unsorted := map[string]*row{
-		"kube-system/heapster-v1.4.3":      {0.008091, 24.137931, 516666, 990333},
-		"test/backend4":                    {0.066121, 38.818565, 494553, 989891},
-		"test/hello10":                     {0.000000, 0.000000, 0, 0},
-		"test/world-deploy1":               {0.051893, 33.870968, 510526, 990210},
-		"test/world-deploy2":               {2.504800, 33.749165, 497249, 989944},
-		"kube-system/kubernetes-dashboard": {0.017856, 39.062500, 520000, 990400},
-		"other/grafana":                    {0.060557, 35.944212, 518960, 990379},
-		"kube-system/l7-default-backend":   {0.020371, 31.508049, 516923, 990338},
-	}
+	t.Run("Sorts the keys alphabetically", func(t *testing.T) {
+		unsorted := map[string]*row{
+			"kube-system/heapster-v1.4.3":      {0.008091, 24.137931, 516666, 990333},
+			"test/backend4":                    {0.066121, 38.818565, 494553, 989891},
+			"test/hello10":                     {0.000000, 0.000000, 0, 0},
+			"test/world-deploy1":               {0.051893, 33.870968, 510526, 990210},
+			"test/world-deploy2":               {2.504800, 33.749165, 497249, 989944},
+			"kube-system/kubernetes-dashboard": {0.017856, 39.062500, 520000, 990400},
+			"other/grafana":                    {0.060557, 35.944212, 518960, 990379},
+			"kube-system/l7-default-backend":   {0.020371, 31.508049, 516923, 990338},
+		}
 
-	expected := []string{"other/grafana", "kube-system/heapster-v1.4.3", "kube-system/kubernetes-dashboard",
-		"kube-system/l7-default-backend", "test/backend4", "test/hello10", "test/world-deploy1", "test/world-deploy2"}
+		expected := []string{"kube-system/heapster-v1.4.3", "kube-system/kubernetes-dashboard", "kube-system/l7-default-backend",
+			"other/grafana", "test/backend4", "test/hello10", "test/world-deploy1", "test/world-deploy2"}
 
-	sorted := sortStatsKeys(unsorted)
-	assert.Equal(t, expected, sorted, "Not Sorted!")
+
+		sorted := sortStatsKeys(unsorted)
+		assert.Equal(t, expected, sorted, "Not Sorted!")
+	})
 }

--- a/cli/shell/kubectl_test.go
+++ b/cli/shell/kubectl_test.go
@@ -39,18 +39,6 @@ func (sh *mockShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Re
 }
 
 func TestKubectlVersion(t *testing.T) {
-	t.Run("Returns some Version as a smoke test", func(t *testing.T) {
-		kctl, err := MakeKubectl(MakeUnixShell())
-		if err != nil {
-			t.Fatalf("Error parsing string: %v", err)
-		}
-		_, err = kctl.Version()
-
-		if err != nil {
-			t.Fatalf("Error running command: %v", err)
-		}
-	})
-
 	t.Run("Correctly parses a Version string", func(t *testing.T) {
 		versions := map[string][3]int{
 			"Client Version: v1.8.4":        {1, 8, 4},

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -56,7 +56,7 @@ func (sh *unixShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Re
 
 	select {
 	case <-time.After(timeout):
-		return "", fmt.Errorf("Timed-out expoecting token [%c] in reader [%v]", charToWaitFor, outputReader)
+		return "", fmt.Errorf("Timed-out expoecting token [%c] in reader", charToWaitFor)
 	case e := <-potentialError:
 		return "", e
 	case o := <-output:

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -27,14 +27,13 @@ func (sh *unixShell) CombinedOutput(name string, arg ...string) (string, error) 
 }
 
 func (sh *unixShell) AsyncStdout(potentialErrorFromAsyncProcess chan error, name string, arg ...string) (*bufio.Reader, error) {
-	errorReturnedByProcess := make(chan error, 1)
 	command := exec.Command(name, arg...)
 	stdout, err := command.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("Error executing command in an async way: %v", err)
 	}
 
-	go func(e chan error) { e <- command.Run() }(errorReturnedByProcess)
+	go func(e chan error) { e <- command.Run() }(potentialErrorFromAsyncProcess)
 	return bufio.NewReader(stdout), nil
 }
 

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -106,7 +106,7 @@ func TestWaitForCharacter(t *testing.T) {
 	t.Run("Executes command and returns timeout error if expected character never shows up in output", func(t *testing.T) {
 		shell := MakeUnixShell()
 		asyncError := make(chan error, 1)
-		output, err := shell.AsyncStdout(asyncError, "tail", "-f", "/dev/random")
+		output, err := shell.AsyncStdout(asyncError, "sleep", "1")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -86,7 +86,7 @@ func TestWaitForCharacter(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		outputString, err := shell.WaitForCharacter('>', output, 100*time.Millisecond)
+		outputString, err := shell.WaitForCharacter('>', output, 10*time.Second)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -112,14 +112,8 @@ func TestWaitForCharacter(t *testing.T) {
 		}
 
 		outputString, err := shell.WaitForCharacter('!', output, 100*time.Millisecond)
-		if err != nil {
+		if err == nil {
 			t.Fatalf("Expecting error, got nothing. output was [%s]", outputString)
-		}
-		select {
-		case e := <-asyncError:
-			if e != nil {
-				t.Fatalf("Unexpected error from the async process: %v", err)
-			}
 		}
 		close(asyncError)
 	})

--- a/proxy-init/integration_test/iptables/http_test.go
+++ b/proxy-init/integration_test/iptables/http_test.go
@@ -21,24 +21,24 @@ func TestPodWithNoRules(t *testing.T) {
 	svcName := "svc-pod-with-no-rules"
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podWithNoRulesIp, proxyContainerPort)
 	})
 
 	t.Run("fails to connect to pod directly through any port that isn't the container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectCannotConnectGetRequestTo(t, podWithNoRulesIp, "8088")
 		expectCannotConnectGetRequestTo(t, podWithNoRulesIp, "8888")
 		expectCannotConnectGetRequestTo(t, podWithNoRulesIp, "8988")
 	})
 
 	t.Run("succeeds connecting to pod via a service through container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, svcName, proxyContainerPort)
 	})
 
 	t.Run("fails to connect to pod via a service through any port that isn't the container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectCannotConnectGetRequestTo(t, svcName, "8088")
 		expectCannotConnectGetRequestTo(t, svcName, "8888")
 		expectCannotConnectGetRequestTo(t, svcName, "8988")
@@ -50,12 +50,12 @@ func TestPodRedirectsAllPorts(t *testing.T) {
 	svcName := "svc-pod-redirects-all-ports"
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIp, proxyContainerPort)
 	})
 
 	t.Run("succeeds connecting to pod directly through any port that isn't the container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIp, "8088")
 		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIp, "8888")
 		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIp, "8988")
@@ -63,12 +63,12 @@ func TestPodRedirectsAllPorts(t *testing.T) {
 	})
 
 	t.Run("succeeds connecting to pod via a service through container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, svcName, proxyContainerPort)
 	})
 
 	t.Run("fails to connect to pod via a service through any port that isn't the container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectCannotConnectGetRequestTo(t, svcName, "8088")
 		expectCannotConnectGetRequestTo(t, svcName, "8888")
 		expectCannotConnectGetRequestTo(t, svcName, "8988")
@@ -79,18 +79,18 @@ func TestPodWithSomePortsRedirected(t *testing.T) {
 	podRedirectsSomePortsIp := os.Getenv("POD_REDIRECTS_WHITELISTED_IP")
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podRedirectsSomePortsIp, proxyContainerPort)
 	})
 
 	t.Run("succeeds connecting to pod directly through ports configured to redirect", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podRedirectsSomePortsIp, "9090")
 		expectSuccessfulGetRequestTo(t, podRedirectsSomePortsIp, "9099")
 	})
 
 	t.Run("fails to connect to pod via through any port that isn't configured to redirect", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectCannotConnectGetRequestTo(t, podRedirectsSomePortsIp, "8088")
 		expectCannotConnectGetRequestTo(t, podRedirectsSomePortsIp, "8888")
 		expectCannotConnectGetRequestTo(t, podRedirectsSomePortsIp, "8988")
@@ -101,18 +101,18 @@ func TestPodWithSomePortsIgnored(t *testing.T) {
 	podIgnoredSomePortsIp := os.Getenv("POD_DOEST_REDIRECT_BLACKLISTED_IP")
 
 	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIp, proxyContainerPort)
 	})
 
 	t.Run("succeeds connecting to pod directly through ports configured to redirect", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIp, "9090")
 		expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIp, "9099")
 	})
 
 	t.Run("doesnt redirect when through port that is ignored", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		response := expectSuccessfulGetRequestTo(t, podIgnoredSomePortsIp, ignoredContainerPort)
 
 		if response == "proxy" {
@@ -134,7 +134,7 @@ func TestPodMakesOutboundConnection(t *testing.T) {
 	proxyPodIp := podIgnoredSomePortsIp
 
 	t.Run("connecting to another pod from non-proxy container gets redirected to proxy", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		portOfContainerToMAkeTheRequest := ignoredContainerPort
 		targetPodIp := podWithNoRulesIp
 		targetPort := ignoredContainerPort
@@ -148,7 +148,7 @@ func TestPodMakesOutboundConnection(t *testing.T) {
 	})
 
 	t.Run("connecting to another pod from proxy container does not get redirected to proxy", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 		targetPodName := podWithNoRulesName
 		targetPodIp := podWithNoRulesIp
 
@@ -161,7 +161,7 @@ func TestPodMakesOutboundConnection(t *testing.T) {
 	})
 
 	t.Run("connecting to loopback from non-proxy container does not get redirected to proxy", func(t *testing.T) {
-		marksParallelIfConfigured(t)
+		checkIfIntegrationTestsAreEnabled(t)
 
 		response := makeCallFromContainerToAnother(t, proxyPodIp, ignoredContainerPort, "127.0.0.1", notTheProxyContainerPort)
 
@@ -180,8 +180,14 @@ func makeCallFromContainerToAnother(t *testing.T, fromPodNamed string, fromConta
 	return expectSuccessfulGetRequestToUrl(t, targetUrl)
 }
 
-func marksParallelIfConfigured(t *testing.T) {
-	t.Parallel()
+func checkIfIntegrationTestsAreEnabled(t *testing.T) {
+	integrationTestsEnvironmentVariable := "CONDUIT_INTEGRATION_TESTS_ENABLED"
+	if _, isSet := os.LookupEnv(integrationTestsEnvironmentVariable); !isSet {
+		fmt.Printf("=> Environment variable [%s] isn'' set, skipping this test\n", integrationTestsEnvironmentVariable)
+		t.SkipNow()
+	} else {
+		t.Parallel()
+	}
 }
 
 func expectCannotConnectGetRequestTo(t *testing.T, host string, port string) {

--- a/proxy-init/integration_test/iptables/http_test.go
+++ b/proxy-init/integration_test/iptables/http_test.go
@@ -183,7 +183,7 @@ func makeCallFromContainerToAnother(t *testing.T, fromPodNamed string, fromConta
 func checkIfIntegrationTestsAreEnabled(t *testing.T) {
 	integrationTestsEnvironmentVariable := "CONDUIT_INTEGRATION_TESTS_ENABLED"
 	if _, isSet := os.LookupEnv(integrationTestsEnvironmentVariable); !isSet {
-		fmt.Printf("=> Environment variable [%s] isn'' set, skipping this test\n", integrationTestsEnvironmentVariable)
+		fmt.Printf("=> Environment variable [%s] isn't set, skipping this test\n", integrationTestsEnvironmentVariable)
 		t.SkipNow()
 	} else {
 		t.Parallel()

--- a/proxy-init/integration_test/iptables/http_test.go
+++ b/proxy-init/integration_test/iptables/http_test.go
@@ -1,19 +1,20 @@
 package iptablestest
 
 import (
-	"testing"
-	"net/http"
-	"io/ioutil"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
-	"net/url"
+	"testing"
 )
 
 const (
-	ignoredContainerPort     = "7070"
-	proxyContainerPort       = "8080"
-	notTheProxyContainerPort = "9090"
+	ignoredContainerPort                = "7070"
+	proxyContainerPort                  = "8080"
+	notTheProxyContainerPort            = "9090"
+	integrationTestsEnvironmentVariable = "CONDUIT_INTEGRATION_TESTS_ENABLED"
 )
 
 func TestPodWithNoRules(t *testing.T) {
@@ -181,7 +182,6 @@ func makeCallFromContainerToAnother(t *testing.T, fromPodNamed string, fromConta
 }
 
 func checkIfIntegrationTestsAreEnabled(t *testing.T) {
-	integrationTestsEnvironmentVariable := "CONDUIT_INTEGRATION_TESTS_ENABLED"
 	if _, isSet := os.LookupEnv(integrationTestsEnvironmentVariable); !isSet {
 		fmt.Printf("=> Environment variable [%s] isn't set, skipping this test\n", integrationTestsEnvironmentVariable)
 		t.SkipNow()

--- a/proxy-init/integration_test/run_tests.sh
+++ b/proxy-init/integration_test/run_tests.sh
@@ -82,6 +82,8 @@ spec:
       - name: tester
         image: buoyantio/iptables-tester:v1
         env:
+          - name: CONDUIT_INTEGRATION_TESTS_ENABLED
+            value: "1"
           - name: POD_REDIRECTS_ALL_PORTS_IP
             value: ${POD_REDIRECTS_ALL_PORTS_IP}
           - name: POD_WITH_NO_RULES_IP

--- a/web/srv/handlers_test.go
+++ b/web/srv/handlers_test.go
@@ -36,10 +36,11 @@ func TestHandleIndex(t *testing.T) {
 		t.Errorf("Expected:          %+v", header)
 	}
 
-	expectedVersionDiv := "<div class=\"main\" id=\"main\" data-release-version=\"0.3.3\" data-go-version=\"the best one\">"
+	expectedVersionDiv := "<div class=\"main\" id=\"main\" data-release-version=\"0.3.3\" data-go-version=\"the best one\" data-uuid=\"\">"
 
-	if !strings.Contains(recorder.Body.String(), expectedVersionDiv) {
-		t.Errorf("the version string was not rendered")
-		t.Errorf("Expected to find: %+v", expectedVersionDiv)
+	actualBody := recorder.Body.String()
+
+	if !strings.Contains(actualBody, expectedVersionDiv) {
+		t.Fatalf("Expected string [%s] to be presentn in [%s]", expectedVersionDiv, actualBody)
 	}
 }

--- a/web/srv/handlers_test.go
+++ b/web/srv/handlers_test.go
@@ -41,6 +41,6 @@ func TestHandleIndex(t *testing.T) {
 	actualBody := recorder.Body.String()
 
 	if !strings.Contains(actualBody, expectedVersionDiv) {
-		t.Fatalf("Expected string [%s] to be presentn in [%s]", expectedVersionDiv, actualBody)
+		t.Fatalf("Expected string [%s] to be present in [%s]", expectedVersionDiv, actualBody)
 	}
 }


### PR DESCRIPTION
The canonical test command used in our `.travis.yml` passes:
```
$ go test -v ./...  --run "^(integration_test)" >/dev/null; echo $?
0
```

But I realised that even if I make a test fail on purpose, it **always** passes. So I've tried running without the `--run "^(integration_test)"` bit, and now this hangs forever:

```
$ go test -v ./...   >/dev/null; echo $?
```

So in commit e043adf907adae17d6b899013ea3bbf85fe78057 I've changed our travis file to the command above. In commit a4db27c I;'ve also made the integration tests only  `CONDUIT_INTEGRATION_TESTS_ENABLED`, removing the need for the flag on `go test`.

Now it still hangs, but before hanging it shows us that another test was broken and has never been reported as such:

```
$ go test ./...

?   	github.com/runconduit/conduit/cli	[no test files]

--- FAIL: TestSortStatsKeys (0.00s)

	Error Trace:	stat_test.go:25

	Error:		Not equal: []string{"other/grafana", "kube-system/heapster-v1.4.3", "kube-system/kubernetes-dashboard", "kube-system/l7-default-backend", "test/backend4", "test/hello10", "test/world-deploy1", "test/world-deploy2"} (expected)

			        != []string{"kube-system/heapster-v1.4.3", "kube-system/kubernetes-dashboard", "kube-system/l7-default-backend", "other/grafana", "test/backend4", "test/hello10", "test/world-deploy1", "test/world-deploy2"} (actual)

			

			Diff:

			--- Expected

			+++ Actual

			@@ -1,3 +1,2 @@

			 ([]string) (len=8 cap=8) {

			- (string) (len=13) "other/grafana",

			  (string) (len=27) "kube-system/heapster-v1.4.3",

			@@ -5,2 +4,3 @@

			  (string) (len=30) "kube-system/l7-default-backend",

			+ (string) (len=13) "other/grafana",

			  (string) (len=13) "test/backend4",

	Messages:	Not Sorted!

		

FAIL

FAIL	github.com/runconduit/conduit/cli/cmd	0.095s
```

So on commit 1c5adc67518b947e136e43d1d42b3b164eb120e5 I've fixed the bug that was causing the test to hang, and now we have a broken build, as it should the case since forever. Running locally you get this:

```
$ go test -v ./...   >/dev/null; echo $?
1
```
Subsequent commits fix tests that had been failing for a while and we didn't know about because of the problems stated above. After that we're back to a good state:

```
$ go test -v ./...   >/dev/null; echo $?
0
```
