### PR TITLE
first iteration of status subcommand: check Kubectl #92

### DIFF
--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -27,7 +27,7 @@ problems were found.`,
 		kubectl, err := k8s.MakeKubectl(shell.MakeUnixShell())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-			return statusCheckResultWasError(os.Stdout, err)
+			return statusCheckResultWasError(os.Stdout)
 		}
 
 		return checkStatus(os.Stdout, kubectl)
@@ -60,32 +60,29 @@ func checkStatus(w io.Writer, kubectl k8s.Kubectl) error {
 	var errBasedOnOverallStatus error
 	switch check.OverallStatus {
 	case healthcheck.CheckOk:
-		errBasedOnOverallStatus = statusCheckResultWasOk(w, errBasedOnOverallStatus)
+		errBasedOnOverallStatus = statusCheckResultWasOk(w)
 	case healthcheck.CheckFailed:
-		errBasedOnOverallStatus = statusCheckResultWasFail(w, errBasedOnOverallStatus)
+		errBasedOnOverallStatus = statusCheckResultWasFail(w)
 	case healthcheck.CheckError:
-		errBasedOnOverallStatus = statusCheckResultWasError(w, errBasedOnOverallStatus)
+		errBasedOnOverallStatus = statusCheckResultWasError(w)
 	}
 
 	return errBasedOnOverallStatus
 }
 
-func statusCheckResultWasOk(w io.Writer, errBasedOnOverallStatus error) error {
+func statusCheckResultWasOk(w io.Writer) error {
 	fmt.Fprintln(w, "Status check results are [ok]")
-	errBasedOnOverallStatus = nil
-	return errBasedOnOverallStatus
+	return nil
 }
 
-func statusCheckResultWasFail(w io.Writer, errBasedOnOverallStatus error) error {
+func statusCheckResultWasFail(w io.Writer) error {
 	fmt.Fprintln(w, "Status check results are [FAIL]")
-	errBasedOnOverallStatus = errors.New("Failed status check")
-	return errBasedOnOverallStatus
+	return errors.New("failed status check")
 }
 
-func statusCheckResultWasError(w io.Writer, errBasedOnOverallStatus error) error {
+func statusCheckResultWasError(w io.Writer) error {
 	fmt.Fprintln(w, "Status check results are [ERROR]")
-	errBasedOnOverallStatus = errors.New("Error during status check")
-	return errBasedOnOverallStatus
+	return errors.New("error during status check")
 }
 
 func init() {

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -57,6 +57,8 @@ func checkStatus(w io.Writer, kubectl k8s.Kubectl) error {
 	checker.Add(kubectl)
 	check := checker.PerformCheck(prettyPrintResults)
 
+	fmt.Fprintln(w, "")
+
 	var errBasedOnOverallStatus error
 	switch check.OverallStatus {
 	case healthcheck.CheckOk:

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/runconduit/conduit/cli/k8s"
 	"github.com/runconduit/conduit/cli/shell"
-	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/spf13/cobra"
 )
 
@@ -25,29 +24,17 @@ problems were found.`,
 	Args: cobra.NoArgs,
 	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
 
-		kubeApi, err := k8s.MakeK8sAPi(shell.MakeUnixShell(), kubeconfigPath, apiAddr)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-			return statusCheckResultWasError(os.Stdout, err)
-		}
-
-		client, err := newApiClient(kubeApi)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-			return statusCheckResultWasError(os.Stdout, err)
-		}
-
 		kubectl, err := k8s.MakeKubectl(shell.MakeUnixShell())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 			return statusCheckResultWasError(os.Stdout, err)
 		}
 
-		return checkStatus(os.Stdout, kubeApi, client, kubectl)
+		return checkStatus(os.Stdout, kubectl)
 	}),
 }
 
