### PR TITLE
Fix web and public-api log info messages.

### DIFF
--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,10 +10,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/api/public"
 	"github.com/runconduit/conduit/controller/tap"
 	"github.com/runconduit/conduit/controller/telemetry"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
@@ -42,18 +41,18 @@ func main() {
 	server := public.NewServer(*addr, telemetryClient, tapClient)
 
 	go func() {
-		fmt.Println("starting HTTP server on", *addr)
+		log.Infof("starting HTTP server on %+v", *addr)
 		server.ListenAndServe()
 	}()
 
 	go func() {
-		fmt.Println("serving scrapable metrics on", *metricsAddr)
+		log.Infof("serving scrapable metrics on %+v", *metricsAddr)
 		http.Handle("/metrics", promhttp.Handler())
 		http.ListenAndServe(*metricsAddr, nil)
 	}()
 
 	<-stop
 
-	fmt.Println("shutting down HTTP server on", *addr)
+	log.Infof("shutting down HTTP server on %+v", *addr)
 	server.Shutdown(context.Background())
 }

--- a/web/main.go
+++ b/web/main.go
@@ -51,19 +51,19 @@ func main() {
 	server := srv.NewServer(*addr, *templateDir, *staticDir, *uuid, *webpackDevServer, *reload, client)
 
 	go func() {
-		log.Info("starting HTTP server on", *addr)
+		log.Infof("starting HTTP server on %+v", *addr)
 		server.ListenAndServe()
 	}()
 
 	go func() {
-		log.Info("serving scrapable metrics on", *metricsAddr)
+		log.Infof("serving scrapable metrics on %+v", *metricsAddr)
 		http.Handle("/metrics", promhttp.Handler())
 		http.ListenAndServe(*metricsAddr, nil)
 	}()
 
 	<-stop
 
-	log.Info("shutting down HTTP server on", *addr)
+	log.Infof("shutting down HTTP server on %+v", *addr)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	server.Shutdown(ctx)


### PR DESCRIPTION
The existing startup/shutdown log info messages had spacing issues and
used fmt.

Update the log messages to use logrus for consistency, and fix spacing
issues.

## Before

```
$ go run main.go
INFO[0000] starting HTTP server on:8084
INFO[0000] serving scrapable metrics on:9994
```

## After

```
$ go run main.go
INFO[0000] starting HTTP server on :8084
INFO[0000] serving scrapable metrics on :9994
```