### PR TITLE
Fix docker builds

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -2,6 +2,7 @@
 FROM gcr.io/runconduit/go-deps:e258aef9 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller
+COPY pkg pkg
 # use `install` so that we produce multiple binaries
 RUN CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo ./controller/cmd/...
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,6 +16,7 @@ FROM gcr.io/runconduit/go-deps:e258aef9 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller
+COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o web/web ./web
 
 ## package it all up


### PR DESCRIPTION
Problem: we now depend on shared code in `pkg`, but `pkg` wasn't being copied over to the container resulting in inability to build images:
```
Step 14/19 : RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o web/web ./web
 ---> Running in b0ed56020b64
controller/api/public/client.go:15:2: cannot find package "github.com/runconduit/conduit/pkg/k8s" in any of:
	/go/src/github.com/runconduit/conduit/vendor/github.com/runconduit/conduit/pkg/k8s (vendor tree)
	/usr/local/go/src/github.com/runconduit/conduit/pkg/k8s (from $GOROOT)
	/go/src/github.com/runconduit/conduit/pkg/k8s (from $GOPATH)
```
  
Solution: copy over `pkg`