### PR TITLE
second iteration of status subcommand: check Kubernetes API #92

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -23,7 +23,7 @@ var dashboardCmd = &cobra.Command{
 			log.Fatalf("port must be positive, was %d", proxyPort)
 		}
 
-		kubectl, err := k8s.MakeKubectl(shell.NewUnixShell())
+		kubectl, err := k8s.NewKubectl(shell.NewUnixShell())
 		if err != nil {
 			log.Fatalf("Failed to start kubectl: %v", err)
 		}

--- a/cli/cmd/status_test.go
+++ b/cli/cmd/status_test.go
@@ -3,53 +3,54 @@ package cmd
 import (
 	"bytes"
 	"io/ioutil"
-	"net/url"
 	"testing"
 
 	"github.com/runconduit/conduit/pkg/healthcheck"
 	"github.com/runconduit/conduit/pkg/k8s"
 )
 
-type mockKubectl struct {
-	resultsToReturn []healthcheck.CheckResult
-	errToReturn     error
-}
-
-func (m *mockKubectl) Version() ([3]int, error) { return [3]int{}, nil }
-func (m *mockKubectl) StartProxy(potentialErrorWhenStartingProxy chan error, port int) error {
-	return nil
-}
-func (m *mockKubectl) UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
-	return nil, nil
-}
-func (m *mockKubectl) ProxyPort() int { return -666 }
-func (m *mockKubectl) SelfCheck() ([]healthcheck.CheckResult, error) {
-	return m.resultsToReturn, m.errToReturn
-}
-
 func TestCheckStatus(t *testing.T) {
 	t.Run("Prints expected output", func(t *testing.T) {
-		kubectl := &mockKubectl{}
-		kubectl.resultsToReturn = []healthcheck.CheckResult{
-			{SubsystemName: k8s.KubectlSubsystemName,
+		kubectl := &k8s.MockKubectl{}
+		kubectl.SelfCheckResultsToReturn = []healthcheck.CheckResult{
+			{
+				SubsystemName:    k8s.KubectlSubsystemName,
 				CheckDescription: k8s.KubectlConnectivityCheckDescription,
 				Status:           healthcheck.CheckOk,
 				NextSteps:        "This shouldnt be printed",
 			},
-			{SubsystemName: k8s.KubectlSubsystemName,
+			{
+				SubsystemName:    k8s.KubectlSubsystemName,
 				CheckDescription: k8s.KubectlIsInstalledCheckDescription,
 				Status:           healthcheck.CheckFailed,
 				NextSteps:        "This should contain instructions for fail",
 			},
-			{SubsystemName: k8s.KubectlSubsystemName,
+			{
+				SubsystemName:    k8s.KubectlSubsystemName,
 				CheckDescription: k8s.KubectlVersionCheckDescription,
 				Status:           healthcheck.CheckError,
 				NextSteps:        "This should contain instructions for err",
 			},
 		}
 
+		kubeApi := &k8s.MockKubeApi{}
+		kubeApi.SelfCheckResultsToReturn = []healthcheck.CheckResult{
+			{
+				SubsystemName:    k8s.KubeapiSubsystemName,
+				CheckDescription: k8s.KubeapiClientCheckDescription,
+				Status:           healthcheck.CheckFailed,
+				NextSteps:        "This should contain instructions for fail",
+			},
+			{
+				SubsystemName:    k8s.KubeapiSubsystemName,
+				CheckDescription: k8s.KubeapiAccessCheckDescription,
+				Status:           healthcheck.CheckOk,
+				NextSteps:        "This shouldnt be printed",
+			},
+		}
+
 		output := bytes.NewBufferString("")
-		checkStatus(output, kubectl)
+		checkStatus(output, kubectl, kubeApi)
 
 		goldenFileBytes, err := ioutil.ReadFile("testdata/status_busy_output.golden")
 		if err != nil {

--- a/cli/cmd/testdata/status_busy_output.golden
+++ b/cli/cmd/testdata/status_busy_output.golden
@@ -1,5 +1,7 @@
 kubectl: can talk to Kubernetes cluster.............[ok]
 kubectl: is in $PATH................................[FAIL]  -- This should contain instructions for fail
 kubectl: has compatible version.....................[ERROR] -- This should contain instructions for err
+kubernetes-api: can initialize the client...........[FAIL]  -- This should contain instructions for fail
+kubernetes-api: can query the Kubernetes API........[ok]
 
 Status check results are [ERROR]

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -15,10 +15,25 @@ func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string,
 		return nil, fmt.Errorf("Path must start with a [/], was [%s]", extraPathStartingWithSlash)
 	}
 
-	urlString := fmt.Sprintf("%s/api/v1/namespaces/%s%s", schemeHostAndPort, namespace, extraPathStartingWithSlash)
+	baseURL, err := generateBaseKubernetesApiUrl(schemeHostAndPort)
+	if err != nil {
+		return nil, err
+	}
+
+	urlString := fmt.Sprintf("%snamespaces/%s%s", baseURL.String(), namespace, extraPathStartingWithSlash)
 	url, err := url.Parse(urlString)
 	if err != nil {
-		return nil, fmt.Errorf("Error generating URL from [%s]", urlString)
+		return nil, fmt.Errorf("error generating namespace URL for Kubernetes API from [%s]", urlString)
+	}
+
+	return url, nil
+}
+
+func generateBaseKubernetesApiUrl(schemeHostAndPort string) (*url.URL, error) {
+	urlString := fmt.Sprintf("%s/api/v1/", schemeHostAndPort)
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, fmt.Errorf("error generating base URL for Kubernetes API from [%s]", urlString)
 	}
 	return url, nil
 }

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -22,11 +22,36 @@ func TestGenerateKubernetesApiBaseUrlFor(t *testing.T) {
 		}
 	})
 
-	t.Run("Return error it extra path doesn't start with slash", func(t *testing.T) {
+	t.Run("Return error if extra path doesn't start with slash", func(t *testing.T) {
 		schemeHostAndPort := "ftp://some-server.example.com:666"
 		namespace := "some-namespace"
 		extraPath := "does-not-start/with/slash"
 		_, err := generateKubernetesApiBaseUrlFor(schemeHostAndPort, namespace, extraPath)
+
+		if err == nil {
+			t.Fatalf("Expected error when tryiong to generate URL with extra path without leading slash, got nothing")
+		}
+	})
+}
+
+func TestGenerateBaseKubernetesApiUrl(t *testing.T) {
+	t.Run("Generates correct URL when all elements are present", func(t *testing.T) {
+		schemeHostAndPort := "gopher://some-server.example.com:661"
+
+		url, err := generateBaseKubernetesApiUrl(schemeHostAndPort)
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+
+		expectedUrlString := "gopher://some-server.example.com:661/api/v1/"
+		if url.String() != expectedUrlString {
+			t.Fatalf("Expected generated URl to be [%s], but got [%s]", expectedUrlString, url.String())
+		}
+	})
+
+	t.Run("Return error if invalid host and port", func(t *testing.T) {
+		schemeHostAndPort := "ftp://some-server.exampl     e.com:666"
+		_, err := generateBaseKubernetesApiUrl(schemeHostAndPort)
 
 		if err == nil {
 			t.Fatalf("Expected error when tryiong to generate URL with extra path without leading slash, got nothing")

--- a/pkg/k8s/kubectl.go
+++ b/pkg/k8s/kubectl.go
@@ -197,7 +197,7 @@ func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error
 	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)
 }
 
-func MakeKubectl(shell shell.Shell) (Kubectl, error) {
+func NewKubectl(shell shell.Shell) (Kubectl, error) {
 
 	kubectl := &kubectl{
 		sh:        shell,

--- a/pkg/k8s/kubectl_test.go
+++ b/pkg/k8s/kubectl_test.go
@@ -24,7 +24,7 @@ func TestKubectlVersion(t *testing.T) {
 		shell := &shell.MockShell{}
 		for k, expectedVersion := range versions {
 			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			kctl, err := MakeKubectl(shell)
+			kctl, err := NewKubectl(shell)
 			shell.OutputToReturn = append(shell.OutputToReturn, k)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -53,7 +53,7 @@ func TestKubectlVersion(t *testing.T) {
 		shell := &shell.MockShell{}
 		for _, expectedVersion := range versions {
 			shell.OutputToReturn = append(shell.OutputToReturn, expectedVersion)
-			_, err := MakeKubectl(shell)
+			_, err := NewKubectl(shell)
 
 			if err == nil {
 				t.Fatalf("Expected error parsing string: %s", expectedVersion)
@@ -67,7 +67,7 @@ func TestKubectlStartProxy(t *testing.T) {
 		shell := &shell.MockShell{}
 		potentialAsyncError := make(chan error, 1)
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		kctl, _ := MakeKubectl(shell)
+		kctl, _ := NewKubectl(shell)
 
 		shell.OutputToReturn = append(shell.OutputToReturn, fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning))
 		err := kctl.StartProxy(potentialAsyncError, kubectlDefaultProxyPort)
@@ -89,7 +89,7 @@ func TestKubectlStartProxy(t *testing.T) {
 		shell := &shell.MockShell{}
 		potentialAsyncError := make(chan error, 1)
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		kctl, _ := MakeKubectl(shell)
+		kctl, _ := NewKubectl(shell)
 
 		shell.OutputToReturn = append(shell.OutputToReturn, fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning))
 		err := kctl.StartProxy(potentialAsyncError, kubectlDefaultProxyPort)
@@ -113,7 +113,7 @@ func TestKubectlStartProxy(t *testing.T) {
 		shell := &shell.MockShell{}
 		potentialAsyncError := make(chan error, 1)
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		kctl, err := MakeKubectl(shell)
+		kctl, err := NewKubectl(shell)
 
 		if err != nil {
 			t.Fatalf("Unexpected error starting proxy: %v", err)
@@ -131,7 +131,7 @@ func TestKubectlStartProxy(t *testing.T) {
 		shell := &shell.MockShell{}
 		potentialAsyncError := make(chan error, 1)
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		kctl, _ := MakeKubectl(shell)
+		kctl, _ := NewKubectl(shell)
 
 		shell.OutputToReturn = append(shell.OutputToReturn, "ANY STRING THAT DOEST CONTAIN THE MAGIC CHARACTER WE ARE LOOKING FOR")
 		err := kctl.StartProxy(potentialAsyncError, kubectlDefaultProxyPort)
@@ -147,7 +147,7 @@ func TestUrlFor(t *testing.T) {
 		shell := &shell.MockShell{}
 		potentialAsyncError := make(chan error, 1)
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		kctl, _ := MakeKubectl(shell)
+		kctl, _ := NewKubectl(shell)
 
 		shell.OutputToReturn = append(shell.OutputToReturn, fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning))
 		err := kctl.StartProxy(potentialAsyncError, kubectlDefaultProxyPort)
@@ -172,7 +172,7 @@ func TestUrlFor(t *testing.T) {
 	t.Run("Returns error if proxy isn't running", func(t *testing.T) {
 		shell := &shell.MockShell{}
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		kctl, _ := MakeKubectl(shell)
+		kctl, _ := NewKubectl(shell)
 
 		shell.OutputToReturn = append(shell.OutputToReturn, fmt.Sprintf("Starting to serve on 127.0.0.1:8001%c", magicCharacterThatIndicatesProxyIsRunning))
 		_, err := kctl.UrlFor("someNamespace", "/somePath")
@@ -221,7 +221,7 @@ func TestKubectlSelfCheck(t *testing.T) {
 		shell := &shell.MockShell{}
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
 		var kubectlAsStatusChecker healthcheck.StatusChecker
-		kubectlAsStatusChecker, _ = MakeKubectl(shell)
+		kubectlAsStatusChecker, _ = NewKubectl(shell)
 
 		output, err := ioutil.ReadFile("testdata/kubectl_config.output")
 		if err != nil {
@@ -257,7 +257,7 @@ func TestKubectlSelfCheck(t *testing.T) {
 		shell := &shell.MockShell{}
 		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
 		var kubectlAsStatusChecker healthcheck.StatusChecker
-		kubectlAsStatusChecker, _ = MakeKubectl(shell)
+		kubectlAsStatusChecker, _ = NewKubectl(shell)
 
 		output, err := ioutil.ReadFile("testdata/kubectl_config.output")
 		if err != nil {
@@ -290,7 +290,7 @@ func TestKubectlSelfCheck(t *testing.T) {
 
 }
 
-func TestMakeKubectl(t *testing.T) {
+func TestNewKubectl(t *testing.T) {
 	t.Run("Starts when kubectl is at compatible version", func(t *testing.T) {
 		versions := map[string][3]int{
 			"Client Version: v1.8.4":        {1, 8, 4},
@@ -300,7 +300,7 @@ func TestMakeKubectl(t *testing.T) {
 		shell := &shell.MockShell{}
 		for k, v := range versions {
 			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			_, err := MakeKubectl(shell)
+			_, err := NewKubectl(shell)
 
 			if err != nil {
 				t.Fatalf("Unexpected error when kubectl is at version [%v]: %v", v, err)
@@ -317,7 +317,7 @@ func TestMakeKubectl(t *testing.T) {
 		shell := &shell.MockShell{}
 		for k, v := range versions {
 			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			_, err := MakeKubectl(shell)
+			_, err := NewKubectl(shell)
 
 			if err == nil {
 				t.Fatalf("Expecting error when starting with incompatible version [%v] but got nothing", v)

--- a/pkg/k8s/test_helper.go
+++ b/pkg/k8s/test_helper.go
@@ -13,19 +13,40 @@ type MockKubeApi struct {
 	UrlExtraPathStartingWithSlashReceived string
 	UrlForUrlToReturn                     *url.URL
 	NewClientClientToReturn               *http.Client
-	errorToReturn                         error
+	ErrorToReturn                         error
 }
 
 func (m *MockKubeApi) UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
 	m.UrlForNamespaceReceived = namespace
 	m.UrlExtraPathStartingWithSlashReceived = extraPathStartingWithSlash
-	return m.UrlForUrlToReturn, m.errorToReturn
+	return m.UrlForUrlToReturn, m.ErrorToReturn
 }
 
 func (m *MockKubeApi) NewClient() (*http.Client, error) {
-	return m.NewClientClientToReturn, m.errorToReturn
+	return m.NewClientClientToReturn, m.ErrorToReturn
 }
 
 func (m *MockKubeApi) SelfCheck() ([]healthcheck.CheckResult, error) {
-	return m.SelfCheckResultsToReturn, m.errorToReturn
+	return m.SelfCheckResultsToReturn, m.ErrorToReturn
+}
+
+type MockKubectl struct {
+	SelfCheckResultsToReturn []healthcheck.CheckResult
+	ErrorToReturn            error
+}
+
+func (m *MockKubectl) Version() ([3]int, error) { return [3]int{}, nil }
+
+func (m *MockKubectl) StartProxy(potentialErrorWhenStartingProxy chan error, port int) error {
+	return nil
+}
+
+func (m *MockKubectl) UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
+	return nil, nil
+}
+
+func (m *MockKubectl) ProxyPort() int { return -666 }
+
+func (m *MockKubectl) SelfCheck() ([]healthcheck.CheckResult, error) {
+	return m.SelfCheckResultsToReturn, m.ErrorToReturn
 }


### PR DESCRIPTION
Continuing #92

Sample output
```
pcalcado@arbeitsziege.local$ conduit status
github.com/runconduit/conduit/pkg/k8s
github.com/runconduit/conduit/controller/api/public
github.com/runconduit/conduit/cli/cmd
github.com/runconduit/conduit/cli
kubectl: is in $PATH................................[ok]
kubectl: has compatible version.....................[ok]
kubectl: can talk to Kubernetes cluster.............[ok]
kubernetes-api: can connect to the Kubernetes API...[ok]
kubernetes-api: can query the Kubernetes API........[ok]

Status check results are [ok]
pcalcado@arbeitsziege.local$ #########
pcalcado@arbeitsziege.local$  minikube stop
Stopping local Kubernetes cluster...
Machine stopped.
pcalcado@arbeitsziege.local$ #########
pcalcado@arbeitsziege.local$ conduit status
github.com/runconduit/conduit/cli
kubectl: is in $PATH................................[ok]
kubectl: has compatible version.....................[ok]
kubectl: can talk to Kubernetes cluster.............[FAIL]  -- Unable to connect to the server: dial tcp 192.168.99.100:8443: i/o timeout

kubernetes-api: can connect to the Kubernetes API...[ok]
kubernetes-api: can query the Kubernetes API........[ERROR] -- HTTP GET request to endpoint [https://192.168.99.100:8443/api/v1/] resulted in error: [Get https://192.168.99.100:8443/api/v1/: dial tcp 192.168.99.100:8443: i/o timeout]

Status check results are [ERROR]
```