### PR TITLE
Add note to run dep ensure prior to go build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ components onto Minikube.
 This setup assumes working Go and Minikube environments.
 
 ```bash
+# ensure all go dependencies are in vendor
+dep ensure && dep prune
+
 # build and install conduit cli locally
 go build -o $GOPATH/bin/conduit ./cli
 


### PR DESCRIPTION
We have example commands for building our go components locally, but we
did not mention a prerequisite step of getting all dependencies.

Add note to run `dep ensure && dep prune`.