### PR TITLE
Fail the build if dep images are out of sync.

### DIFF
--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -31,3 +31,38 @@ clean_head_root_tag() {
 master_root_tag() {
     echo "git-$(git_sha master)"
 }
+
+validate_tag() {
+    file="$1"
+    shift
+
+    image="$1"
+    shift
+
+    sha="$1"
+    shift
+
+    dockerfile_tag=$(grep -oe $image':[^ ]*' $file) || true
+    deps_tag="$image:$sha"
+    if [ "$dockerfile_tag" != "" ] && [ "$dockerfile_tag" != "$deps_tag" ]; then
+        echo "Tag in "$file" does not match source tree:"
+        echo $dockerfile_tag" ("$file")"
+        echo $deps_tag" (source)"
+        exit 3
+    fi
+}
+
+# These functions should be called by any docker-build-* script that relies on
+# Go or Rust dependencies. To confirm the set of scripts that should call this
+# function, run:
+# $ grep -ER 'docker-build-(go|proxy)-deps' .
+
+validate_go_deps_tag() {
+    file="$1"
+    validate_tag "$file" "gcr.io/runconduit/go-deps" "$(go_deps_sha)"
+}
+
+validate_proxy_deps_tag() {
+    file="$1"
+    validate_tag "$file" "gcr.io/runconduit/proxy-deps" "$(proxy_deps_sha)"
+}

--- a/bin/docker-build-cli
+++ b/bin/docker-build-cli
@@ -15,7 +15,7 @@ else
 fi
 
 
-# Build gcr.io/runconduit/cli-bin, which is used by Dockerfile-cli.
+# Build gcr.io/runconduit/cli-bin, which is used by cli/Dockerfile.
 bin/docker-build-cli-bin "${tag}" >/dev/null
 
 docker_maybe_build . \

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -14,6 +14,10 @@ else
     exit 64
 fi
 
+dockerfile=cli/Dockerfile-bin
+
+validate_go_deps_tag $dockerfile
+
 (
     unset DOCKER_FORCE_BUILD
     bin/docker-build-base
@@ -23,7 +27,7 @@ fi
 IMG=$(docker_maybe_build . \
     "$(docker_repo cli-bin)" \
     "${tag}" \
-    cli/Dockerfile-bin)
+    $dockerfile)
 
 ID=$(docker create "$IMG")
 

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -14,6 +14,10 @@ else
     exit 64
 fi
 
+dockerfile=controller/Dockerfile
+
+validate_go_deps_tag $dockerfile
+
 (
     unset DOCKER_FORCE_BUILD
     bin/docker-build-base
@@ -23,4 +27,4 @@ fi
 docker_maybe_build . \
     "$(docker_repo controller)" \
     "${tag}" \
-    controller/Dockerfile
+    $dockerfile

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,10 @@ else
     exit 64
 fi
 
+dockerfile=proxy/Dockerfile
+
+validate_proxy_deps_tag $dockerfile
+
 (
     unset DOCKER_FORCE_BUILD
     bin/docker-build-base
@@ -24,5 +28,5 @@ fi
 docker_build . \
     "$(docker_repo proxy)" \
     "${tag}" \
-    proxy/Dockerfile \
+    $dockerfile \
     --build-arg="RELEASE=${PROXY_RELEASE:-1}"

--- a/bin/docker-build-proxy-init
+++ b/bin/docker-build-proxy-init
@@ -14,6 +14,10 @@ else
     exit 64
 fi
 
+dockerfile=proxy-init/Dockerfile
+
+validate_go_deps_tag $dockerfile
+
 (
     unset DOCKER_FORCE_BUILD
     bin/docker-build-base
@@ -23,4 +27,4 @@ fi
 docker_maybe_build . \
     "$(docker_repo proxy-init)" \
     "${tag}" \
-    proxy-init/Dockerfile
+    $dockerfile

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -14,6 +14,10 @@ else
     exit 64
 fi
 
+dockerfile=web/Dockerfile
+
+validate_go_deps_tag $dockerfile
+
 (
     unset DOCKER_FORCE_BUILD
     bin/docker-build-base
@@ -23,4 +27,4 @@ fi
 docker_maybe_build . \
     "$(docker_repo web)" \
     "${tag}" \
-    web/Dockerfile
+    $dockerfile


### PR DESCRIPTION
Previously if dependencies changed but dep image SHAs were not updated,
the build could succeed, creating docker images with indeterminate
dependencies.

This change checks the dependency image SHAs hard-coded in Dockerfile's
against the current source tree. If the SHAs do not match, the build
fails.

Fixes #118

output if build fails:
```
$ bin/docker-build-controller latest
Tag in controller/Dockerfile does not match source tree:
gcr.io/runconduit/go-deps:41719552 (controller/Dockerfile)
gcr.io/runconduit/go-deps:151268ee (source)
```