### PR TITLE
Require Rust 1.23 in proxy Dockerfile-deps

### DIFF
--- a/proxy/Dockerfile-deps
+++ b/proxy/Dockerfile-deps
@@ -1,4 +1,4 @@
-FROM rust:1.21.0
+FROM rust:1.23.0
 WORKDIR /usr/src/conduit
 COPY codegen ./codegen
 COPY futures-mpsc-lossy ./futures-mpsc-lossy


### PR DESCRIPTION
After merging #104, Conduit will not build against pre-1.23 Rust versions. This PR updates the Dockerfile to require this version.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>