### PR TITLE
Remove scheme requirement for api-addr flag in conduit CLI

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -34,7 +34,7 @@ Valid resource types include:
 			return fmt.Errorf("invalid resource type %s, only %s are allowed as resource types", friendlyName, k8s.KubernetesPods)
 		}
 
-		kubeApi, err := k8s.NewK8sAPi(shell.NewUnixShell(), kubeconfigPath, apiAddr)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -39,7 +39,7 @@ Valid resource types include:
 			return err
 		}
 
-		client, err := newApiClient(kubeApi)
+		client, err := newPublicAPIClient(kubeApi, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -7,7 +7,6 @@ import (
 
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
-	"github.com/runconduit/conduit/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -33,13 +32,7 @@ Valid resource types include:
 		if err != nil || resourceType != k8s.KubernetesPods {
 			return fmt.Errorf("invalid resource type %s, only %s are allowed as resource types", friendlyName, k8s.KubernetesPods)
 		}
-
-		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
-		if err != nil {
-			return err
-		}
-
-		client, err := newPublicAPIClient(kubeApi, apiAddr)
+		client, err := newPublicAPIClient()
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -44,8 +44,11 @@ func addControlPlaneNetworkingArgs(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 }
 
-func newApiClient(kubeApi k8s.KubernetesApi) (pb.ApiClient, error) {
-	return public.NewExternalClient(controlPlaneNamespace, kubeApi)
+func newPublicAPIClient(api k8s.KubernetesApi, apiAddr string) (pb.ApiClient, error) {
+	if apiAddr != "" {
+		return public.NewInternalClient(apiAddr)
+	}
+	return public.NewExternalClient(controlPlaneNamespace, api)
 }
 
 // Exit with non-zero exit status without printing the command line usage and

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -61,7 +61,7 @@ The optional [TARGET] option can be either a name for a deployment or pod resour
 			return err
 		}
 
-		client, err := newApiClient(kubeApi)
+		client, err := newPublicAPIClient(kubeApi, apiAddr)
 		if err != nil {
 			return fmt.Errorf("error creating api client while making stats request: %v", err)
 		}

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -12,7 +12,6 @@ import (
 	"github.com/runconduit/conduit/controller/api/util"
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
-	"github.com/runconduit/conduit/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -56,12 +55,7 @@ The optional [TARGET] option can be either a name for a deployment or pod resour
 				return fmt.Errorf("invalid resource type %s, only %v are allowed as resource types", friendlyNameForResourceType, []string{k8s.KubernetesPods, k8s.KubernetesDeployments, ConduitPaths})
 			}
 		}
-		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
-		if err != nil {
-			return err
-		}
-
-		client, err := newPublicAPIClient(kubeApi, apiAddr)
+		client, err := newPublicAPIClient()
 		if err != nil {
 			return fmt.Errorf("error creating api client while making stats request: %v", err)
 		}

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -56,7 +56,7 @@ The optional [TARGET] option can be either a name for a deployment or pod resour
 				return fmt.Errorf("invalid resource type %s, only %v are allowed as resource types", friendlyNameForResourceType, []string{k8s.KubernetesPods, k8s.KubernetesDeployments, ConduitPaths})
 			}
 		}
-		kubeApi, err := k8s.NewK8sAPi(shell.NewUnixShell(), kubeconfigPath, apiAddr)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -31,7 +31,7 @@ problems were found.`,
 			return statusCheckResultWasError(os.Stdout)
 		}
 
-		kubeApi, err := k8s.NewK8sAPi(shell.NewUnixShell(), kubeconfigPath, apiAddr)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error with Kubernetes API: %s\n", err.Error())
 			return statusCheckResultWasError(os.Stdout)

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -37,7 +37,7 @@ problems were found.`,
 			return statusCheckResultWasError(os.Stdout)
 		}
 
