### PR TITLE
Respect $KUBECONFIG env var 

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -42,7 +42,7 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Opening [%s] in the default browser\n", url)
-		err = browser.OpenURL(url)
+		err = browser.OpenURL(url.String())
 
 		if err != nil {
 			log.Fatalf("failed to open URL %s in the default browser: %v", url, err)

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"github.com/runconduit/conduit/cli/shell"
+	"github.com/runconduit/conduit/cli/k8s"
 )
 
 var (
@@ -21,7 +22,7 @@ var dashboardCmd = &cobra.Command{
 			log.Fatalf("port must be positive, was %d", proxyPort)
 		}
 
-		kubectl, err := shell.MakeKubectl(shell.MakeUnixShell())
+		kubectl, err := k8s.MakeKubectl(shell.MakeUnixShell())
 		if err != nil {
 			log.Fatalf("Failed to start kubectl: %v", err)
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,18 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 
-	"path/filepath"
-	"runtime"
-
+	"github.com/runconduit/conduit/cli/k8s"
+	"github.com/runconduit/conduit/cli/shell"
 	"github.com/runconduit/conduit/controller/api/public"
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var cfgFile string
@@ -43,60 +38,33 @@ func init() {
 // TODO: decide if we want to use viper
 
 func addControlPlaneNetworkingArgs(cmd *cobra.Command) {
-	// See https://github.com/kubernetes/client-go/blob/master/examples/out-of-cluster-client-configuration/main.go
-	kubeconfigDefaultPath := ""
-	var homeEnvVar string
-	if runtime.GOOS == "windows" {
-		homeEnvVar = "USERPROFILE"
-	} else {
-		homeEnvVar = "HOME"
-	}
-	homeDir := os.Getenv(homeEnvVar)
-	if homeDir != "" {
-		kubeconfigDefaultPath = filepath.Join(homeDir, ".kube", "config")
-	}
 	// Use the same argument name as `kubectl` (see the output of `kubectl options`).
-	cmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", kubeconfigDefaultPath, "Path to the kubeconfig file to use for CLI requests")
+	cmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
 
 	cmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 }
 
 func newApiClient() (pb.ApiClient, error) {
-	var serverURL *url.URL
-	var secureK8sTransport http.RoundTripper
+	kubeApi, err := k8s.MakeK8sAPi(shell.MakeUnixShell(), kubeconfigPath, apiAddr)
+	if err != nil {
+		return nil, err
+	}
 
-	if apiAddr != "" {
-		// TODO: Standalone local testing should be done over HTTPS too.
-		serverURL = &url.URL{
-			Scheme: "http",
-			Host:   apiAddr,
-			Path:   "/",
-		}
-		secureK8sTransport = http.DefaultTransport
-	} else {
-		kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
-			return nil, err
-		}
-		serverURLBase, err := url.Parse(kubeConfig.Host)
-		if err != nil {
-			return nil, fmt.Errorf("invalid host in kubernetes config: %s", kubeConfig.Host)
-		}
-		conduitProxyApiUrlRef := url.URL{
-			Path: fmt.Sprintf("api/v1/namespaces/%s/services/http:api:http/proxy/", controlPlaneNamespace),
-		}
-		serverURL = serverURLBase.ResolveReference(&conduitProxyApiUrlRef)
-
-		secureK8sTransport, err = rest.TransportFor(kubeConfig)
-		if err != nil {
-			return nil, err
-		}
+	url, err := kubeApi.UrlFor(controlPlaneNamespace, "/services/http:api:http/proxy/")
+	if err != nil {
+		return nil, err
 	}
 
 	apiConfig := &public.Config{
-		ServerURL: serverURL,
+		ServerURL: url,
 	}
-	return public.NewClient(apiConfig, secureK8sTransport)
+
+	transport, err := kubeApi.MakeSecureTransport()
+	if err != nil {
+		return nil, err
+	}
+
+	return public.NewClient(apiConfig, transport)
 }
 
 // Exit with non-zero exit status without printing the command line usage and

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -69,16 +69,16 @@ The optional [TARGET] option can be either a name for a deployment or pod resour
 func makeStatsRequest(aggType pb.AggregationType) error {
 	client, err := newApiClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating api client while making stats request: %v", err)
 	}
 	req, err := buildMetricRequest(aggType)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating metrics request while making stats request: %v", err)
 	}
 
 	resp, err := client.Stat(context.Background(), req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error calling stat with request: %v", err)
 	}
 
 	var buffer bytes.Buffer

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -43,3 +43,5 @@ func getVersion()(string, error) {
 	}
 	return resp.GetReleaseVersion(), nil
 }
+
+//TODO: server not responding

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -13,7 +13,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the client and server version information",
 	Long:  "Print the client and server version information.",
-	Args: cobra.NoArgs,
+	Args:  cobra.NoArgs,
 	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Client version: " + controller.Version)
 
@@ -32,7 +32,7 @@ func init() {
 	addControlPlaneNetworkingArgs(versionCmd)
 }
 
-func getVersion()(string, error) {
+func getVersion() (string, error) {
 	client, err := newApiClient()
 	if err != nil {
 		return "", err
@@ -43,5 +43,3 @@ func getVersion()(string, error) {
 	}
 	return resp.GetReleaseVersion(), nil
 }
-
-//TODO: server not responding

--- a/cli/k8s/api.go
+++ b/cli/k8s/api.go
@@ -1,0 +1,50 @@
+package k8s
+
+import (
+	"net/http"
+	"net/url"
+
+	"os"
+
+	"fmt"
+
+	"github.com/runconduit/conduit/cli/shell"
+	"k8s.io/client-go/rest"
+)
+
+const kubernetesConfigFilePathEnvVariable = "KUBECONFIG"
+
+type KubernetesApi interface {
+	MakeSecureTransport() (http.RoundTripper, error)
+	UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error)
+}
+
+type kubernetesApi struct {
+	config               *rest.Config
+	apiSchemeHostAndPort string
+}
+
+func (k8s *kubernetesApi) UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
+	return generateKubernetesApiBaseUrlFor(k8s.apiSchemeHostAndPort, namespace, extraPathStartingWithSlash)
+}
+
+func (k8s *kubernetesApi) MakeSecureTransport() (http.RoundTripper, error) {
+	return rest.TransportFor(k8s.config)
+}
+
+func MakeK8sAPi(shell shell.Shell, k8sConfigFilesystemPathOverride string, apiHostAndPortOverride string) (KubernetesApi, error) {
+	kubeconfigEnvVar := os.Getenv(kubernetesConfigFilePathEnvVariable)
+	config, err := parseK8SConfig(findK8sConfigFile(k8sConfigFilesystemPathOverride, kubeconfigEnvVar, shell.HomeDir()))
+	if err != nil {
+		return nil, fmt.Errorf("error instantiating Kubernetes API client: %v", err)
+	}
+
+	if apiHostAndPortOverride == "" {
+		apiHostAndPortOverride = config.Host
+	}
+
+	return &kubernetesApi{
+		apiSchemeHostAndPort: apiHostAndPortOverride,
+		config:               config,
+	}, nil
+}

--- a/cli/k8s/api.go
+++ b/cli/k8s/api.go
@@ -1,12 +1,10 @@
 package k8s
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
-
 	"os"
-
-	"fmt"
 
 	"github.com/runconduit/conduit/cli/shell"
 	"k8s.io/client-go/rest"

--- a/cli/k8s/api_test.go
+++ b/cli/k8s/api_test.go
@@ -1,0 +1,29 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/runconduit/conduit/cli/shell"
+)
+
+func TestKubernetesApiUrlFor(t *testing.T) {
+	t.Run("Returns URL from base URL overridden in construction", func(t *testing.T) {
+		namespace := "some-namespace"
+		extraPath := "/some/extra/path"
+		expectedUrlString := "https://35.184.231.31/api/v1/namespaces/some-namespace/some/extra/path"
+
+		api, err := MakeK8sAPi(shell.MakeUnixShell(), "config.test", "https://35.184.231.31")
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		actualUrl, err := api.UrlFor(namespace, extraPath)
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		if actualUrl.String() != expectedUrlString {
+			t.Fatalf("Expected generated URl to be [%s], but got [%s]", expectedUrlString, actualUrl.String())
+		}
+	})
+}

