### PR TITLE
Remove `AsciiExt` import

### DIFF
--- a/proxy/src/fully_qualified_authority.rs
+++ b/proxy/src/fully_qualified_authority.rs
@@ -1,6 +1,5 @@
 use bytes::BytesMut;
 
-use std::ascii::AsciiExt;
 use std::net::IpAddr;
 use std::str::FromStr;
 


### PR DESCRIPTION
Since the methods on this trait were moved to direct implementations on the 
implementing types, this produces an unused import warning with the latest
(1.23) Rust standard library. As we set `deny(warnings)`, this breaks the build.

Note that this pins Conduit to requiring Rust 1.23 or later. We could alternatively
add an `#[allow(unused_imports)]` on this import to preserve compatibility with
pre-1.23 Rust.