-func checkStatus(w io.Writer, api k8s.KubernetesApi, client pb.ApiClient, kubectl k8s.Kubectl) error {
+func checkStatus(w io.Writer, kubectl k8s.Kubectl) error {
 	prettyPrintResults := func(result healthcheck.CheckResult) {
 		checkLabel := fmt.Sprintf("%s: %s", result.SubsystemName, result.CheckDescription)
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/runconduit/conduit/cli/k8s"
+	"github.com/runconduit/conduit/cli/shell"
+	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check your Conduit installation for potential problems.",
+	Long: `Check your Conduit installation for potential problems. The status command will perform various checks of your
+local system, the Conduit control plane, and connectivity between those. The process will exit with non-zero status if
+problems were found.`,
+	Args: cobra.NoArgs,
+	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
+
+		kubeApi, err := k8s.MakeK8sAPi(shell.MakeUnixShell(), kubeconfigPath, apiAddr)
+		if err != nil {
+			return err
+		}
+
+		client, err := newApiClient(kubeApi)
+		if err != nil {
+			return err
+		}
+
+		kubectl, err := k8s.MakeKubectl(shell.MakeUnixShell())
+		if err != nil {
+			log.Fatalf("Failed to start kubectl: %v", err)
+		}
+
+		return checkStatus(os.Stdout, kubeApi, client, kubectl)
+	}),
+}
+
+func checkStatus(w io.Writer, api k8s.KubernetesApi, client pb.ApiClient, kubectl k8s.Kubectl) error {
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(statusCmd)
+	addControlPlaneNetworkingArgs(statusCmd)
+}

--- a/cli/cmd/status_test.go
+++ b/cli/cmd/status_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/url"
+	"testing"
+
+	"github.com/runconduit/conduit/cli/k8s"
+
+	"github.com/runconduit/conduit/cli/healthcheck"
+)
+
+type mockKubectl struct {
+	resultsToReturn []healthcheck.CheckResult
+	errToReturn     error
+}
+
+func (m *mockKubectl) Version() ([3]int, error) { return [3]int{}, nil }
+func (m *mockKubectl) StartProxy(potentialErrorWhenStartingProxy chan error, port int) error {
+	return nil
+}
+func (m *mockKubectl) UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
+	return nil, nil
+}
+func (m *mockKubectl) ProxyPort() int { return -666 }
+func (m *mockKubectl) SelfCheck() ([]healthcheck.CheckResult, error) {
+	return m.resultsToReturn, m.errToReturn
+}
+
+func TestCheckStatus(t *testing.T) {
+	t.Run("Prints expected output", func(t *testing.T) {
+		kubectl := &mockKubectl{}
+		kubectl.resultsToReturn = []healthcheck.CheckResult{
+			{SubsystemName: k8s.KubectlSubsystemName,
+				CheckDescription: k8s.KubectlConnectivityCheckDescription,
+				Status:           healthcheck.CheckOk,
+				NextSteps:        "This shouldnt be printed",
+			},
+			{SubsystemName: k8s.KubectlSubsystemName,
+				CheckDescription: k8s.KubectlIsInstalledCheckDescription,
+				Status:           healthcheck.CheckFailed,
+				NextSteps:        "This should contain instructions for fail",
+			},
+			{SubsystemName: k8s.KubectlSubsystemName,
+				CheckDescription: k8s.KubectlVersionCheckDescription,
+				Status:           healthcheck.CheckError,
+				NextSteps:        "This should contain instructions for err",
+			},
+		}
+
+		output := bytes.NewBufferString("")
+		checkStatus(output, nil, nil, kubectl)
+
+		goldenFileBytes, err := ioutil.ReadFile("testdata/status_busy_output.golden")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		expectedContent := string(goldenFileBytes)
+
+		if expectedContent != output.String() {
+			t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
+		}
+	})
+}

--- a/cli/cmd/status_test.go
+++ b/cli/cmd/status_test.go
@@ -50,7 +50,7 @@ func TestCheckStatus(t *testing.T) {
 		}
 
 		output := bytes.NewBufferString("")
