### PR TITLE
Add shell completion command to cli

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var example = `  # bash <= 3.2
+  source /dev/stdin <<< "$(conduit completion bash)"
+
+  # bash >= 4.0
+  source <(conduit completion bash)
+
+  # bash <= 3.2 on osx
+  brew install bash-completion # ensure you have bash-completion 1.3+
+  conduit completion bash > $(brew --prefix)/etc/bash_completion.d/conduit
+
+  # bash >= 4.0 on osx
+  brew install bash-completion@2
+  conduit completion bash > $(brew --prefix)/etc/bash_completion.d/conduit
+
+  # zsh
+  source <(conduit completion zsh)
+
+  # zsh on osx / oh-my-zsh
+  conduit completion zsh > "${fpath[1]}/_conduit"`
+
+var completionCmd = &cobra.Command{
+	Use:       "completion [bash|zsh]",
+	Short:     "Shell completion",
+	Long:      "Output completion code for the specified shell (bash or zsh).",
+	Example:   example,
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"bash", "zsh"},
+	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
+
+		out, err := getCompletion(args[0])
+		if err != nil {
+			log.Fatal(err.Error())
+		} else {
+			fmt.Printf(out)
+		}
+
+		return err
+	}),
+}
+
+func init() {
+	RootCmd.AddCommand(completionCmd)
+}
+
+func getCompletion(sh string) (string, error) {
+	var err error
+	var buf bytes.Buffer
+
+	switch sh {
+	case "bash":
+		err = RootCmd.GenBashCompletion(&buf)
+	case "zsh":
+		err = RootCmd.GenZshCompletion(&buf)
+	default:
+		err = errors.New("unsupported shell type (must be bash or zsh): " + sh)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/cli/cmd/completion_test.go
+++ b/cli/cmd/completion_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompletion(t *testing.T) {
+	t.Run("Returns completion code", func(t *testing.T) {
+
+		bash, err := getCompletion("bash")
+		if err != nil {
+			t.Fatalf("Unexpected error: %+v", err)
+		}
+
+		zsh, err := getCompletion("zsh")
+		if err != nil {
+			t.Fatalf("Unexpected error: %+v", err)
+		}
+
+		if !strings.Contains(bash, "# bash completion for conduit") {
+			t.Fatalf("Unexpected bash output: %+v", bash)
+		}
+
+		if !strings.Contains(zsh, "#compdef conduit") {
+			t.Fatalf("Unexpected zsh output: %+v", zsh)
+		}
+	})
+
+	t.Run("Fails with invalid shell type", func(t *testing.T) {
+		out, err := getCompletion("foo")
+		if err == nil {
+			t.Fatalf("Unexpected success for invalid shell type: %+v", out)
+		}
+	})
+}


### PR DESCRIPTION
Cobra supports bash and zsh completion code generation, but our cli
project was not leveraging it.

Add a 'completion' command to the conduit cli, which outputs bash and
zsh completion code.

Signed-off-by: Andrew Seigner <andrew@sig.gy>

Note that the completion code can be further customized and embellished using Cobra annotations, but this PR gets us started.

Example usage:

```bash
$ source <(conduit completion bash)

$ conduit [tab][tab]
completion  dashboard   get         inject      install     stat        tap         version

$ conduit completion [tab][tab]
bash  zsh

$ conduit inject -[tab][tab]
--api-port=             --conduit-version=      --image-pull-policy=    --init-image=           --proxy-image=          --skip-inbound-ports=   -n
--conduit-namespace=    --control-port=         --inbound-port=         --outbound-port=        --proxy-uid=            --skip-outbound-ports=  -v

$ conduit install -[tab][tab]
--conduit-namespace=    --controller-replicas=  --image-pull-policy=    --prometheus-replicas=  --registry=             --version=              --web-replicas=         -n                      -r                      -v
```