### PR TITLE
Make TabbedMetricsTable in charge of fetching timeseries

### DIFF
--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -50,12 +50,12 @@ export default class Deployment extends React.Component {
       metricsWindow: "10m",
       deploy: deployment,
       metrics:[],
-      timeseriesByPod: {},
+
       pods: [],
       upstreamMetrics: [],
-      upstreamTsByDeploy: {},
+
       downstreamMetrics: [],
-      downstreamTsByDeploy: {},
+
       pendingRequests: false,
       loaded: false,
       error: ''
@@ -71,32 +71,22 @@ export default class Deployment extends React.Component {
     let metricsUrl = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}` ;
     let deployMetricsUrl = `${metricsUrl}&timeseries=true&target_deploy=${this.state.deploy}`;
     let podRollupUrl = `${metricsUrl}&aggregation=target_pod&target_deploy=${this.state.deploy}`;
-    let podTimeseriesUrl = `${podRollupUrl}&timeseries=true`;
     let upstreamRollupUrl = `${metricsUrl}&aggregation=source_deploy&target_deploy=${this.state.deploy}`;
-    let upstreamTimeseriesUrl = `${upstreamRollupUrl}&timeseries=true`;
     let downstreamRollupUrl = `${metricsUrl}&aggregation=target_deploy&source_deploy=${this.state.deploy}`;
-    let downstreamTimeseriesUrl = `${downstreamRollupUrl}&timeseries=true`;
 
     let deployFetch = this.api.fetch(deployMetricsUrl);
     let podListFetch = this.api.fetchPods();
     let podRollupFetch = this.api.fetch(podRollupUrl);
-    let podTsFetch = this.api.fetch(podTimeseriesUrl);
     let upstreamFetch = this.api.fetch(upstreamRollupUrl);
-    let upstreamTsFetch = this.api.fetch(upstreamTimeseriesUrl);
     let downstreamFetch = this.api.fetch(downstreamRollupUrl);
-    let downstreamTsFetch = this.api.fetch(downstreamTimeseriesUrl);
 
     // expose serverPromise for testing
-    this.serverPromise = Promise.all([deployFetch, podRollupFetch, podTsFetch, upstreamFetch, upstreamTsFetch, downstreamFetch, downstreamTsFetch, podListFetch])
-      .then(([deployMetrics, podRollup, podTimeseries, upstreamRollup, upstreamTimeseries, downstreamRollup, downstreamTimeseries, podList]) => {
+    this.serverPromise = Promise.all([deployFetch, podRollupFetch, upstreamFetch, downstreamFetch, podListFetch])
+      .then(([deployMetrics, podRollup, upstreamRollup, downstreamRollup, podList]) => {
         let tsByDeploy = processTimeseriesMetrics(deployMetrics.metrics, "targetDeploy");
         let podMetrics = processRollupMetrics(podRollup.metrics, "targetPod");
-        let podTs = processTimeseriesMetrics(podTimeseries.metrics, "targetPod");
-
         let upstreamMetrics = processRollupMetrics(upstreamRollup.metrics, "sourceDeploy");
-        let upstreamTsByDeploy = processTimeseriesMetrics(upstreamTimeseries.metrics, "sourceDeploy");
         let downstreamMetrics = processRollupMetrics(downstreamRollup.metrics, "targetDeploy");
-        let downstreamTsByDeploy = processTimeseriesMetrics(downstreamTimeseries.metrics, "targetDeploy");
 
         let deploy = _.find(getPodsByDeployment(podList.pods), ["name", this.state.deploy]);
         let totalRequestRate = _.sumBy(podMetrics, "requestRate");
@@ -104,14 +94,11 @@ export default class Deployment extends React.Component {
 
         this.setState({
           metrics: podMetrics,
-          timeseriesByPod: podTs,
           pods: deploy.pods,
           added: deploy.added,
           deployTs: _.get(tsByDeploy, this.state.deploy, {}),
           upstreamMetrics: upstreamMetrics,
-          upstreamTsByDeploy: upstreamTsByDeploy,
           downstreamMetrics: downstreamMetrics,
-          downstreamTsByDeploy: downstreamTsByDeploy,
           lastUpdated: Date.now(),
           pendingRequests: false,
           loaded: true,
@@ -156,12 +143,12 @@ export default class Deployment extends React.Component {
       this.renderMidsection(),
       <UpstreamDownstream
         key="deploy-upstream-downstream"
-        entity="deployment"
+        resource="deployment"
+        entity={this.state.deploy}
         lastUpdated={this.state.lastUpdated}
         upstreamMetrics={this.state.upstreamMetrics}
-        upstreamTsByEntity={this.state.upstreamTsByDeploy}
         downstreamMetrics={this.state.downstreamMetrics}
-        downstreamTsByEntity={this.state.downstreamTsByDeploy}
+        metricsWindow={this.state.metricsWindow}
         pathPrefix={this.props.pathPrefix} />
     ];
   }
@@ -194,10 +181,11 @@ export default class Deployment extends React.Component {
             }
             <TabbedMetricsTable
               resource="pod"
-              lastUpdated={this.state.lastUpdated}
+              entity={this.state.deploy}
               metrics={podTableData}
-              timeseries={this.state.timeseriesByPod}
-              pathPrefix={this.props.pathPrefix} />
+              lastUpdated={this.state.lastUpdated}
+              pathPrefix={this.props.pathPrefix}
+              metricsWindow={this.state.metricsWindow} />
           </div>
         </Col>
 

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { ApiHelpers } from './util/ApiHelpers.js';
 import BarChart from './BarChart.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
@@ -11,6 +10,7 @@ import { rowGutter } from './util/Utils.js';
 import StatPane from './StatPane.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import UpstreamDownstream from './UpstreamDownstream.jsx';
+import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import { Col, Row } from 'antd';
 import { emptyMetric, getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import './../../css/deployment.css';
@@ -68,11 +68,13 @@ export default class Deployment extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
+    let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
+
     let metricsUrl = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}` ;
     let deployMetricsUrl = `${metricsUrl}&timeseries=true&target_deploy=${this.state.deploy}`;
-    let podRollupUrl = `${metricsUrl}&aggregation=target_pod&target_deploy=${this.state.deploy}`;
-    let upstreamRollupUrl = `${metricsUrl}&aggregation=source_deploy&target_deploy=${this.state.deploy}`;
-    let downstreamRollupUrl = `${metricsUrl}&aggregation=target_deploy&source_deploy=${this.state.deploy}`;
+    let podRollupUrl = urls["pod"].url(this.state.deploy).rollup;
+    let upstreamRollupUrl = urls["upstream_deployment"].url(this.state.deploy).rollup;
+    let downstreamRollupUrl = urls["downstream_deployment"].url(this.state.deploy).rollup;
 
     let deployFetch = this.api.fetch(deployMetricsUrl);
     let podListFetch = this.api.fetchPods();

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -67,8 +67,7 @@ export default class Deployment extends React.Component {
 
     let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
 
-    let metricsUrl = urls["deployment"].url().rollup;
-    let deployMetricsUrl = `${metricsUrl}&timeseries=true&target_deploy=${this.state.deploy}`;
+    let deployMetricsUrl = urls["deployment"].url(this.state.deploy).ts;
     let podRollupUrl = urls["pod"].url(this.state.deploy).rollup;
     let upstreamRollupUrl = urls["upstream_deployment"].url(this.state.deploy).rollup;
     let downstreamRollupUrl = urls["downstream_deployment"].url(this.state.deploy).rollup;

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -50,12 +50,9 @@ export default class Deployment extends React.Component {
       metricsWindow: "10m",
       deploy: deployment,
       metrics:[],
-
       pods: [],
       upstreamMetrics: [],
-
       downstreamMetrics: [],
-
       pendingRequests: false,
       loaded: false,
       error: ''
@@ -70,7 +67,7 @@ export default class Deployment extends React.Component {
 
     let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
 
-    let metricsUrl = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}` ;
+    let metricsUrl = urls["deployment"].url().rollup;
     let deployMetricsUrl = `${metricsUrl}&timeseries=true&target_deploy=${this.state.deploy}`;
     let podRollupUrl = urls["pod"].url(this.state.deploy).rollup;
     let upstreamRollupUrl = urls["upstream_deployment"].url(this.state.deploy).rollup;

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -43,9 +43,7 @@ export default class PodDetail extends React.Component {
       metricsWindow: "10m",
       pod: pod,
       upstreamMetrics: [],
-      upstreamTsByPod: {},
       downstreamMetrics: [],
-      downstreamTsByPod: {},
       podTs: {},
       pendingRequests: false,
       loaded: false,
@@ -61,36 +59,27 @@ export default class PodDetail extends React.Component {
 
     let metricsUrl = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}` ;
     let podMetricsUrl = `${metricsUrl}&timeseries=true&target_pod=${this.state.pod}`;
-
     let upstreamRollupUrl = `${metricsUrl}&aggregation=source_pod&target_pod=${this.state.pod}`;
-    let upstreamTimeseriesUrl = `${upstreamRollupUrl}&timeseries=true`;
     let downstreamRollupUrl = `${metricsUrl}&aggregation=target_pod&source_pod=${this.state.pod}`;
-    let downstreamTimeseriesUrl = `${downstreamRollupUrl}&timeseries=true`;
 
     let podFetch = this.api.fetch(podMetricsUrl);
     let upstreamFetch =  this.api.fetch(upstreamRollupUrl);
-    let upstreamTsFetch =  this.api.fetch(upstreamTimeseriesUrl);
     let downstreamFetch =  this.api.fetch(downstreamRollupUrl);
-    let downstreamTsFetch =  this.api.fetch(downstreamTimeseriesUrl);
 
-    Promise.all([podFetch, upstreamFetch, upstreamTsFetch, downstreamFetch, downstreamTsFetch])
-      .then(([podMetrics, upstreamRollup, upstreamTimeseries, downstreamRollup, downstreamTimeseries]) => {
+    Promise.all([podFetch, upstreamFetch, downstreamFetch])
+      .then(([podMetrics, upstreamRollup, downstreamRollup]) => {
         let podTs = processTimeseriesMetrics(podMetrics.metrics, "targetPod");
         let podTimeseries = _.get(podTs, this.state.pod, {});
 
         let upstreamMetrics = processRollupMetrics(upstreamRollup.metrics, "sourcePod");
-        let upstreamTsByPod = processTimeseriesMetrics(upstreamTimeseries.metrics, "sourcePod");
         let downstreamMetrics = processRollupMetrics(downstreamRollup.metrics, "targetPod");
-        let downstreamTsByPod = processTimeseriesMetrics(downstreamTimeseries.metrics, "targetPod");
 
         this.setState({
           pendingRequests: false,
           lastUpdated: Date.now(),
           podTs: podTimeseries,
           upstreamMetrics: upstreamMetrics,
-          upstreamTsByPod: upstreamTsByPod,
           downstreamMetrics: downstreamMetrics,
-          downstreamTsByPod: downstreamTsByPod,
           loaded: true,
           error: ''
         });
@@ -122,12 +111,12 @@ export default class PodDetail extends React.Component {
           timeseries={this.state.podTs} />,
       <UpstreamDownstream
         key="pod-upstream-downstream"
-        entity="pod"
+        resource="pod"
+        entity={this.state.pod}
         lastUpdated={this.state.lastUpdated}
         upstreamMetrics={this.state.upstreamMetrics}
-        upstreamTsByEntity={this.state.upstreamTsByPod}
         downstreamMetrics={this.state.downstreamMetrics}
-        downstreamTsByEntity={this.state.downstreamTsByPod}
+        metricsWindow={this.state.metricsWindow}
         pathPrefix={this.props.pathPrefix} />
     ];
   }

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -1,11 +1,11 @@
 import _ from 'lodash';
-import { ApiHelpers } from './util/ApiHelpers.js';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import HealthPane from './HealthPane.jsx';
 import React from 'react';
 import StatPane from './StatPane.jsx';
 import UpstreamDownstream from './UpstreamDownstream.jsx';
+import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import { processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import 'whatwg-fetch';
 
@@ -57,10 +57,12 @@ export default class PodDetail extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
+    let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
+
     let metricsUrl = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}` ;
     let podMetricsUrl = `${metricsUrl}&timeseries=true&target_pod=${this.state.pod}`;
-    let upstreamRollupUrl = `${metricsUrl}&aggregation=source_pod&target_pod=${this.state.pod}`;
-    let downstreamRollupUrl = `${metricsUrl}&aggregation=target_pod&source_pod=${this.state.pod}`;
+    let upstreamRollupUrl = urls["upstream_pod"].url(this.state.pod).rollup;
+    let downstreamRollupUrl = urls["downstream_pod"].url(this.state.pod).rollup;
 
     let podFetch = this.api.fetch(podMetricsUrl);
     let upstreamFetch =  this.api.fetch(upstreamRollupUrl);

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -59,7 +59,7 @@ export default class PodDetail extends React.Component {
 
     let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
 
-    let metricsUrl = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}` ;
+    let metricsUrl = urls["deployment"].url().rollup;
     let podMetricsUrl = `${metricsUrl}&timeseries=true&target_pod=${this.state.pod}`;
     let upstreamRollupUrl = urls["upstream_pod"].url(this.state.pod).rollup;
     let downstreamRollupUrl = urls["downstream_pod"].url(this.state.pod).rollup;

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Percentage from './util/Percentage.js';
 import { processTimeseriesMetrics } from './util/MetricUtils.js';
 import React from 'react';
-import { ApiHelpers, timeseriesUrls } from './util/ApiHelpers.js';
+import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import { metricToFormatter, toClassName } from './util/Utils.js';
 import { Table, Tabs } from 'antd';
 
@@ -102,7 +102,7 @@ export default class TabbedMetricsTable extends React.Component {
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
 
-    let tsHelper = timeseriesUrls(this.props.pathPrefix, this.props.metricsWindow)[this.props.resource];
+    let tsHelper = urlsForResource(this.props.pathPrefix, this.props.metricsWindow)[this.props.resource];
 
     this.state = {
       timeseries: {},

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -111,7 +111,7 @@ export default class TabbedMetricsTable extends React.Component {
       error: '',
       lastUpdated: this.props.lastUpdated,
       metricsWindow: "10s",
-      pollingInterval: "10000",
+      pollingInterval: 10000,
       pendingRequests: false
     };
   }
@@ -121,18 +121,6 @@ export default class TabbedMetricsTable extends React.Component {
       this.loadFromServer();
       this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
     }
-  }
-
-  shouldComponentUpdate(nextProps) {
-    /*
-      Even though we update the state after each timeseries fetch, only re-render
-      the component when the rollup metrics also need updating, so that all the
-      parts of the table refresh at once.
-     */
-    if (nextProps.lastUpdated === this.props.lastUpdated) {
-      return false;
-    }
-    return true;
   }
 
   componentWillUnmount() {

--- a/web/app/js/components/UpstreamDownstream.jsx
+++ b/web/app/js/components/UpstreamDownstream.jsx
@@ -4,6 +4,7 @@ import { rowGutter } from './util/Utils.js';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import { Col, Row } from 'antd';
 
+const maxTsToFetch = 15;
 export default class UpstreamDownstreamTables extends React.Component {
   render() {
     let numUpstreams = _.size(this.props.upstreamMetrics);
@@ -16,14 +17,16 @@ export default class UpstreamDownstreamTables extends React.Component {
               <div className="upstream-downstream-list">
                 <div className="border-container border-neutral subsection-header">
                   <div className="border-container-content subsection-header">
-                Upstream {this.props.entity}s: {numUpstreams}
+                Upstream {this.props.resource}s: {numUpstreams}
                   </div>
                 </div>
                 <TabbedMetricsTable
-                  resource={`upstream_${this.props.entity}`}
+                  resource={`upstream_${this.props.resource}`}
+                  entity={this.props.entity}
+                  hideSparklines={numUpstreams > maxTsToFetch}
                   lastUpdated={this.props.lastUpdated}
                   metrics={this.props.upstreamMetrics}
-                  timeseries={this.props.upstreamTsByEntity}
+                  metricsWindow={this.props.metricsWindow}
                   pathPrefix={this.props.pathPrefix} />
               </div>
           }
@@ -32,14 +35,16 @@ export default class UpstreamDownstreamTables extends React.Component {
               <div className="upstream-downstream-list">
                 <div className="border-container border-neutral subsection-header">
                   <div className="border-container-content subsection-header">
-                Downstream {this.props.entity}s: {numDownstreams}
+                Downstream {this.props.resource}s: {numDownstreams}
                   </div>
                 </div>
                 <TabbedMetricsTable
-                  resource={`downstream_${this.props.entity}`}
+                  resource={`downstream_${this.props.resource}`}
+                  entity={this.props.entity}
+                  hideSparklines={numDownstreams > maxTsToFetch}
                   lastUpdated={this.props.lastUpdated}
                   metrics={this.props.downstreamMetrics}
-                  timeseries={this.props.downstreamTsByEntity}
+                  metricsWindow={this.props.metricsWindow}
                   pathPrefix={this.props.pathPrefix} />
               </div>
           }

--- a/web/app/js/components/util/ApiHelpers.js
+++ b/web/app/js/components/util/ApiHelpers.js
@@ -23,3 +23,84 @@ export const ApiHelpers = pathPrefix => {
     fetchPods
   };
 };
+
+export const timeseriesUrls = (pathPrefix, metricsWindow) => {
+  /*
+    Timeseries fetches used in the TabbedMetricsTable
+  */
+  let metricsUrl = `${pathPrefix}/api/metrics?window=${metricsWindow}`;
+
+  return {
+    // all deploys
+    "deployment": {
+      groupBy: "targetDeploy",
+      url: () => {
+        let timeseriesPath = `${metricsUrl}&timeseries=true`;
+        return {
+          ts: timeseriesPath,
+          rollup: metricsUrl
+        };
+      }
+    },
+    "pod": {
+      // all pods of a given deploy
+      groupBy: "targetPod",
+      url: deploy => {
+        let podRollupUrl = `${metricsUrl}&aggregation=target_pod&target_deploy=${deploy}`;
+        let podTimeseriesUrl = `${podRollupUrl}&timeseries=true`;
+        return {
+          ts: podTimeseriesUrl,
+          rollup: podRollupUrl
+        };
+      }
+    },
+    "upstream_deployment": {
+      // all upstreams of a given deploy
+      groupBy: "sourceDeploy",
+      url: deploy => {
+        let upstreamRollupUrl = `${metricsUrl}&aggregation=source_deploy&target_deploy=${deploy}`;
+        let upstreamTimeseriesUrl = `${upstreamRollupUrl}&timeseries=true`;
+        return {
+          ts: upstreamTimeseriesUrl,
+          rollup: upstreamRollupUrl
+        };
+      }
+    },
+    "downstream_deployment": {
+      // all downstreams of a given deploy
+      groupBy: "targetDeploy",
+      url: deploy => {
+        let downstreamRollupUrl = `${metricsUrl}&aggregation=target_deploy&source_deploy=${deploy}`;
+        let downstreamTimeseriesUrl = `${downstreamRollupUrl}&timeseries=true`;
+        return {
+          ts: downstreamTimeseriesUrl,
+          rollup: downstreamRollupUrl
+        };
+      }
+    },
+    "upstream_pod": {
+      groupBy: "sourcePod",
+      url: pod => {
+        let upstreamRollupUrl = `${metricsUrl}&aggregation=source_pod&target_pod=${pod}`;
+        let upstreamTimeseriesUrl = `${upstreamRollupUrl}&timeseries=true`;
+
+        return {
+          ts: upstreamTimeseriesUrl,
+          rollup: upstreamRollupUrl
+        };
+      }
+    },
+    "downstream_pod": {
+      groupBy: "targetPod",
+      url: pod => {
+        let downstreamRollupUrl = `${metricsUrl}&aggregation=target_pod&source_pod=${pod}`;
+        let downstreamTimeseriesUrl = `${downstreamRollupUrl}&timeseries=true`;
+
+        return {
+          ts: downstreamTimeseriesUrl,
+          rollup: downstreamRollupUrl
+        };
+      }
+    }
+  };
+};

--- a/web/app/js/components/util/ApiHelpers.js
+++ b/web/app/js/components/util/ApiHelpers.js
@@ -24,9 +24,10 @@ export const ApiHelpers = pathPrefix => {
   };
 };
 
-export const timeseriesUrls = (pathPrefix, metricsWindow) => {
+export const urlsForResource = (pathPrefix, metricsWindow) => {
   /*
     Timeseries fetches used in the TabbedMetricsTable
+    Rollup fetches used throughout app
   */
   let metricsUrl = `${pathPrefix}/api/metrics?window=${metricsWindow}`;
 

--- a/web/app/js/components/util/ApiHelpers.js
+++ b/web/app/js/components/util/ApiHelpers.js
@@ -32,13 +32,14 @@ export const urlsForResource = (pathPrefix, metricsWindow) => {
   let metricsUrl = `${pathPrefix}/api/metrics?window=${metricsWindow}`;
 
   return {
-    // all deploys
+    // all deploys (default), or a given deploy if specified
     "deployment": {
       groupBy: "targetDeploy",
-      url: () => {
-        let timeseriesPath = `${metricsUrl}&timeseries=true`;
+      url: (deploy = null) => {
+        let timeseriesUrl = !deploy ? `${metricsUrl}&timeseries=true` :
+          `${metricsUrl}&timeseries=true&target_deploy=${deploy}`;
         return {
-          ts: timeseriesPath,
+          ts: timeseriesUrl,
           rollup: metricsUrl
         };
       }


### PR DESCRIPTION
All of the parent components in charge of fetching timeseries data
don't actually use them, but pass them to this table. It would simplify
a lot of the parent components if the table handled the ts fetching instead.

This also reduces the number of api calls that we make on pageload in the Deployment Detail and Pod Detail components.