--- a/cli/k8s/api_test.go
+++ b/cli/k8s/api_test.go
@@ -23,7 +23,7 @@ func TestKubernetesApiUrlFor(t *testing.T) {
 		}
 
 		if actualUrl.String() != expectedUrlString {
-			t.Fatalf("Expected generated URl to be [%s], but got [%s]", expectedUrlString, actualUrl.String())
+			t.Fatalf("Expected generated URL to be [%s], but got [%s]", expectedUrlString, actualUrl.String())
 		}
 	})
 }

--- a/cli/k8s/config.test
+++ b/cli/k8s/config.test
@@ -1,0 +1,88 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: cXVlIHBhcmFkYSBhdHJhc2FkYQ==
+    server: https://55.197.171.239
+  name: cluster1
+- cluster:
+    certificate-authority-data: cXVlIHBhcmFkYSBhdHJhc2FkYQ==
+    server: https://30.88.172.234
+  name: cluster2
+- cluster:
+    certificate-authority-data: cXVlIHBhcmFkYSBhdHJhc2FkYQ==
+    server: https://13.184.231.31
+  name: cluster3
+- cluster:
+    certificate-authority-data: cXVlIHBhcmFkYSBhdHJhc2FkYQ==
+    server: https://162.128.50.10
+  name: cluster4
+contexts:
+- context:
+    cluster: cluster3
+    namespace: bobo-lab
+    user: cluster3
+  name: dev
+- context:
+    cluster: cluster1
+    user: cluster1
+  name: cluster1
+- context:
+    cluster: cluster2
+    user: cluster2
+  name: cluster2
+- context:
+    cluster: cluster3
+    user: cluster3
+  name: cluster3
+- context:
+    cluster: cluster4
+    user: cluster4
+  name: cluster4
+current-context: cluster1
+kind: Config
+preferences: {}
+users:
+- name: cluster1
+  user:
+    auth-provider:
+      config:
+        access-token: 4cc3sspassatempo
+        cmd-args: config config-helper --format=json
+        cmd-path: /Users/bobojones/bin/google-cloud-sdk/bin/gcloud
+        expiry: 2017-10-11T06:30:02Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+- name: cluster2
+  user:
+    auth-provider:
+      config:
+        access-token: 4cc3sspassatempo
+        cmd-args: config config-helper --format=json
+        cmd-path: /Users/bobojones/bin/google-cloud-sdk/bin/gcloud
+        expiry: 2017-12-14 06:30:02
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+- name: cluster3
+  user:
+    auth-provider:
+      config:
+        access-token: 4cc3sspassatempo
+        cmd-args: config config-helper --format=json
+        cmd-path: /Users/bobojones/bin/google-cloud-sdk/bin/gcloud
+        expiry: 2017-10-17 18:40:01
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+- name: cluster4
+  user:
+    auth-provider:
+      config:
+        access-token: 4cc3sspassatempoq
+        cmd-args: config config-helper --format=json
+        cmd-path: /Users/bobojones/bin/google-cloud-sdk/bin/gcloud
+        expiry: 2017-11-22 22:13:05
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp

