### PR TITLE
Add more information to async test failures

### DIFF
--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -38,16 +38,17 @@ func TestAsyncStdout(t *testing.T) {
 		asyncError := make(chan error, 1)
 		output, err := MakeUnixShell().AsyncStdout(asyncError, "echo", expectedOutput)
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
 		}
 
 		outputBytes, err := ioutil.ReadAll(output)
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
 		}
 
-		if strings.TrimSpace(string(outputBytes)) != expectedOutput {
-			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
+		actualOutput := strings.TrimSpace(string(outputBytes))
+		if actualOutput != expectedOutput {
+			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, actualOutput)
 		}
 
 		select {
@@ -63,7 +64,7 @@ func TestAsyncStdout(t *testing.T) {
 		asyncError := make(chan error, 1)
 		out, err := MakeUnixShell().AsyncStdout(asyncError, "command-that-doesnt", "--exist")
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
 		}
 
 		select {
@@ -78,24 +79,25 @@ func TestAsyncStdout(t *testing.T) {
 }
 
 func TestWaitForCharacter(t *testing.T) {
-
 	t.Run("Executes command and returns result without error if return code 0", func(t *testing.T) {
 		shell := MakeUnixShell()
 		asyncError := make(chan error, 1)
 		expectedOutput := "expected>"
+
 		output, err := shell.AsyncStdout(asyncError, "echo", expectedOutput)
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
 		}
 
 		outputString, err := shell.WaitForCharacter('>', output, 10*time.Second)
 		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
 		}
 
 		if strings.TrimSpace(outputString) != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
+
 		select {
 		case e := <-asyncError:
 			if e != nil {


### PR DESCRIPTION
This is trying to provide more information for a flaky failing test that happens every now and then on Travis:
```

=== RUN   TestAsyncStdout/Executes_command_and_returns_result_and_error_if_did_not_find_expected_character

--- FAIL: TestAsyncStdout (0.00s)

    --- FAIL: TestAsyncStdout/Executes_command_and_returns_result_without_error_if_return_code_0 (0.00s)

    	shell_test.go:46: Unexpected error: read |0: file already closed

    --- PASS: TestAsyncStdout/Executes_command_and_returns_result_and_error_if_did_not_find_expected_character (0.00s)

=== RUN   TestWaitForCharacter

=== RUN   TestWaitForCharacter/Executes_command_and_returns_result_without_error_if_return_code_0

=== RUN   TestWaitForCharacter/Executes_command_and_returns_timeout_error_if_expected_character_never_shows_up_in_output

--- FAIL: TestWaitForCharacter (0.10s)

    --- FAIL: TestWaitForCharacter/Executes_command_and_returns_result_without_error_if_return_code_0 (0.00s)

    	shell_test.go:93: Unexpected error: Error while reading output from command: read |0: file already closed

    --- PASS: TestWaitForCharacter/Executes_command_and_returns_timeout_error_if_expected_character_never_shows_up_in_output (0.10s)
```