-		checkStatus(output, nil, nil, kubectl)
+		checkStatus(output, kubectl)
 
 		goldenFileBytes, err := ioutil.ReadFile("testdata/status_busy_output.golden")
 		if err != nil {

--- a/cli/cmd/testdata/status_busy_output.golden
+++ b/cli/cmd/testdata/status_busy_output.golden
@@ -1,0 +1,4 @@
+kubectl: can talk to Kubernetes cluster.............[ok]
+kubectl: is in $PATH................................[FAIL]  -- This should contain instructions for fail
+kubectl: has compatible version.....................[ERROR] -- This should contain instructions for err
+Status check results are [ERROR]

--- a/cli/cmd/testdata/status_busy_output.golden
+++ b/cli/cmd/testdata/status_busy_output.golden
@@ -1,4 +1,5 @@
 kubectl: can talk to Kubernetes cluster.............[ok]
 kubectl: is in $PATH................................[FAIL]  -- This should contain instructions for fail
 kubectl: has compatible version.....................[ERROR] -- This should contain instructions for err
+
 Status check results are [ERROR]

--- a/cli/healthcheck/healthcheck.go
+++ b/cli/healthcheck/healthcheck.go
@@ -48,6 +48,7 @@ func (hC *HealthChecker) PerformCheck(observer CheckObserver) Check {
 		results, err := checker.SelfCheck()
 		if err != nil {
 			check.OverallStatus = CheckError
+			continue
 		}
 		for _, singleResult := range results {
 			check.Results = append(check.Results, singleResult)

--- a/cli/healthcheck/healthcheck.go
+++ b/cli/healthcheck/healthcheck.go
@@ -1,5 +1,7 @@
 package healthcheck
 
+import log "github.com/sirupsen/logrus"
+
 type CheckStatus string
 
 const (
@@ -47,6 +49,7 @@ func (hC *HealthChecker) PerformCheck(observer CheckObserver) Check {
 	for _, checker := range hC.subsystemsToCheck {
 		results, err := checker.SelfCheck()
 		if err != nil {
+			log.Errorf("Error checking [%s]: %s", checker, err)
 			check.OverallStatus = CheckError
 			continue
 		}

--- a/cli/healthcheck/healthcheck.go
+++ b/cli/healthcheck/healthcheck.go
@@ -1,0 +1,63 @@
+package healthcheck
+
+type CheckStatus string
+
+const (
+	CheckOk     = CheckStatus("OK")
+	CheckFailed = CheckStatus("FAIL")
+	CheckError  = CheckStatus("ERROR")
+)
+
+type CheckResult struct {
+	ComponentName    string
+	checkDescription string
+	status           CheckStatus
+}
+
+type Check struct {
+	Results       []CheckResult
+	OverallStatus CheckStatus
+}
+
+type StatusChecker interface {
+	SelfCheck() ([]CheckResult, error)
+}
+
+type HealthChecker struct {
+	subsystemsToCheck []StatusChecker
+}
+
+func (hC *HealthChecker) Add(subsystemChecker StatusChecker) {
+	hC.subsystemsToCheck = append(hC.subsystemsToCheck, subsystemChecker)
+}
+
+func (hC *HealthChecker) PerformCheck() Check {
+	check := Check{
+		Results:       make([]CheckResult, 0),
+		OverallStatus: CheckOk,
+	}
+
+	for _, checker := range hC.subsystemsToCheck {
+		results, err := checker.SelfCheck()
+		if err != nil {
+			check.OverallStatus = CheckError
+		}
+		for _, r := range results {
+			check.Results = append(check.Results, r)
+			checkResultContainsError := r.status == CheckError
+			shouldOverriveStatus := r.status == CheckFailed && check.OverallStatus == CheckOk
+
+			if checkResultContainsError || shouldOverriveStatus {
+				check.OverallStatus = r.status
+			}
+		}
+
+	}
+	return check
+}
+
+func MakeHealthChecker() *HealthChecker {
+	return &HealthChecker{
+		subsystemsToCheck: make([]StatusChecker, 0),
+	}
+}

--- a/cli/healthcheck/healthcheck_test.go
+++ b/cli/healthcheck/healthcheck_test.go
@@ -1,0 +1,118 @@
+package healthcheck
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type mockSubsystem struct {
+	checksToReturn []CheckResult
+	errToReturn    error
+}
+
+func (m *mockSubsystem) SelfCheck() ([]CheckResult, error) {
+	return m.checksToReturn, m.errToReturn
+}
+
+func TestSelfChecker(t *testing.T) {
+	workingSubsystem1 := &mockSubsystem{
+		checksToReturn: []CheckResult{
+			{ComponentName: "w1", checkDescription: "w1a", status: CheckOk},
+			{ComponentName: "w1", checkDescription: "w1b", status: CheckOk},
+		},
+	}
+	workingSubsystem2 := &mockSubsystem{
+		checksToReturn: []CheckResult{
+			{ComponentName: "w2", checkDescription: "w2a", status: CheckOk},
+			{ComponentName: "w2", checkDescription: "w2b", status: CheckOk},
+		},
+	}
+
+	failingSubsystem1 := &mockSubsystem{
+		checksToReturn: []CheckResult{
+			{ComponentName: "f1", checkDescription: "fa", status: CheckOk},
+			{ComponentName: "f1", checkDescription: "fb", status: CheckFailed},
+		},
+	}
+
+	erroingSubsystem1 := &mockSubsystem{
+		errToReturn: errors.New("Expected"),
+	}
+
+	t.Run("Returns all checks by subsystems", func(t *testing.T) {
+		healthChecker := MakeHealthChecker()
+
+		healthChecker.Add(workingSubsystem1)
+		healthChecker.Add(workingSubsystem2)
+		healthChecker.Add(failingSubsystem1)
+
+		results := healthChecker.PerformCheck()
+
+		allExpectedResults := make([]CheckResult, 0)
+		allExpectedResults = append(allExpectedResults, workingSubsystem1.checksToReturn...)
+		allExpectedResults = append(allExpectedResults, workingSubsystem2.checksToReturn...)
+		allExpectedResults = append(allExpectedResults, failingSubsystem1.checksToReturn...)
+
+		expectedLength := len(allExpectedResults)
+		actualLength := len(results.Results)
+
+		if actualLength != expectedLength {
+			t.Fatalf("Expecting check results to contain [%d] results, got [%d]", expectedLength, actualLength)
+		}
+
+		actualChecksSet := make(map[CheckResult]bool)
+		for _, result := range results.Results {
+			actualChecksSet[result] = true
+		}
+
+		for _, expected := range allExpectedResults {
+			if !actualChecksSet[expected] {
+				t.Fatalf("Expected results to contain [%v], but was: %v", expected,
+					reflect.ValueOf(actualChecksSet).MapKeys())
+			}
+		}
+	})
+
+	t.Run("Is successful if all checks were succesful", func(t *testing.T) {
+		healthChecker := MakeHealthChecker()
+
+		healthChecker.Add(workingSubsystem1)
+		healthChecker.Add(workingSubsystem2)
+
+		results := healthChecker.PerformCheck()
+
+		if results.OverallStatus != CheckOk {
+			t.Fatalf("Expecting check to be successful, but got [%v]", results)
+		}
+	})
+
+	t.Run("Is failure if even a single test failed", func(t *testing.T) {
+		healthChecker := MakeHealthChecker()
+
+		healthChecker.Add(workingSubsystem1)
+		healthChecker.Add(failingSubsystem1)
+		healthChecker.Add(workingSubsystem2)
+
+		results := healthChecker.PerformCheck()
+
+		if results.OverallStatus != CheckFailed {
+			t.Fatalf("Expecting check to be error, but got [%v]", results)
+		}
+	})
+
+	t.Run("Is in error if even a single test returned error", func(t *testing.T) {
+		healthChecker := MakeHealthChecker()
+
+		healthChecker.Add(workingSubsystem1)
+		healthChecker.Add(failingSubsystem1)
+		healthChecker.Add(workingSubsystem2)
+		healthChecker.Add(erroingSubsystem1)
+
+		results := healthChecker.PerformCheck()
+
+		if results.OverallStatus != CheckError {
+			t.Fatalf("Expecting check to be error, but got [%v]", results)
+		}
+	})
+}

--- a/cli/k8s/kubectl.go
+++ b/cli/k8s/kubectl.go
@@ -155,7 +155,7 @@ func (kctl *kubectl) SelfCheck() ([]healthcheck.CheckResult, error) {
 	output, err := kctl.sh.CombinedOutput("kubectl", "get", "pods")
 	if err != nil {
 		kubectlApiAccessCheck.Status = healthcheck.CheckFailed
-		kubectlApiAccessCheck.NextSteps = fmt.Sprintf("kubectl cannot reach the Kubernetes cluster. The error message is: %s", output)
+		kubectlApiAccessCheck.NextSteps = output
 	} else {
 		kubectlApiAccessCheck.Status = healthcheck.CheckOk
 	}

--- a/cli/k8s/kubectl.go
+++ b/cli/k8s/kubectl.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/runconduit/conduit/cli/healthcheck"
+
 	"github.com/runconduit/conduit/cli/shell"
 )
 
@@ -16,6 +18,7 @@ type Kubectl interface {
 	StartProxy(potentialErrorWhenStartingProxy chan error, port int) error
 	UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error)
 	ProxyPort() int
+	SelfCheck() ([]healthcheck.CheckResult, error)
 }
 
 type kubectl struct {
@@ -24,11 +27,15 @@ type kubectl struct {
 }
 
 const (
-	KubernetesDeployments   = "deployments"
-	KubernetesPods          = "pods"
-	kubectlDefaultProxyPort = 8001
-	kubectlDefaultTimeout   = 10 * time.Second
-	portWhenProxyNotRunning = -1
+	KubernetesDeployments               = "deployments"
+	KubernetesPods                      = "pods"
+	kubectlDefaultProxyPort             = 8001
+	kubectlDefaultTimeout               = 10 * time.Second
+	portWhenProxyNotRunning             = -1
+	KubectlSubsystemName                = "kubectl"
+	KubectlIsInstalledCheckDescription  = "is in $PATH"
+	KubectlVersionCheckDescription      = "has compatible version"
+	KubectlConnectivityCheckDescription = "can talk to Kubernetes cluster"
 	//As per https://github.com/kubernetes/kubernetes/commit/0daee3ad2238de7bb356d1b4368b0733a3497a3a#diff-595bfea7ed0dd0171e1f339a1f8bfcb6R155
 	magicCharacterThatIndicatesProxyIsRunning = '\n'
 )
@@ -52,7 +59,7 @@ func (kctl *kubectl) Version() ([3]int, error) {
 	bytes, err := kctl.sh.CombinedOutput("kubectl", "version", "--client", "--short")
 	versionString := string(bytes)
 	if err != nil {
-		return version, fmt.Errorf("Error running kubectl Version. Output: %s Error: %v", versionString, err)
+		return version, fmt.Errorf("error running kubectl Version. Output: %s Error: %v", versionString, err)
 	}
 
 	justTheVersionString := strings.TrimPrefix(versionString, "Client Version: v")
@@ -60,13 +67,13 @@ func (kctl *kubectl) Version() ([3]int, error) {
 	split := strings.Split(justTheMajorMinorRevisionNumbers, ".")
 
 	if len(split) < 3 {
-		return version, fmt.Errorf("Unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split)
+		return version, fmt.Errorf("unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split)
 	}
 
 	for i, segment := range split {
 		v, err := strconv.Atoi(strings.TrimSpace(segment))
 		if err != nil {
-			return version, fmt.Errorf("Unknown Version string format from Kubectl: [%s], not an integer: [%s]", versionString, segment)
+			return version, fmt.Errorf("unknown Version string format from Kubectl: [%s], not an integer: [%s]", versionString, segment)
 		}
 		version[i] = v
 	}
@@ -78,7 +85,7 @@ func (kctl *kubectl) StartProxy(potentialErrorWhenStartingProxy chan error, port
 	fmt.Printf("Running `kubectl proxy -p %d`\n", port)
 
 	if kctl.ProxyPort() != portWhenProxyNotRunning {
-		return fmt.Errorf("Kubectl proxy already running on port [%d]", kctl.ProxyPort)
+		return fmt.Errorf("kubectl proxy already running on port [%d]", kctl.ProxyPort)
 	}
 
 	output, err := kctl.sh.AsyncStdout(potentialErrorWhenStartingProxy, "kubectl", "proxy", "-p", strconv.Itoa(port))
@@ -87,7 +94,7 @@ func (kctl *kubectl) StartProxy(potentialErrorWhenStartingProxy chan error, port
 
 	fmt.Println(kubectlOutput)
 	if err != nil {
-		return fmt.Errorf("Error waiting for kubectl to start the proxy. kubectl returned [%s], error: %v", kubectlOutput, err)
+		return fmt.Errorf("error waiting for kubectl to start the proxy. kubectl returned [%s], error: %v", kubectlOutput, err)
 	}
 
 	kctl.proxyPort = kubectlDefaultProxyPort
@@ -102,6 +109,59 @@ func (kctl *kubectl) UrlFor(namespace string, extraPathStartingWithSlash string)
 	schemeHostAndPort := fmt.Sprintf("%s://%s:%d", kctl.ProxyScheme(), kctl.ProxyHost(), kctl.ProxyPort())
 
 	return generateKubernetesApiBaseUrlFor(schemeHostAndPort, namespace, extraPathStartingWithSlash)
+}
+
+func (kctl *kubectl) SelfCheck() ([]healthcheck.CheckResult, error) {
+	results := make([]healthcheck.CheckResult, 0)
+
+	kubectlOnPathCheck := healthcheck.CheckResult{
+		SubsystemName:    KubectlSubsystemName,
+		CheckDescription: KubectlIsInstalledCheckDescription,
+	}
+	_, err := kctl.sh.CombinedOutput("kubectl", "config")
+	if err != nil {
+		kubectlOnPathCheck.Status = healthcheck.CheckFailed
+		kubectlOnPathCheck.NextSteps = fmt.Sprintf("Could not run the command `kubectl`. The error message is: [%s] and the current $PATH is: %s", err.Error(), kctl.sh.Path())
+	} else {
+		kubectlOnPathCheck.Status = healthcheck.CheckOk
+	}
+	results = append(results, kubectlOnPathCheck)
+
+	kubectlVersionCheck := healthcheck.CheckResult{
+		SubsystemName:    KubectlSubsystemName,
+		CheckDescription: KubectlVersionCheckDescription,
+	}
+
+	actualVersion, err := kctl.Version()
+	if err != nil {
+		kubectlVersionCheck.Status = healthcheck.CheckError
+		kubectlVersionCheck.NextSteps = fmt.Sprintf("Error getting version from kubectl. The error message is: [%s].", err.Error())
+	} else {
+		if isCompatibleVersion(minimumKubectlVersionExpected, actualVersion) {
+			kubectlVersionCheck.Status = healthcheck.CheckOk
+		} else {
+			kubectlVersionCheck.Status = healthcheck.CheckFailed
+			kubectlVersionCheck.NextSteps = fmt.Sprintf("Kubectl is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required.",
+				actualVersion[0], actualVersion[1], actualVersion[2],
+				minimumKubectlVersionExpected[0], minimumKubectlVersionExpected[1], minimumKubectlVersionExpected[2])
+		}
+	}
+	results = append(results, kubectlVersionCheck)
+
+	kubectlApiAccessCheck := healthcheck.CheckResult{
+		SubsystemName:    KubectlSubsystemName,
+		CheckDescription: KubectlConnectivityCheckDescription,
+	}
+	output, err := kctl.sh.CombinedOutput("kubectl", "get", "pods")
+	if err != nil {
+		kubectlApiAccessCheck.Status = healthcheck.CheckFailed
+		kubectlApiAccessCheck.NextSteps = fmt.Sprintf("kubectl cannot reach the Kubernetes cluster. The error message is: %s", output)
+	} else {
+		kubectlApiAccessCheck.Status = healthcheck.CheckOk
+	}
+	results = append(results, kubectlApiAccessCheck)
+
+	return results, nil
 }
 
 func isCompatibleVersion(minimalRequirementVersion [3]int, actualVersion [3]int) bool {
@@ -148,7 +208,7 @@ func MakeKubectl(shell shell.Shell) (Kubectl, error) {
 
 	if !isCompatibleVersion(minimumKubectlVersionExpected, actualVersion) {
 		return nil, fmt.Errorf(
-			"Kubectl is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required",
+			"kubectl is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required",
 			actualVersion[0], actualVersion[1], actualVersion[2],
 			minimumKubectlVersionExpected[0], minimumKubectlVersionExpected[1], minimumKubectlVersionExpected[2])
 	}

--- a/cli/k8s/testdata/kubectl_cluster-info.output
+++ b/cli/k8s/testdata/kubectl_cluster-info.output
@@ -1,0 +1,3 @@
+Kubernetes master is running at https://192.168.99.10:8443
+
+To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

--- a/cli/k8s/testdata/kubectl_config.output
+++ b/cli/k8s/testdata/kubectl_config.output
@@ -1,0 +1,32 @@
+Modify kubeconfig files using subcommands like "kubectl config set current-context my-context"
+
+The loading order follows these rules:
+
+  1. If the --kubeconfig flag is set, then only that file is loaded.  The flag may only be set once and no merging takes
+place.
+  2. If $KUBECONFIG environment variable is set, then it is used a list of paths (normal path delimitting rules for your
+system).  These paths are merged.  When a value is modified, it is modified in the file that defines the stanza.  When a
+value is created, it is created in the first file that exists.  If no files in the chain exist, then it creates the last
+file in the list.
+  3. Otherwise, ${HOME}/.kube/config is used and no merging takes place.
+
+Available Commands:
+  current-context Displays the current-context
+  delete-cluster  Delete the specified cluster from the kubeconfig
+  delete-context  Delete the specified context from the kubeconfig
+  get-clusters    Display clusters defined in the kubeconfig
+  get-contexts    Describe one or many contexts
+  rename-context  Renames a context from the kubeconfig file.
+  set             Sets an individual value in a kubeconfig file
+  set-cluster     Sets a cluster entry in kubeconfig
+  set-context     Sets a context entry in kubeconfig
+  set-credentials Sets a user entry in kubeconfig
+  unset           Unsets an individual value in a kubeconfig file
+  use-context     Sets the current-context in a kubeconfig file
+  view            Display merged kubeconfig settings or a specified kubeconfig file
+
+Usage:
+  kubectl config SUBCOMMAND [options]
+
+Use "kubectl <command> --help" for more information about a given command.
+Use "kubectl options" for a list of global command-line options (applies to all commands).

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -16,6 +16,7 @@ type Shell interface {
 	AsyncStdout(potentialErrorFromAsyncProcess chan error, name string, arg ...string) (*bufio.Reader, error)
 	WaitForCharacter(charToWaitFor byte, output *bufio.Reader, timeout time.Duration) (string, error)
 	HomeDir() string
+	Path() string
 }
 
 type unixShell struct{}
@@ -80,6 +81,16 @@ func (sh *unixShell) HomeDir() string {
 		homeEnvVar = "HOME"
 	}
 	return os.Getenv(homeEnvVar)
+}
+
+func (sh *unixShell) Path() string {
+	var pathEnvVar string
+	if runtime.GOOS == "windows" {
+		pathEnvVar = "Path"
+	} else {
+		pathEnvVar = "PATH"
+	}
+	return os.Getenv(pathEnvVar)
 }
 
 func MakeUnixShell() Shell {


### PR DESCRIPTION
(I'm breaking this feature down in several PRs)

As per #92, this adds a `status` subcommand and checks for the current status ok Kubectl.

Here's a sample of the output:
```
$ conduit status
kubectl: is in $PATH................................[ok]
kubectl: has compatible version.....................[ok]
kubectl: can talk to Kubernetes cluster.............[FAIL]  -- Unable to connect to the server: dial tcp 192.168.99.100:8443: i/o timeout

Status check results are [FAIL]
```