### PR TITLE
Add /paths page that displays metrics by path, add ability to sort Table

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -220,6 +220,10 @@ a.button.primary:active {
     border-bottom: 1px solid;
     border-color: var(--status-gray);
     word-break: keep-all;
+
+    &.ant-table-column-sort {
+      background: none;
+    }
   }
 
   & .ant-table table {

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -49,7 +49,7 @@ export default class Deployment extends React.Component {
       pollingInterval: 10000,
       metricsWindow: "10m",
       deploy: deployment,
-      metrics:[],
+      metrics: [],
       pods: [],
       upstreamMetrics: [],
       downstreamMetrics: [],

--- a/web/app/js/components/Deployment.jsx
+++ b/web/app/js/components/Deployment.jsx
@@ -209,7 +209,7 @@ export default class Deployment extends React.Component {
 
   renderPaths() {
     return _.size(this.state.pathMetrics) === 0 ? null :
-      <div>
+      <div key="deployment-paths">
         <div className="border-container border-neutral subsection-header">
           <div className="border-container-content subsection-header">
               Paths

--- a/web/app/js/components/Paths.jsx
+++ b/web/app/js/components/Paths.jsx
@@ -76,7 +76,6 @@ export default class Paths extends React.Component {
 
             <TabbedMetricsTable
               resource="path"
-              entity=""
               metrics={this.state.metrics}
               lastUpdated={this.state.lastUpdated}
               pathPrefix={this.props.pathPrefix}

--- a/web/app/js/components/Paths.jsx
+++ b/web/app/js/components/Paths.jsx
@@ -1,0 +1,91 @@
+import ConduitSpinner from "./ConduitSpinner.jsx";
+import ErrorBanner from './ErrorBanner.jsx';
+import { processRollupMetrics } from './util/MetricUtils.js';
+import React from 'react';
+import TabbedMetricsTable from './TabbedMetricsTable.jsx';
+import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
+import 'whatwg-fetch';
+
+export default class Paths extends React.Component {
+  constructor(props) {
+    super(props);
+    this.api = ApiHelpers(this.props.pathPrefix);
+    this.handleApiError = this.handleApiError.bind(this);
+    this.loadFromServer = this.loadFromServer.bind(this);
+    this.state = this.initialState();
+  }
+
+  componentDidMount() {
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.timerId);
+  }
+
+  initialState() {
+    return {
+      lastUpdated: 0,
+      pollingInterval: 10000,
+      metricsWindow: "1m",
+      metrics: [],
+      pendingRequests: false,
+      loaded: false,
+      error: ''
+    };
+  }
+
+  loadFromServer() {
+    if (this.state.pendingRequests) {
+      return;
+    }
+    this.setState({ pendingRequests: true });
+
+    let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
+
+    this.api.fetch(urls["path"].url().rollup).then(r => {
+      let metrics = processRollupMetrics(r.metrics, "path");
+
+      this.setState({
+        metrics: metrics,
+        lastUpdated: Date.now(),
+        pendingRequests: false,
+        loaded: true,
+        error: ''
+      });
+    }).catch(this.handleApiError);
+  }
+
+  handleApiError(e) {
+    this.setState({
+      pendingRequests: false,
+      error: `Error getting data from server: ${e.message}`
+    });
+  }
+
+  render() {
+    return (
+      <div className="page-content">
+        { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
+        { !this.state.loaded ? <ConduitSpinner /> :
+          <div>
+            <div className="page-header">
+              <h1>Paths</h1>
+            </div>
+
+            <TabbedMetricsTable
+              resource="path"
+              entity=""
+              metrics={this.state.metrics}
+              lastUpdated={this.state.lastUpdated}
+              pathPrefix={this.props.pathPrefix}
+              metricsWindow={this.state.metricsWindow}
+              sortable={true}
+              hideSparklines={true} />
+          </div>
+        }
+      </div>
+    );
+  }
+}

--- a/web/app/js/components/util/ApiHelpers.js
+++ b/web/app/js/components/util/ApiHelpers.js
@@ -36,11 +36,12 @@ export const urlsForResource = (pathPrefix, metricsWindow) => {
     "deployment": {
       groupBy: "targetDeploy",
       url: (deploy = null) => {
+        let rollupUrl = !deploy ? metricsUrl : `${metricsUrl}&target_deploy=${deploy}`;
         let timeseriesUrl = !deploy ? `${metricsUrl}&timeseries=true` :
           `${metricsUrl}&timeseries=true&target_deploy=${deploy}`;
         return {
           ts: timeseriesUrl,
-          rollup: metricsUrl
+          rollup: rollupUrl
         };
       }
     },
@@ -105,9 +106,10 @@ export const urlsForResource = (pathPrefix, metricsWindow) => {
       }
     },
     "path": {
+      // all paths (default), or all paths of a given deploy if specified
       groupBy: "path",
-      url: () => {
-        let pathRollupUrl = `${metricsUrl}&aggregation=path`;
+      url: (deploy = null) => {
+        let pathRollupUrl = `${metricsUrl}&aggregation=path${ !deploy ? "" : `&target_deploy=${deploy}`}`;
         let pathTsUrl = `${pathRollupUrl}&timeseries=true`;
 
         return {

--- a/web/app/js/components/util/ApiHelpers.js
+++ b/web/app/js/components/util/ApiHelpers.js
@@ -103,6 +103,18 @@ export const urlsForResource = (pathPrefix, metricsWindow) => {
           rollup: downstreamRollupUrl
         };
       }
+    },
+    "path": {
+      groupBy: "path",
+      url: () => {
+        let pathRollupUrl = `${metricsUrl}&aggregation=path`;
+        let pathTsUrl = `${pathRollupUrl}&timeseries=true`;
+
+        return {
+          ts: pathTsUrl,
+          rollup: pathRollupUrl
+        };
+      }
     }
   };
 };

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -1,6 +1,7 @@
 import Deployment from './components/Deployment.jsx';
 import Deployments from './components/Deployments.jsx';
 import NoMatch from './components/NoMatch.jsx';
+import Paths from './components/Paths.jsx';
 import PodDetail from './components/PodDetail.jsx';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -33,6 +34,7 @@ ReactDOM.render((
             <Route path={`${pathPrefix}/servicemesh`} render={() => <ServiceMesh pathPrefix={pathPrefix} releaseVersion={appData.releaseVersion} />} />
             <Route path={`${pathPrefix}/deployments`} render={() => <Deployments pathPrefix={pathPrefix} />} />
             <Route path={`${pathPrefix}/deployment`} render={props => <Deployment pathPrefix={pathPrefix} location={props.location} />} />
+            <Route path={`${pathPrefix}/paths`} render={props => <Paths pathPrefix={pathPrefix} location={props.location} />} />
             <Route path={`${pathPrefix}/pod`} render={props => <PodDetail pathPrefix={pathPrefix} location={props.location} />} />
             <Route path={`${pathPrefix}/routes`} render={() => <Routes pathPrefix={pathPrefix} />} />
             <Route component={NoMatch} />

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -92,6 +92,7 @@ func NewServer(addr, templateDir, staticDir, uuid, webpackDevServer string, relo
 	server.router.GET("/pod", handler.handleIndex)
 	server.router.GET("/deployment", handler.handleIndex)
 	server.router.GET("/deployments", handler.handleIndex)
+	server.router.GET("/paths", handler.handleIndex)
 	server.router.GET("/servicemesh", handler.handleIndex)
 	server.router.GET("/routes", handler.handleIndex)
 	server.router.ServeFiles(


### PR DESCRIPTION
- Adds ability to sort by column in the tabbed metrics table (to make a TabbedMetricsTable sortable, set `sortable={true}`)
- Adds a page, accessible via `/paths` that shows a table of all paths, with their request/success/latency metrics. I haven't exposed it in the sidebar as it doesn't have design treatment.

![screen shot 2018-01-10 at 1 23 36 pm](https://user-images.githubusercontent.com/549258/34796520-9b286a9c-f60a-11e7-9d83-2466fd8271e5.png)

Note that this table shows all paths for all deploys. 

I've added a table in the Deployment page that shows the paths for that particular deploy. This does mean this page makes yet another metrics request to the server. We can remove if this is too much.

![screen shot 2018-01-10 at 2 06 21 pm](https://user-images.githubusercontent.com/549258/34799101-571a98f8-f613-11e7-9d2b-6e31f053bf2a.png)


