### PR TITLE
Prepare the repo for the v0.1.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,21 @@
+## v0.1.1
+
+Conduit 0.1.1 is focused on making it easier to get started with Conduit.
+
+* Conduit can now be installed on Kubernetes clusters that use RBAC
+* The new `--skip-outbound-ports` flag for the CLI `inject` command directs Conduit to bypass proxying for specific outbound ports, making Conduit easier to use with non-gRPC or HTTP/2 protocols.
+* The CLI `tap` command output has been reformatted to be line-oriented, making it easier to parse with common UNIX command line utilities
+* Proxies now support routing to non-fully qualified domain names, with routing rules that more closely resemble the default Kubernetes DNS search path
+* The web UI has improved support for large deployments and deployments that don’t have any inbound/outbound traffic
+
+## v0.1.0
+
+Conduit 0.1.0 is the first public release of Conduit.
+
+* This release supports services that communicate via gRPC only. non-gRPC HTTP/2 services should work. More complete HTTP support, including HTTP/1.0 and HTTP/1.1 and non-gRPC HTTP/2, will be added in an upcoming release.
+* Kubernetes 1.8.0 or later is required.
+* kubectl 1.8.0 or later is required. `conduit dashboard` will not work with earlier versions of kubectl.
+* When deploying to Minikube, Minikube 0.23 or 0.24.1 or later are required. Earlier versions will not work.
+* This release has been tested using Google Kubernetes Engine and Minikube. Upcoming releases will be tested on additional providers too.
+* Configuration settings and protocols are not stable yet.
+* Services written in Go must use grpc-go 1.3 or later to avoid [grpc-go bug #1120](https://github.com/grpc/grpc-go/issues/1120).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,20 +2,30 @@
 
 Conduit 0.1.1 is focused on making it easier to get started with Conduit.
 
-* Conduit can now be installed on Kubernetes clusters that use RBAC
-* The new `--skip-outbound-ports` flag for the CLI `inject` command directs Conduit to bypass proxying for specific outbound ports, making Conduit easier to use with non-gRPC or HTTP/2 protocols.
-* The CLI `tap` command output has been reformatted to be line-oriented, making it easier to parse with common UNIX command line utilities
-* Proxies now support routing to non-fully qualified domain names, with routing rules that more closely resemble the default Kubernetes DNS search path
-* The web UI has improved support for large deployments and deployments that don’t have any inbound/outbound traffic
+* Conduit can now be installed on Kubernetes clusters that use RBAC.
+* The `conduit inject` command now supports a `--skip-outbound-ports` flag that directs Conduit to
+  bypass proxying for specific outbound ports, making Conduit easier to use with non-gRPC or HTTP/2
+  protocols.
+* The `conduit tap` command output has been reformatted to be line-oriented, making it easier to
+  parse with common UNIX command line utilities.
+* Conduit now supports routing of non-fully qualified domain names.
+* The web UI has improved support for large deployments and deployments that don’t have any
+  inbound/outbound traffic.
 
 ## v0.1.0
 
 Conduit 0.1.0 is the first public release of Conduit.
 
-* This release supports services that communicate via gRPC only. non-gRPC HTTP/2 services should work. More complete HTTP support, including HTTP/1.0 and HTTP/1.1 and non-gRPC HTTP/2, will be added in an upcoming release.
+* This release supports services that communicate via gRPC only. non-gRPC HTTP/2 services should
+  work. More complete HTTP support, including HTTP/1.0 and HTTP/1.1 and non-gRPC HTTP/2, will be
+  added in an upcoming release.
 * Kubernetes 1.8.0 or later is required.
-* kubectl 1.8.0 or later is required. `conduit dashboard` will not work with earlier versions of kubectl.
-* When deploying to Minikube, Minikube 0.23 or 0.24.1 or later are required. Earlier versions will not work.
-* This release has been tested using Google Kubernetes Engine and Minikube. Upcoming releases will be tested on additional providers too.
+* kubectl 1.8.0 or later is required. `conduit dashboard` will not work with earlier versions of
+  kubectl.
+* When deploying to Minikube, Minikube 0.23 or 0.24.1 or later are required. Earlier versions will
+  not work.
+* This release has been tested using Google Kubernetes Engine and Minikube. Upcoming releases will
+  be tested on additional providers too.
 * Configuration settings and protocols are not stable yet.
-* Services written in Go must use grpc-go 1.3 or later to avoid [grpc-go bug #1120](https://github.com/grpc/grpc-go/issues/1120).
+* Services written in Go must use grpc-go 1.3 or later to avoid
+  [grpc-go bug #1120](https://github.com/grpc/grpc-go/issues/1120).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,14 +98,14 @@ dependencies = [
 
 [[package]]
 name = "codegen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conduit-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "abstract-ns 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -132,11 +132,11 @@ dependencies = [
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-grpc 0.1.0",
- "tower-grpc-build 0.1.0",
- "tower-h2 0.1.0",
+ "tower-grpc 0.1.1",
+ "tower-grpc-build 0.1.1",
+ "tower-h2 0.1.1",
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-router 0.1.0",
+ "tower-router 0.1.1",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "tower-grpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -864,21 +864,21 @@ dependencies = [
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-h2 0.1.0",
+ "tower-h2 0.1.1",
  "tower-router 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-grpc-build"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "codegen 0.1.0",
+ "codegen 0.1.1",
  "prost-build 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-grpc-examples"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,14 +891,14 @@ dependencies = [
  "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-grpc 0.1.0",
- "tower-grpc-build 0.1.0",
- "tower-h2 0.1.0",
+ "tower-grpc 0.1.1",
+ "tower-grpc-build 0.1.1",
+ "tower-h2 0.1.1",
 ]
 
 [[package]]
 name = "tower-h2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "tower-router"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -8,14 +8,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/runconduit/conduit/controller"
-
 	"github.com/ghodss/yaml"
-	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-
+	"github.com/runconduit/conduit/controller"
 	"github.com/spf13/cobra"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	yamlDecoder "k8s.io/client-go/pkg/util/yaml"
 )
 
@@ -281,8 +279,8 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 				ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 			},
 			v1.EnvVar{
-				Name:      "CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN",
-				Value:     "Kubernetes",
+				Name:  "CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN",
+				Value: "Kubernetes",
 			},
 		},
 	}