--- a/cli/k8s/k8s.go
+++ b/cli/k8s/k8s.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"fmt"
+	"net/url"
+
+	"path/filepath"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
+	if string(extraPathStartingWithSlash[0]) != "/" {
+		return nil, fmt.Errorf("Path must start with a [/], was [%s]", extraPathStartingWithSlash)
+	}
+
+	urlString := fmt.Sprintf("%s/api/v1/namespaces/%s%s", schemeHostAndPort, namespace, extraPathStartingWithSlash)
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, fmt.Errorf("Error generating URL from [%s]", urlString)
+	}
+	return url, nil
+}
+
+func findK8sConfigFile(override string, contentsOfKubecongigEnvVar string, homeDir string) string {
+	// See https://github.com/kubernetes/client-go/blob/master/examples/out-of-cluster-client-configuration/main.go
+	if override != "" {
+		return override
+	}
+
+	if contentsOfKubecongigEnvVar != "" {
+		return contentsOfKubecongigEnvVar
+	}
+
+	return filepath.Join(homeDir, ".kube", "config")
+}
+
+func parseK8SConfig(pathToConfigFile string) (*rest.Config, error) {
+	return clientcmd.BuildConfigFromFlags("", pathToConfigFile)
+}

--- a/cli/k8s/k8s_test.go
+++ b/cli/k8s/k8s_test.go
@@ -1,0 +1,87 @@
+package k8s
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateKubernetesApiBaseUrlFor(t *testing.T) {
+	t.Run("Generates correct URL when all elements are present", func(t *testing.T) {
+		schemeHostAndPort := "ftp://some-server.example.com:666"
+		namespace := "some-namespace"
+		extraPath := "/starts/with/slash"
+		url, err := generateKubernetesApiBaseUrlFor(schemeHostAndPort, namespace, extraPath)
+
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		expectedUrlString := "ftp://some-server.example.com:666/api/v1/namespaces/some-namespace/starts/with/slash"
+		if url.String() != expectedUrlString {
+			t.Fatalf("Expected generated URl to be [%s], but got [%s]", expectedUrlString, url.String())
+		}
+	})
+
+	t.Run("Return error it extra path doesn'' start with slash", func(t *testing.T) {
+		schemeHostAndPort := "ftp://some-server.example.com:666"
+		namespace := "some-namespace"
+		extraPath := "does-not-start/with/slash"
+		_, err := generateKubernetesApiBaseUrlFor(schemeHostAndPort, namespace, extraPath)
+
+		if err == nil {
+			t.Fatalf("Expected error when tryiong to generate URL with extra path without leading slash, got nothing")
+		}
+	})
+}
+
+func TestParseK8SConfig(t *testing.T) {
+	t.Run("Gets host correctly form existing file", func(t *testing.T) {
+		config, err := parseK8SConfig("config.test")
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		expectedHost := "https://55.197.171.239"
+		if config.Host != expectedHost {
+			t.Fatalf("Expected host to be [%s] got [%s]", expectedHost, config.Host)
+		}
+	})
+
+	t.Run("Returns error if configuration cannot be found", func(t *testing.T) {
+		_, err := parseK8SConfig("/this/doest./not/exist.config")
+		if err == nil {
+			t.Fatalf("Expecting error when config file doesnt exist, got nothing")
+		}
+	})
+}
+
+func TestFindK8sConfigFile(t *testing.T) {
+	override := "/this/is/overrriden"
+	envVarContents := "~/tmp/.kube"
+	homeDir := "/home/bob"
+
+	t.Run("When override is set, everything else is ignored", func(t *testing.T) {
+		whereTheConfigFileIs := findK8sConfigFile(override, envVarContents, homeDir)
+
+		if whereTheConfigFileIs != override {
+			t.Fatalf("Expected override [%s] to take precedence, but it was [%s]", override, whereTheConfigFileIs)
+		}
+	})
+
+	t.Run("When override NOT set, $KUBECONFIG takes precedence", func(t *testing.T) {
+		whereTheConfigFileIs := findK8sConfigFile("", envVarContents, homeDir)
+
+		if whereTheConfigFileIs != envVarContents {
+			t.Fatalf("Expected $KUBECONFIG [%s] to take precedence, but it was [%s]", envVarContents, envVarContents)
+		}
+	})
+
+	t.Run("When override NOT set, and $KUBECONFIG is NOT set, takes default dir", func(t *testing.T) {
+		whereTheConfigFileIs := findK8sConfigFile("", "", homeDir)
+
+		expectedDir := filepath.Join(homeDir, ".kube", "config")
+		if whereTheConfigFileIs != expectedDir {
+			t.Fatalf("Expected default directory [%s] to take precedence, but it was [%s]", expectedDir, expectedDir)
+		}
+	})
+}

