### PR TITLE
Attempt to fix issue where proxy deps Docker image was not rebuilt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,3 +1150,4 @@ dependencies = [
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum zip 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "21c4067ff2f91926cb9aef8a8a55f8568b0f2631bb6b827d0fb9770ff5894e43"
+

--- a/proxy/Dockerfile-deps
+++ b/proxy/Dockerfile-deps
@@ -1,3 +1,13 @@
+# WARNING: because whether or not to build a new deps image is based on 
+#          the SHA of `Cargo.lock`, changes to this Dockerfile will NOT 
+#          cause a new deps image to be built. If you change anything in 
+#          this file, it is necessary to also change `Cargo.lock`, such 
+#          as by appending a newline, to cause the deps image to be 
+#          rebuilt.
+#
+#          See https://github.com/runconduit/conduit/issues/115 for more
+#          information.
+
 FROM rust:1.23.0
 WORKDIR /usr/src/conduit
 COPY codegen ./codegen


### PR DESCRIPTION
Because whether or not to build a new deps image is based on the SHA of `Cargo.lock`, changes to the deps Dockerfile will not cause a new deps image to be built. Because of this, the current proxy deps Docker image is based on the wrong Rust version, breaking the build. See #115 for details on this issue.

I've appended a newline to Cargo.lock to change the lockfile's SHA and trigger a rebuild of the deps Docker image on CI. I've also added a comment in the Dockerfile noting that it is necessary to do this when changing that file.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>