@@ -376,7 +374,7 @@ type enhancedDaemonSet struct {
 
 func init() {
 	RootCmd.AddCommand(injectCmd)
-	injectCmd.PersistentFlags().StringVarP(&version, "conduit-version", "v", "v0.1.0", "tag to be used for conduit images")
+	injectCmd.PersistentFlags().StringVarP(&version, "conduit-version", "v", controller.Version, "tag to be used for conduit images")
 	injectCmd.PersistentFlags().StringVar(&initImage, "init-image", "gcr.io/runconduit/proxy-init", "Conduit init container image name")
 	injectCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", "gcr.io/runconduit/proxy", "Conduit proxy container image name")
 	injectCmd.PersistentFlags().StringVar(&imagePullPolicy, "image-pull-policy", "IfNotPresent", "Docker image pull policy")

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -8,7 +8,6 @@ import (
 	"text/template"
 
 	"github.com/runconduit/conduit/controller"
-
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 )
@@ -426,7 +425,7 @@ func validate() error {
 
 func init() {
 	RootCmd.AddCommand(installCmd)
-	installCmd.PersistentFlags().StringVarP(&version, "version", "v", "v0.1.0", "Conduit version to install")
+	installCmd.PersistentFlags().StringVarP(&version, "version", "v", controller.Version, "Conduit version to install")
 	installCmd.PersistentFlags().StringVarP(&dockerRegistry, "registry", "r", "gcr.io/runconduit", "Docker registry to pull images from")
 	installCmd.PersistentFlags().UintVar(&controllerReplicas, "controller-replicas", 1, "replicas of the controller to deploy")
 	installCmd.PersistentFlags().UintVar(&webReplicas, "web-replicas", 1, "replicas of the web server to deploy")

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codegen"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 
 [dependencies]

--- a/controller/api/public/client_test.go
+++ b/controller/api/public/client_test.go
@@ -15,7 +15,7 @@ func TestClientUnmarshal(t *testing.T) {
 	versionInfo := pb.VersionInfo{
 		GoVersion:      "1.9.1",
 		BuildDate:      "2017.11.17",
-		ReleaseVersion: "0.1.0",
+		ReleaseVersion: "1.2.3",
 	}
 
 	var unmarshaled pb.VersionInfo

--- a/controller/version.go
+++ b/controller/version.go
@@ -1,3 +1,3 @@
 package controller
 
-var Version = "v0.1.0"
+const Version = "v0.1.1"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit-proxy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 publish = false
 

--- a/tower-grpc-build/Cargo.toml
+++ b/tower-grpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-grpc-build"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 
 [dependencies]

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-grpc-examples"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 
 [[bin]]

--- a/tower-grpc/Cargo.toml
+++ b/tower-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-grpc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 
 [features]

--- a/tower-h2/Cargo.toml
+++ b/tower-h2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-h2"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 description = "Exploring tower + h2"
 publish = false

--- a/tower-router/Cargo.toml
+++ b/tower-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-router"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 publish = false
 


### PR DESCRIPTION
Bumping the controller and proxy versions to v0.1.1, adding a changelog, and fixing a few issues with version handling. We need to pick up #74 before merging this change.

