### PR TITLE
Add instructions to run web locally

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -30,6 +30,17 @@ go run main.go
 
 The web server will be running on localhost:8084.
 
+Note the web process depends on a public-api server, for which you have three options:
+
+1. Boot public-api locally
+
+    ```
+    go run ../controller/cmd/public-api/main.go
+    ```
+
+2. Connect to public-api in docker-compose (see below)
+3. Connect to public-api in Kubernetes (see below)
+
 To develop with a webpack dev server, start the server in a separate window:
 
 ```
@@ -68,7 +79,7 @@ that's running in your docker environment:
 ```
 docker-compose stop web
 cd web
-go run main.go -api-addr=localhost:8085
+go run main.go -api-addr=localhost:8085 # where localhost is the Docker address
 ```
 
 ## Run Web against a public API server in Kubernetes


### PR DESCRIPTION
The web README.md mentions running locally, but it's not explicit about
how to connect to public-api.

Add notes on various ways to connect a local web to a public-api
process.

Signed-off-by: Andrew Seigner <andrew@sig.gy>