-		conduitApi, err := newApiClient(kubeApi)
+		conduitApi, err := newPublicAPIClient(kubeApi, apiAddr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error with Conduit API: %s\n", err.Error())
 			return statusCheckResultWasError(os.Stdout)

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/runconduit/conduit/controller/api/public"
 	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
+	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/healthcheck"
 	"github.com/runconduit/conduit/pkg/k8s"
 	"github.com/runconduit/conduit/pkg/shell"
@@ -31,13 +32,18 @@ problems were found.`,
 			return statusCheckResultWasError(os.Stdout)
 		}
 
-		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error with Kubernetes API: %s\n", err.Error())
 			return statusCheckResultWasError(os.Stdout)
 		}
 
-		conduitApi, err := newPublicAPIClient(kubeApi, apiAddr)
+		var conduitApi pb.ApiClient
+		if apiAddr != "" {
+			conduitApi, err = public.NewInternalClient(apiAddr)
+		} else {
+			conduitApi, err = public.NewExternalClient(controlPlaneNamespace, kubeApi)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error with Conduit API: %s\n", err.Error())
 			return statusCheckResultWasError(os.Stdout)

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -13,7 +13,6 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/k8s"
-	"github.com/runconduit/conduit/pkg/shell"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
@@ -63,12 +62,7 @@ Valid targets include:
 			return fmt.Errorf("unsupported resourceType [%s]", friendlyNameForResourceType)
 		}
 
-		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
-		if err != nil {
-			return err
-		}
-
-		client, err := newPublicAPIClient(kubeApi, apiAddr)
+		client, err := newPublicAPIClient()
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -63,7 +63,7 @@ Valid targets include:
 			return fmt.Errorf("unsupported resourceType [%s]", friendlyNameForResourceType)
 		}
 
-		kubeApi, err := k8s.NewK8sAPi(shell.NewUnixShell(), kubeconfigPath, apiAddr)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -68,7 +68,7 @@ Valid targets include:
 			return err
 		}
 
-		client, err := newApiClient(kubeApi)
+		client, err := newPublicAPIClient(kubeApi, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -20,7 +20,7 @@ var versionCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
 
-		kubeApi, err := k8s.NewK8sAPi(shell.NewUnixShell(), kubeconfigPath, apiAddr)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -19,13 +19,12 @@ var versionCmd = &cobra.Command{
 	Long:  "Print the client and server version information.",
 	Args:  cobra.NoArgs,
 	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
-
 		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
 		if err != nil {
 			return err
 		}
 
-		client, err := newApiClient(kubeApi)
+		client, err := newPublicAPIClient(kubeApi, apiAddr)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/runconduit/conduit/controller"
 	pb "github.com/runconduit/conduit/controller/gen/public"
-	"github.com/runconduit/conduit/pkg/k8s"
-	"github.com/runconduit/conduit/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -19,12 +17,7 @@ var versionCmd = &cobra.Command{
 	Long:  "Print the client and server version information.",
 	Args:  cobra.NoArgs,
 	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
-		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath, apiAddr)
-		if err != nil {
-			return err
-		}
-
-		client, err := newPublicAPIClient(kubeApi, apiAddr)
+		client, err := newPublicAPIClient()
 		if err != nil {
 			return err
 		}

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -154,10 +154,6 @@ func NewExternalClient(controlPlaneNamespace string, kubeApi k8s.KubernetesApi) 
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	httpClientToUse, err := kubeApi.NewClient()
 	if err != nil {
 		return nil, err

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/runconduit/conduit/pkg/healthcheck"
 	"github.com/runconduit/conduit/pkg/shell"
 	"k8s.io/client-go/rest"
-	"strings"
 	"regexp"
 )
 
@@ -125,15 +124,17 @@ func NewK8sAPI(shell shell.Shell, k8sConfigFilesystemPathOverride string, apiHos
 	}
 
 	if apiHostAndPortOverride == "" {
-		apiHostAndPortOverride = config.Host
+		return &kubernetesApi{
+			apiSchemeHostAndPort: config.Host,
+			config:               config,
+		}, nil
 	} else {
 		if !httpPrefix.MatchString(apiHostAndPortOverride) {
-			apiHostAndPortOverride = strings.Join([]string{"https://", apiHostAndPortOverride}, "")
+			apiHostAndPortOverride = fmt.Sprintf("https://%s", apiHostAndPortOverride)
 		}
+		return &kubernetesApi{
+			apiSchemeHostAndPort: apiHostAndPortOverride,
+			config:               config,
+		}, nil
 	}
-
-	return &kubernetesApi{
-		apiSchemeHostAndPort: apiHostAndPortOverride,
-		config:               config,
-	}, nil
 }

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -20,7 +20,7 @@ const (
 	KubeapiClientCheckDescription       = "can initialize the client"
 	KubeapiAccessCheckDescription       = "can query the Kubernetes API"
 )
-var httpPrefix = regexp.MustCompile(`https?://`)
+var httpPrefix = regexp.MustCompile(`://`)
 type KubernetesApi interface {
 	UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error)
 	NewClient() (*http.Client, error)
@@ -129,7 +129,12 @@ func NewK8sAPI(shell shell.Shell, k8sConfigFilesystemPathOverride string, apiHos
 			config:               config,
 		}, nil
 	} else {
-		if !httpPrefix.MatchString(apiHostAndPortOverride) {
+		parsedURL, err := url.Parse(apiHostAndPortOverride)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing override url: %v", err)
+		}
+
+		if parsedURL.Scheme == "" {
 			apiHostAndPortOverride = fmt.Sprintf("https://%s", apiHostAndPortOverride)
 		}
 		return &kubernetesApi{

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/runconduit/conduit/pkg/healthcheck"
 	"github.com/runconduit/conduit/pkg/shell"
 	"k8s.io/client-go/rest"
-	"regexp"
 )
 
 const (
@@ -20,7 +19,7 @@ const (
 	KubeapiClientCheckDescription       = "can initialize the client"
 	KubeapiAccessCheckDescription       = "can query the Kubernetes API"
 )
-var httpPrefix = regexp.MustCompile(`://`)
+
 type KubernetesApi interface {
 	UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error)
 	NewClient() (*http.Client, error)
@@ -128,18 +127,10 @@ func NewK8sAPI(shell shell.Shell, k8sConfigFilesystemPathOverride string, apiHos
 			apiSchemeHostAndPort: config.Host,
 			config:               config,
 		}, nil
-	} else {
-		parsedURL, err := url.Parse(apiHostAndPortOverride)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing override url: %v", err)
-		}
-
-		if parsedURL.Scheme == "" {
-			apiHostAndPortOverride = fmt.Sprintf("https://%s", apiHostAndPortOverride)
-		}
-		return &kubernetesApi{
-			apiSchemeHostAndPort: apiHostAndPortOverride,
-			config:               config,
-		}, nil
 	}
