### PR TITLE
Have better empty states in Deployment Detail and Pod Detail

### DIFF
--- a/web/app/js/components/CallToAction.jsx
+++ b/web/app/js/components/CallToAction.jsx
@@ -40,7 +40,7 @@ export default class CallToAction extends React.Component {
           </Row>
         </div>
 
-        {instructions}
+        {instructions()}
       </div>
     );
   }

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -193,7 +193,7 @@ export default class Deployment extends React.Component {
           <div className="border-container border-neutral deployment-details">
             <div className="border-container-content">
               <div className=" subsection-header">Deployment details</div>
-              <Metric title="Pods" value={_.size(this.state.metrics)} />
+              <Metric title="Pods" value={_.size(podTableData)} />
               <Metric title="Upstream deployments" value={this.numUpstreams()} />
               <Metric title="Downstream deployments" value={this.numDownstreams()} />
             </div>

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -9,7 +9,7 @@ import StatPane from './StatPane.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import UpstreamDownstream from './UpstreamDownstream.jsx';
 import { Col, Row } from 'antd';
-import { getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
+import { emptyMetric, getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import './../../css/deployment.css';
 import 'whatwg-fetch';
 
@@ -46,6 +46,7 @@ export default class Deployment extends React.Component {
       deploy: deployment,
       metrics:[],
       timeseriesByPod: {},
+      pods: [],
       upstreamMetrics: [],
       upstreamTsByDeploy: {},
       downstreamMetrics: [],
@@ -98,6 +99,7 @@ export default class Deployment extends React.Component {
         this.setState({
           metrics: podMetrics,
           timeseriesByPod: podTs,
+          pods: deploy.pods,
           added: deploy.added,
           deployTs: _.get(tsByDeploy, this.state.deploy, {}),
           upstreamMetrics: upstreamMetrics,
@@ -134,10 +136,11 @@ export default class Deployment extends React.Component {
         upstreamMetrics={this.state.upstreamMetrics}
         downstreamMetrics={this.state.downstreamMetrics}
         deploymentAdded={this.state.added} />,
-      <StatPane
-        key="stat-pane"
-        lastUpdated={this.state.lastUpdated}
-        timeseries={this.state.deployTs} />,
+      _.isEmpty(this.state.deployTs) ? null :
+        <StatPane
+          key="stat-pane"
+          lastUpdated={this.state.lastUpdated}
+          timeseries={this.state.deployTs} />,
       this.renderMidsection(),
       <UpstreamDownstream
         key="deploy-upstream-downstream"
@@ -152,6 +155,11 @@ export default class Deployment extends React.Component {
   }
 
   renderMidsection() {
+    let podTableData = this.state.metrics;
+    if (_.isEmpty(this.state.metrics)) {
+      podTableData = _.map(this.state.pods, po => emptyMetric(po.name));
+    }
+
     return (
       <Row gutter={rowGutter} key="deployment-midsection">
         <Col span={16}>
@@ -159,21 +167,23 @@ export default class Deployment extends React.Component {
             <div className="border-container border-neutral subsection-header">
               <div className="border-container-content subsection-header">Pod summary</div>
             </div>
-            <div className="pod-distribution-chart">
-              <div className="bar-chart-title">
-                <div>Request load by pod</div>
-                <div className="bar-chart-tooltip" />
-              </div>
-              <BarChart
-                data={this.state.metrics}
-                lastUpdated={this.state.lastUpdated}
-                containerClassName="pod-distribution-chart" />
-            </div>
-
+            {
+              _.isEmpty(this.state.metrics) ? null :
+                <div className="pod-distribution-chart">
+                  <div className="bar-chart-title">
+                    <div>Request load by pod</div>
+                    <div className="bar-chart-tooltip" />
+                  </div>
+                  <BarChart
+                    data={this.state.metrics}
+                    lastUpdated={this.state.lastUpdated}
+                    containerClassName="pod-distribution-chart" />
+                </div>
+            }
             <TabbedMetricsTable
               resource="pod"
               lastUpdated={this.state.lastUpdated}
-              metrics={this.state.metrics}
+              metrics={podTableData}
               timeseries={this.state.timeseriesByPod}
               pathPrefix={this.props.pathPrefix} />
           </div>
@@ -215,14 +225,16 @@ export default class Deployment extends React.Component {
   render() {
     if (!this.state.loaded) {
       return <ConduitSpinner />;
-    } else return (
-      <div className="page-content deployment-detail">
-        <div className="page-header">
-          <div className="subsection-header">Deployment detail</div>
-          {this.renderDeploymentTitle()}
+    } else {
+      return (
+        <div className="page-content deployment-detail">
+          <div className="page-header">
+            <div className="subsection-header">Deployment detail</div>
+            {this.renderDeploymentTitle()}
+          </div>
+          {this.renderSections()}
         </div>
-        {this.renderSections()}
-      </div>
-    );
+      );
+    }
   }
 }

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -4,12 +4,12 @@ import ConduitSpinner from "./ConduitSpinner.jsx";
 import HealthPane from './HealthPane.jsx';
 import Metric from './Metric.jsx';
 import React from 'react';
-import { rowGutter } from './util/Utils.js';
 import StatPane from './StatPane.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import UpstreamDownstream from './UpstreamDownstream.jsx';
 import { Col, Row } from 'antd';
 import { emptyMetric, getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
+import { instructions, rowGutter } from './util/Utils.js';
 import './../../css/deployment.css';
 import 'whatwg-fetch';
 
@@ -212,8 +212,7 @@ export default class Deployment extends React.Component {
             <div className="unadded-message">
               <div className="status-badge unadded"><p>UNADDED</p></div>
               <div className="call-to-action">
-                <div className="action">Add {this.state.deploy} to the deployment.yml file</div>
-                <div className="action">Then run <code>kubectl inject deployment.yml | kubectl apply -f -</code> to add the deploys to the service mesh</div>
+                {instructions(this.state.deploy)}
               </div>
             </div>
           ) : null

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -95,6 +95,7 @@ export default class PodDetail extends React.Component {
 
   renderSections() {
     let currentSuccessRate = _.get(_.last(_.get(this.state.podTs, "SUCCESS_RATE", [])), "value");
+
     return [
       <HealthPane
         key="pod-health-pane"
@@ -103,10 +104,11 @@ export default class PodDetail extends React.Component {
         currentSr={currentSuccessRate}
         upstreamMetrics={this.state.upstreamMetrics}
         downstreamMetrics={this.state.downstreamMetrics} />,
-      <StatPane
-        key="pod-stat-pane"
-        lastUpdated={this.state.lastUpdated}
-        timeseries={this.state.podTs} />,
+      _.isEmpty(this.state.podTs) ? null :
+        <StatPane
+          key="pod-stat-pane"
+          lastUpdated={this.state.lastUpdated}
+          timeseries={this.state.podTs} />,
       <UpstreamDownstream
         key="pod-upstream-downstream"
         entity="pod"
@@ -119,14 +121,6 @@ export default class PodDetail extends React.Component {
     ];
   }
 
-  renderContent() {
-    if (_.isEmpty(this.state.podTs)) {
-      return <div>No data</div>;
-    } else {
-      return this.renderSections();
-    }
-  }
-
   render() {
     if (!this.state.loaded) {
       return <ConduitSpinner />;
@@ -136,7 +130,7 @@ export default class PodDetail extends React.Component {
           <div className="subsection-header">Pod detail</div>
           <h1>{this.state.pod}</h1>
         </div>
-        {this.renderContent()}
+        {this.renderSections()}
       </div>
     );
   }

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -257,7 +257,7 @@ export default class ServiceMesh extends React.Component {
     if (this.deployCount() === 0) {
       return (
         <div className="incomplete-mesh-message">
-          No deployments detected. {instructions}
+          No deployments detected. {instructions()}
         </div>
       );
     } else {
@@ -271,13 +271,13 @@ export default class ServiceMesh extends React.Component {
       case 1:
         return (
           <div className="incomplete-mesh-message">
-            1 deployment has not been added to the service mesh. {instructions}
+            1 deployment has not been added to the service mesh. {instructions()}
           </div>
         );
       default:
         return (
           <div className="incomplete-mesh-message">
-            {this.unaddedDeploymentCount()} deployments have not been added to the service mesh. {instructions}
+            {this.unaddedDeploymentCount()} deployments have not been added to the service mesh. {instructions()}
           </div>
         );
       }

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -125,7 +125,7 @@ export default class TabbedMetricsTable extends React.Component {
 
     // TODO: move this into rollup aggregation
     let tableData = this.props.metrics;
-    let totalRequestRate = _.sumBy(this.props.metrics, "requestRate");
+    let totalRequestRate = _.sumBy(this.props.metrics, "requestRate") || 0;
     _.each(tableData, datum => datum.totalRequests = totalRequestRate);
 
     return (<Table

--- a/web/app/js/components/UpstreamDownstream.jsx
+++ b/web/app/js/components/UpstreamDownstream.jsx
@@ -6,35 +6,43 @@ import { Col, Row } from 'antd';
 
 export default class UpstreamDownstreamTables extends React.Component {
   render() {
+    let numUpstreams = _.size(this.props.upstreamMetrics);
+    let numDownstreams = _.size(this.props.downstreamMetrics);
     return (
       <Row gutter={rowGutter}>
         <Col span={24}>
-          <div className="upstream-downstream-list">
-            <div className="border-container border-neutral subsection-header">
-              <div className="border-container-content subsection-header">
-                Upstream {this.props.entity}s: {_.size(this.props.upstreamMetrics)}
+          {
+            numUpstreams === 0 ? null :
+              <div className="upstream-downstream-list">
+                <div className="border-container border-neutral subsection-header">
+                  <div className="border-container-content subsection-header">
+                Upstream {this.props.entity}s: {numUpstreams}
+                  </div>
+                </div>
+                <TabbedMetricsTable
+                  resource={`upstream_${this.props.entity}`}
+                  lastUpdated={this.props.lastUpdated}
+                  metrics={this.props.upstreamMetrics}
+                  timeseries={this.props.upstreamTsByEntity}
+                  pathPrefix={this.props.pathPrefix} />
               </div>
-            </div>
-            <TabbedMetricsTable
-              resource={`upstream_${this.props.entity}`}
-              lastUpdated={this.props.lastUpdated}
-              metrics={this.props.upstreamMetrics}
-              timeseries={this.props.upstreamTsByEntity}
-              pathPrefix={this.props.pathPrefix} />
-          </div>
-          <div className="upstream-downstream-list">
-            <div className="border-container border-neutral subsection-header">
-              <div className="border-container-content subsection-header">
-                Downstream {this.props.entity}s: {_.size(this.props.downstreamMetrics)}
+          }
+          {
+            numDownstreams === 0 ? null :
+              <div className="upstream-downstream-list">
+                <div className="border-container border-neutral subsection-header">
+                  <div className="border-container-content subsection-header">
+                Downstream {this.props.entity}s: {numDownstreams}
+                  </div>
+                </div>
+                <TabbedMetricsTable
+                  resource={`downstream_${this.props.entity}`}
+                  lastUpdated={this.props.lastUpdated}
+                  metrics={this.props.downstreamMetrics}
+                  timeseries={this.props.downstreamTsByEntity}
+                  pathPrefix={this.props.pathPrefix} />
               </div>
-            </div>
-            <TabbedMetricsTable
-              resource={`downstream_${this.props.entity}`}
-              lastUpdated={this.props.lastUpdated}
-              metrics={this.props.downstreamMetrics}
-              timeseries={this.props.downstreamTsByEntity}
-              pathPrefix={this.props.pathPrefix} />
-          </div>
+          }
         </Col>
       </Row>
     );

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -31,7 +31,11 @@ export const getPodsByDeployment = pods => {
     .reject(p => _.isEmpty(p.deployment) || p.controlPlane)
     .groupBy('deployment')
     .map((componentPods, name) => {
-      return { name: name, added: _.every(componentPods, 'added') };
+      return {
+        name: name,
+        added: _.every(componentPods, 'added'),
+        pods: componentPods
+      };
     })
     .sortBy('name')
     .value();

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -79,7 +79,16 @@ export const toClassName = name => {
 /*
 * Instructions for adding deployments to service mesh
 */
-export const instructions = (
-  <div className="action">Add one or more deployments to the deployment.yml file <br /><br />
-  Then run <code>conduit inject deployment.yml | kubectl apply -f - </code> to add deploys to the service mesh</div>
-);
+export const instructions = name => {
+  if (name) {
+    return (
+      <div className="action">Add {name} to the deployment.yml file<br /><br />
+      Then run <code>conduit inject deployment.yml | kubectl apply -f -</code> to add it to the service mesh</div>
+    );
+  } else {
+    return (
+      <div className="action">Add one or more deployments to the deployment.yml file<br /><br />
+      Then run <code>conduit inject deployment.yml | kubectl apply -f -</code> to add them to the service mesh</div>
+    );
+  }
+};


### PR DESCRIPTION
Adds various checks to hide sections of pages that don't have data:
* Removes the timeseries graphs and latency overview from Deployment/Pod detail if there are no metrics for it
* Removes the Upstreams/Downstreams if num upstreams / downstreams is 0
* Removes the pod barcharts from the Deployment detail if there are no pods
* If there are no pod metrics, populate the list of pods from `/pods`
* These changes strip the pod detail view down a lot if there's no pod data, but that might be fine

![screen shot 2017-12-19 at 3 19 38 pm](https://user-images.githubusercontent.com/549258/34184570-54915404-e4d5-11e7-9f63-bb59a5be19d9.png)

![screen shot 2017-12-19 at 3 58 42 pm](https://user-images.githubusercontent.com/549258/34184609-85382fd8-e4d5-11e7-9bfc-be0f8e82a3a5.png)

 