### PR TITLE
Add message to indicate /routes is not implemented

### DIFF
--- a/web/app/js/components/Routes.jsx
+++ b/web/app/js/components/Routes.jsx
@@ -8,6 +8,7 @@ export default class Routes extends React.Component {
         <div className="page-header">
           <h1>Routes</h1>
         </div>
+        <div>Coming soon!</div>
       </div>
     );
   }


### PR DESCRIPTION
If someone clicks on Routes in the sidebar, the page appears to fail to load, but this endpoint is unimplemented. Add a message to indicate that.

(This came up in  #76)

![screen shot 2017-12-20 at 10 14 54 am](https://user-images.githubusercontent.com/549258/34221970-c0eb1010-e56e-11e7-8545-cec4dec45780.png)
