### PR TITLE
returns rs name in case of there's no deployment

### DIFF
--- a/controller/k8s/replicasets.go
+++ b/controller/k8s/replicasets.go
@@ -74,6 +74,9 @@ func (p *ReplicaSetStore) GetDeploymentForPod(pod *v1.Pod) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if len(rs.GetOwnerReferences()) == 0 {
+			return namespace + "/" + rsName, nil
+		}
 		return namespace + "/" + rs.GetOwnerReferences()[0].Name, nil
 	}
 	return namespace + "/" + parent.Name, nil


### PR DESCRIPTION
This is obviously wrong to return the RS name on a method called GetDeploymentForPod, but it removes an exception in case there is no Deployment