--- a/cli/k8s/k8s_test.go
+++ b/cli/k8s/k8s_test.go
@@ -22,7 +22,7 @@ func TestGenerateKubernetesApiBaseUrlFor(t *testing.T) {
 		}
 	})
 
-	t.Run("Return error it extra path doesn'' start with slash", func(t *testing.T) {
+	t.Run("Return error it extra path doesn't start with slash", func(t *testing.T) {
 		schemeHostAndPort := "ftp://some-server.example.com:666"
 		namespace := "some-namespace"
 		extraPath := "does-not-start/with/slash"

--- a/cli/k8s/kubectl.go
+++ b/cli/k8s/kubectl.go
@@ -1,4 +1,4 @@
-package shell
+package k8s
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"strconv"
 	"time"
+	"github.com/runconduit/conduit/cli/shell"
 )
 
 type Kubectl interface {
@@ -16,7 +17,7 @@ type Kubectl interface {
 }
 
 type kubectl struct {
-	sh        Shell
+	sh        shell.Shell
 	proxyPort int
 }
 
@@ -106,7 +107,7 @@ func isCompatibleVersion(minimalRequirementVersion [3]int, actualVersion [3]int)
 	return false
 }
 
-func MakeKubectl(shell Shell) (Kubectl, error) {
+func MakeKubectl(shell shell.Shell) (Kubectl, error) {
 
 	kubectl := &kubectl{
 		sh:        shell,

--- a/cli/k8s/kubectl.go
+++ b/cli/k8s/kubectl.go
@@ -36,6 +36,14 @@ func (kctl *kubectl) ProxyPort() int {
 	return kctl.proxyPort
 }
 
+func (kctl *kubectl) ProxyHost() string {
+	return "127.0.0.1"
+}
+
+func (kctl *kubectl) ProxyScheme() string {
+	return "http"
+}
+
 func (kctl *kubectl) Version() ([3]int, error) {
 	var version [3]int
 	bytes, err := kctl.sh.CombinedOutput("kubectl", "version", "--client", "--short")
@@ -88,12 +96,9 @@ func (kctl *kubectl) UrlFor(namespace string, extraPathStartingWithSlash string)
 		return nil, errors.New("proxy needs to be started before generating URLs")
 	}
 
-	urlString := fmt.Sprintf("http://%s:%d/api/v1/namespaces/%s%s", "127.0.0.1", kctl.ProxyPort(), namespace, extraPathStartingWithSlash)
-	url, err := url.Parse(urlString)
-	if err != nil {
-		return nil, fmt.Errorf("Error generating URL from [%s]", urlString)
-	}
-	return url, err
+	schemeHostAndPort := fmt.Sprintf("%s://%s:%d",kctl.ProxyScheme(),kctl.ProxyHost(), kctl.ProxyPort())
+
+	return generateKubernetesApiBaseUrlFor(schemeHostAndPort, namespace, extraPathStartingWithSlash)
 }
 
 func isCompatibleVersion(minimalRequirementVersion [3]int, actualVersion [3]int) bool {

--- a/cli/k8s/kubectl_test.go
+++ b/cli/k8s/kubectl_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"bufio"
 	"time"
+	"net/url"
 )
 
 type mockShell struct {
@@ -182,14 +183,14 @@ func TestUrlFor(t *testing.T) {
 
 		expectedNamespace := "expected-namespace"
 		expectedPath := "/expected/path:for/desired/endpoint"
-		expectedUrl := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s%s", kubectlDefaultProxyPort, expectedNamespace, expectedPath)
+		expectedUrl, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s%s", kubectlDefaultProxyPort, expectedNamespace, expectedPath))
 
 		actualUrl, err := kctl.UrlFor(expectedNamespace, expectedPath)
 		if err != nil {
 			t.Fatalf("Unexpected error generating URL: %v", err)
 		}
 
-		if actualUrl != expectedUrl {
+		if actualUrl.String() != expectedUrl.String() {
 			t.Fatalf("Expected generated URL to be [%s] but was [%s]", expectedUrl, actualUrl)
 		}
 	})

--- a/cli/k8s/kubectl_test.go
+++ b/cli/k8s/kubectl_test.go
@@ -1,4 +1,4 @@
-package shell
+package k8s
 
 import (
 	"testing"

--- a/cli/k8s/kubectl_test.go
+++ b/cli/k8s/kubectl_test.go
@@ -1,13 +1,13 @@
 package k8s
 
 import (
-	"testing"
-	"fmt"
-	"strings"
-	"errors"
 	"bufio"
-	"time"
+	"errors"
+	"fmt"
 	"net/url"
+	"strings"
+	"testing"
+	"time"
 )
 
 type mockShell struct {
@@ -37,6 +37,10 @@ func (sh *mockShell) AsyncStdout(asyncError chan error, name string, arg ...stri
 
 func (sh *mockShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Reader, timeout time.Duration) (string, error) {
 	return outputReader.ReadString(charToWaitFor)
+}
+
+func (sh *mockShell) HomeDir() string {
+	return "/home/bob"
 }
 
 func TestKubectlVersion(t *testing.T) {

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -1,17 +1,20 @@
 package shell
 
 import (
-	"os/exec"
 	"bufio"
-	"time"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
 )
 
 type Shell interface {
 	CombinedOutput(name string, arg ...string) (string, error)
 	AsyncStdout(potentialErrorFromAsyncProcess chan error, name string, arg ...string) (*bufio.Reader, error)
 	WaitForCharacter(charToWaitFor byte, output *bufio.Reader, timeout time.Duration) (string, error)
+	HomeDir() string
 }
 
 type unixShell struct{}
@@ -63,6 +66,16 @@ func (sh *unixShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Re
 		return o, nil
 	}
 
+}
+
+func (sh *unixShell) HomeDir() string {
+	var homeEnvVar string
+	if runtime.GOOS == "windows" {
+		homeEnvVar = "USERPROFILE"
+	} else {
+		homeEnvVar = "HOME"
+	}
+	return os.Getenv(homeEnvVar)
 }
 
 func MakeUnixShell() Shell {

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -127,7 +127,7 @@ func TestHomeDir(t *testing.T) {
 		home := shell.HomeDir()
 		expected := os.Getenv("HOME")
 		if runtime.GOOS != "windows" && !strings.Contains(home, expected) {
-			t.Errorf("This is a UNIX-like system, expecting home dir [%s] to contain [/home]", expected)
+			t.Errorf("This is a UNIX-like system, expecting home dir [%s] to contain [%s]", home, expected)
 		}
 	})
 }

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -1,9 +1,11 @@
 package shell
 
 import (
-	"testing"
-	"strings"
 	"io/ioutil"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
 	"time"
 )
 
@@ -116,5 +118,16 @@ func TestWaitForCharacter(t *testing.T) {
 			t.Fatalf("Expecting error, got nothing. output was [%s]", outputString)
 		}
 		close(asyncError)
+	})
+}
+
+func TestHomeDir(t *testing.T) {
+	t.Run("Home dir for non-Windows boxes follow a common pattern", func(t *testing.T) {
+		shell := MakeUnixShell()
+		home := shell.HomeDir()
+		expected := os.Getenv("HOME")
+		if runtime.GOOS != "windows" && !strings.Contains(home, expected) {
+			t.Errorf("This is a UNIX-like system, expecting home dir [%s] to contain [/home]", expected)
+		}
 	})
 }

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -35,7 +35,7 @@ type (
 
 func NewClient(config *Config, transport http.RoundTripper) (pb.ApiClient, error) {
 	if !config.ServerURL.IsAbs() {
-		return nil, fmt.Errorf("server URL must be absolute")
+		return nil, fmt.Errorf("server URL must be absolute, was [%s]", config.ServerURL.String())
 	}
 
 	return &client{

--- a/controller/gen/public/api.pb.go
+++ b/controller/gen/public/api.pb.go
@@ -899,7 +899,7 @@ func (c *apiClient) Stat(ctx context.Context, in *MetricRequest, opts ...grpc.Ca
 	out := new(MetricResponse)
 	err := grpc.Invoke(ctx, "/conduit.public.Api/Stat", in, out, c.cc, opts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error invoking gRPC service: %v", err)
 	}
 	return out, nil
 }


### PR DESCRIPTION

This PR extracts some of the kube api creatin logic into its own object, and makes sure that it respects the `$KUBECONFIG` variable. It would probably be more interesting to use something like [Kubernetes' own logic to deal with this](https://github.com/kubernetes/kubernetes/blob/8e161212f6f02fce5f17894373ae46ef5ccc22dc/pkg/kubectl/cmd/util/factory_client_access.go#L165), but this is not in scope for this issue.

Closes #17 