+
+	return &kubernetesApi{
+		apiSchemeHostAndPort: apiHostAndPortOverride,
+		config:               config,
+	}, nil
 }

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -7,23 +7,38 @@ import (
 )
 
 func TestKubernetesApiUrlFor(t *testing.T) {
+	const namespace = "some-namespace"
+	const extraPath = "/some/extra/path"
+
 	t.Run("Returns URL from base URL overridden in construction", func(t *testing.T) {
-		namespace := "some-namespace"
-		extraPath := "/some/extra/path"
+		testUrl := "https://35.184.231.31"
 		expectedUrlString := "https://35.184.231.31/api/v1/namespaces/some-namespace/some/extra/path"
-
-		api, err := NewK8sAPi(shell.NewUnixShell(), "testdata/config.test", "https://35.184.231.31")
-		if err != nil {
-			t.Fatalf("Unexpected error starting proxy: %v", err)
-		}
-
-		actualUrl, err := api.UrlFor(namespace, extraPath)
-		if err != nil {
-			t.Fatalf("Unexpected error starting proxy: %v", err)
-		}
-
-		if actualUrl.String() != expectedUrlString {
-			t.Fatalf("Expected generated URL to be [%s], but got [%s]", expectedUrlString, actualUrl.String())
-		}
+		generateUrlTest(t, namespace, extraPath, testUrl, expectedUrlString)
 	})
+
+	t.Run("Returns URL from base URL with no https prefix in URL override", func(t *testing.T) {
+		testUrl := "35.184.231.31"
+		expectedUrlString := "https://35.184.231.31/api/v1/namespaces/some-namespace/some/extra/path"
+		generateUrlTest(t, namespace, extraPath, testUrl, expectedUrlString)
+	})
+
+	t.Run("Returns URL from base URL with with http prefix in URL override", func(t *testing.T) {
+		testUrl := "http://35.184.231.31"
+		expectedUrlString := "http://35.184.231.31/api/v1/namespaces/some-namespace/some/extra/path"
+		generateUrlTest(t, namespace, extraPath, testUrl, expectedUrlString)
+	})
+}
+
+func generateUrlTest(t *testing.T, namespace string, extraPath string, testUrl string,  expectedUrlString string) {
+	api, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", testUrl)
+	if err != nil {
+		t.Fatalf("Unexpected error starting proxy: %v", err)
+	}
+	actualUrl, err := api.UrlFor(namespace, extraPath)
+	if err != nil {
+		t.Fatalf("Unexpected error starting proxy: %v", err)
+	}
+	if actualUrl.String() != expectedUrlString {
+		t.Fatalf("Expected generated URL to be [%s], but got [%s]", expectedUrlString, actualUrl.String())
+	}
 }

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -5,42 +5,85 @@ import (
 
 	"github.com/runconduit/conduit/pkg/shell"
 	"fmt"
+	"net/url"
 )
 
