### PR TITLE
Bind this.handleApiError in PodDetail

### DIFF
--- a/web/app/js/components/Deployments.jsx
+++ b/web/app/js/components/Deployments.jsx
@@ -17,9 +17,9 @@ export default class Deployments extends React.Component {
   constructor(props) {
     super(props);
     this.api = ApiHelpers(this.props.pathPrefix);
+    this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.loadTimeseriesFromServer = this.loadTimeseriesFromServer.bind(this);
-    this.handleApiError = this.handleApiError.bind(this);
 
     this.state = {
       metricsWindow: "10m",

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -13,6 +13,7 @@ export default class PodDetail extends React.Component {
   constructor(props) {
     super(props);
     this.api = ApiHelpers(this.props.pathPrefix);
+    this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.state = this.initialState(this.props.location);
   }


### PR DESCRIPTION
In #65 I forgot to bind handleApiError in the PodDetail module, which resulted in this error if a fetch call failed:
```
Uncaught (in promise) TypeError: Cannot read property 'setState' of undefined
```

This adds that binding.