+type TestFixture struct{
+	testInput string
+	expectedOutput string
+}
 func TestKubernetesApiUrlFor(t *testing.T) {
 	const namespace = "some-namespace"
 	const extraPath = "/some/extra/path"
-	testData := []struct {
-		testInput string
-		expected  string
-	}{
+	testData := []TestFixture{
 		{
 			testInput: "https://35.184.231.31",
-			expected:  fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			expectedOutput:  fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
 		},
 		{
 			testInput: "35.184.231.31",
-			expected:  fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			expectedOutput:  fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
 		},
 		{
 			testInput: "http://35.184.231.31",
-			expected:  fmt.Sprintf("http://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			expectedOutput:  fmt.Sprintf("http://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
 		},
 	}
 
 	t.Run("Returns URL from base URL overridden in construction", func(t *testing.T) {
 		for _, data := range testData {
-			api, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", data.testInput)
-			if err != nil {
-				t.Fatalf("Unexpected error starting proxy: %v", err)
-			}
-			actualUrl, err := api.UrlFor(namespace, extraPath)
-			if err != nil {
-				t.Fatalf("Unexpected error starting proxy: %v", err)
-			}
-			if actualUrl.String() != data.expected {
-				t.Fatalf("Expected generated URL to be [%s], but got [%s]", data.expected, actualUrl.String())
+			actualUrl := generateURL(data, t, namespace, extraPath)
+			if actualUrl.String() != data.expectedOutput {
+				t.Fatalf("Expected generated URL to be [%s], but got [%s]", data.expectedOutput, actualUrl.String())
 			}
 		}
 	})
+
+	t.Run("Returns unmodified URL from base URL overridden in construction", func(t *testing.T){
+		/* NewK8sAPI is agnostic to the scheme used for the override API. It is only contains code that conveniently
+		adds the default scheme used to connect with the k8s API (https). Supplying a URL with a scheme other than https
+		should return an unmodified override URL */
+		testData := []TestFixture {
+			{
+				testInput: "htp://35.184.231.31",
+				expectedOutput:  fmt.Sprintf("htp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			},
+			{
+				testInput: "tcp://35.184.231.31",
+				expectedOutput:  fmt.Sprintf("tcp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			},
+			{
+				testInput: "htttpp://35.184.231.31",
+				expectedOutput:  fmt.Sprintf("htttpp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			},
+		}
+		for _, data := range testData {
+			actualUrl := generateURL(data, t, namespace, extraPath)
+			if actualUrl.String() != data.expectedOutput {
+				t.Fatalf("Expected generated URL to be [%s], but got [%s]", data.expectedOutput, actualUrl.String())
+			}
+
+		}
+	})
+
+	t.Run("Return error on malformed URL from base URL during API construction", func(t *testing.T) {
+		testData := []string{"http://**&^^.(&(^"}
+		for _, data := range testData {
+			_, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", data)
+			if err == nil {
+				t.Fatalf("Expected error from proxy on malformed URL: %s", data)
+			}
+		}
+	})
+}
+func generateURL(data TestFixture, t *testing.T, namespace string, extraPath string) *url.URL {
+	api, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", data.testInput)
+	if err != nil {
+		t.Fatalf("Unexpected error starting proxy: %v", err)
+	}
+	actualUrl, err := api.UrlFor(namespace, extraPath)
+	if err != nil {
+		t.Fatalf("Unexpected error starting proxy: %v", err)
+	}
+	return actualUrl
 }

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -8,59 +8,45 @@ import (
 	"net/url"
 )
 
-type TestFixture struct{
-	testInput string
-	expectedOutput string
-}
 func TestKubernetesApiUrlFor(t *testing.T) {
 	const namespace = "some-namespace"
 	const extraPath = "/some/extra/path"
-	testData := []TestFixture{
-		{
-			testInput: "https://35.184.231.31",
-			expectedOutput:  fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-		},
-		{
-			testInput: "35.184.231.31",
-			expectedOutput:  fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-		},
-		{
-			testInput: "http://35.184.231.31",
-			expectedOutput:  fmt.Sprintf("http://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-		},
-	}
 
 	t.Run("Returns URL from base URL overridden in construction", func(t *testing.T) {
-		for _, data := range testData {
-			actualUrl := generateURL(data, t, namespace, extraPath)
-			if actualUrl.String() != data.expectedOutput {
-				t.Fatalf("Expected generated URL to be [%s], but got [%s]", data.expectedOutput, actualUrl.String())
+		testData := map[string]string{
+			"https://35.184.231.31": fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			"http://35.184.231.31":  fmt.Sprintf("http://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+		}
+		for testInput, expected := range testData {
+			actualUrl := generateURL(testInput, t, namespace, extraPath)
+			if actualUrl.String() != expected {
+				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
 			}
 		}
 	})
 
-	t.Run("Returns unmodified URL from base URL overridden in construction", func(t *testing.T){
-		/* NewK8sAPI is agnostic to the scheme used for the override API. It is only contains code that conveniently
-		adds the default scheme used to connect with the k8s API (https). Supplying a URL with a scheme other than https
-		should return an unmodified override URL */
-		testData := []TestFixture {
-			{
-				testInput: "htp://35.184.231.31",
-				expectedOutput:  fmt.Sprintf("htp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-			},
-			{
-				testInput: "tcp://35.184.231.31",
-				expectedOutput:  fmt.Sprintf("tcp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-			},
-			{
-				testInput: "htttpp://35.184.231.31",
-				expectedOutput:  fmt.Sprintf("htttpp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-			},
+	t.Run("Return URL with prepended scheme from a base URL with no scheme specified", func(t *testing.T) {
+		testData := map[string]string{
+			"35.184.231.31": fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
 		}
-		for _, data := range testData {
-			actualUrl := generateURL(data, t, namespace, extraPath)
-			if actualUrl.String() != data.expectedOutput {
-				t.Fatalf("Expected generated URL to be [%s], but got [%s]", data.expectedOutput, actualUrl.String())
+		for testInput, expected := range testData {
+			actualUrl := generateURL(testInput, t, namespace, extraPath)
+			if actualUrl.String() != expected {
+				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
+			}
+		}
+	})
+
+	t.Run("Return unmodified URL from a base URL with an existing scheme", func(t *testing.T) {
+		testData := map[string]string{
+			"htp://35.184.231.31":    fmt.Sprintf("htp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			"tcp://35.184.231.31":    fmt.Sprintf("tcp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+			"htttpp://35.184.231.31": fmt.Sprintf("htttpp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+		}
+		for testInput, expected := range testData {
+			actualUrl := generateURL(testInput, t, namespace, extraPath)
+			if actualUrl.String() != expected {
+				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
 			}
 
 		}
@@ -76,8 +62,9 @@ func TestKubernetesApiUrlFor(t *testing.T) {
 		}
 	})
 }
-func generateURL(data TestFixture, t *testing.T, namespace string, extraPath string) *url.URL {
-	api, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", data.testInput)
+
+func generateURL(hostPort string, t *testing.T, namespace string, extraPath string) *url.URL {
+	api, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", hostPort)
 	if err != nil {
 		t.Fatalf("Unexpected error starting proxy: %v", err)
 	}

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/runconduit/conduit/pkg/shell"
@@ -12,28 +11,19 @@ func TestKubernetesApiUrlFor(t *testing.T) {
 	const namespace = "some-namespace"
 	const extraPath = "/some/extra/path"
 
-	t.Run("Returns URL from base URL overridden in construction", func(t *testing.T) {
-		testData := map[string]string{
-			"https://35.184.231.31": fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-			"http://35.184.231.31":  fmt.Sprintf("http://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
+	t.Run("Returns base config containing k8s endpoint listed in config.test", func(t *testing.T) {
+		expected := fmt.Sprintf("https://55.197.171.239/api/v1/namespaces/%s%s", namespace, extraPath)
+		shell := &shell.MockShell{}
+		api, err := NewK8sAPI(shell, "testdata/config.test")
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
 		}
-		for testInput, expected := range testData {
-			actualUrl := generateURL(testInput, t, namespace, extraPath)
-			if actualUrl.String() != expected {
-				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
-			}
+		actualUrl, err := api.UrlFor(namespace, extraPath)
+		if err != nil {
+			t.Fatalf("Unexpected error starting proxy: %v", err)
+		}
+		if actualUrl.String() != expected {
+			t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
 		}
 	})
-}
-
-func generateURL(hostPort string, t *testing.T, namespace string, extraPath string) *url.URL {
-	api, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", hostPort)
-	if err != nil {
-		t.Fatalf("Unexpected error starting proxy: %v", err)
-	}
-	actualUrl, err := api.UrlFor(namespace, extraPath)
-	if err != nil {
-		t.Fatalf("Unexpected error starting proxy: %v", err)
-	}
-	return actualUrl
 }

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -1,11 +1,11 @@
 package k8s
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/runconduit/conduit/pkg/shell"
-	"fmt"
-	"net/url"
 )
 
 func TestKubernetesApiUrlFor(t *testing.T) {
@@ -21,43 +21,6 @@ func TestKubernetesApiUrlFor(t *testing.T) {
 			actualUrl := generateURL(testInput, t, namespace, extraPath)
 			if actualUrl.String() != expected {
 				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
-			}
-		}
-	})
-
-	t.Run("Return URL with prepended scheme from a base URL with no scheme specified", func(t *testing.T) {
-		testData := map[string]string{
-			"35.184.231.31": fmt.Sprintf("https://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-		}
-		for testInput, expected := range testData {
-			actualUrl := generateURL(testInput, t, namespace, extraPath)
-			if actualUrl.String() != expected {
-				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
-			}
-		}
-	})
-
-	t.Run("Return unmodified URL from a base URL with an existing scheme", func(t *testing.T) {
-		testData := map[string]string{
-			"htp://35.184.231.31":    fmt.Sprintf("htp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-			"tcp://35.184.231.31":    fmt.Sprintf("tcp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-			"htttpp://35.184.231.31": fmt.Sprintf("htttpp://35.184.231.31/api/v1/namespaces/%s%s", namespace, extraPath),
-		}
-		for testInput, expected := range testData {
-			actualUrl := generateURL(testInput, t, namespace, extraPath)
-			if actualUrl.String() != expected {
-				t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
-			}
-
-		}
-	})
-
-	t.Run("Return error on malformed URL from base URL during API construction", func(t *testing.T) {
-		testData := []string{"http://**&^^.(&(^"}
-		for _, data := range testData {
-			_, err := NewK8sAPI(shell.NewUnixShell(), "testdata/config.test", data)
-			if err == nil {
-				t.Fatalf("Expected error from proxy on malformed URL: %s", data)
 			}
 		}
 	})


### PR DESCRIPTION
Conduit CLI has the option of providing a URL for a `--api-addr` flag. This option requires that the URL must contain an http scheme in order to create a Kubernetes API client. This PR removes the scheme restriction and allows for a user to enter both a `host:port` or `scheme://host:port` format

New tests were added to `api_test.go` to capture the scenario and tests were run manually with the CLI to ensure that no regression was introduced.

fixes #121

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>
  