### PR TITLE
Revive scatterplot: re-add scatterplot to Deployments page

### DIFF
--- a/web/app/css/deployments.css
+++ b/web/app/css/deployments.css
@@ -5,22 +5,22 @@
   width: 50%;
 }
 
-.deployments-list, .scatterplot {
-  padding-top: 30px;
-}
-
 .line-graph {
   margin-top: var(--base-width);
 }
 
-.scatterplot-tooltip .chart-label {
-  float: left;
-}
+.scatterplot-display {
+  font-size: 12px;
 
-.scatterplot-tooltip .tooltip {
-  float: right;
-  color: black;
-  font-weight: bold;
+  & .title {
+    font-weight: var(--font-weight-bold);
+    margin-top: var(--base-width);
+  }
+
+  & .extremal-latencies {
+    padding-bottom: var(--base-width);
+    border-bottom: 1px solid #BDBDBD;
+  }
 }
 
 & .border-container {

--- a/web/app/css/scatterplot.css
+++ b/web/app/css/scatterplot.css
@@ -20,9 +20,16 @@
 
 circle.dot {
   stroke-width: 2px;
-  opacity: 0.8;
+  fill-opacity: 0.7;
+  stroke-opacity: 0.9;
 }
 
-.dot-label {
-  font-size: 11px;
+.overlay {
+  fill: none;
+  pointer-events: all;
+}
+
+.vertical-highlight {
+  fill: steelblue;
+  opacity: 0.1;
 }

--- a/web/app/css/scatterplot.css
+++ b/web/app/css/scatterplot.css
@@ -29,6 +29,11 @@ circle.dot {
   pointer-events: all;
 }
 
+.overlay-tooltip {
+  fill: #777;
+  font-size: 12px;
+}
+
 .vertical-highlight {
   fill: steelblue;
   opacity: 0.1;

--- a/web/app/js/components/Deployments.jsx
+++ b/web/app/js/components/Deployments.jsx
@@ -4,15 +4,26 @@ import ConduitSpinner from "./ConduitSpinner.jsx";
 import DeploymentSummary from './DeploymentSummary.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import React from 'react';
-import { rowGutter } from './util/Utils.js';
+import ScatterPlot from './ScatterPlot.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import { Col, Row } from 'antd';
 import { emptyMetric, getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
+import { metricToFormatter, rowGutter } from './util/Utils.js';
 import './../../css/deployments.css';
 import 'whatwg-fetch';
 
 const maxTsToFetch = 15; // Beyond this, stop showing sparklines in table
+const getP99 = d => _.get(d, ["latency", "P99", 0, "value"]);
+let nodeStats = (description, node) => (
+  <div>
+    <div className="title">{description}:</div>
+    <div>
+      {node.name} ({metricToFormatter["LATENCY"](getP99(node))})
+    </div>
+  </div>
+);
+
 export default class Deployments extends React.Component {
   constructor(props) {
     super(props);
@@ -125,11 +136,19 @@ export default class Deployments extends React.Component {
 
   renderPageContents() {
     let leastHealthyDeployments = this.getLeastHealthyDeployments(this.state.metrics);
+    let slowestNode = _.maxBy(this.state.metrics, getP99);
+    let fastestNode = _.minBy(this.state.metrics, getP99);
+
+    let scatterplotData = _.reduce(this.state.metrics, (mem, datum) => {
+      if (!_.isNil(datum.successRate) && !_.isNil(datum.latency)) {
+        mem.push(datum);
+      }
+      return mem;
+    }, []);
 
     return (
       <div className="clearfix">
-        <div className="subsection-header">Least-healthy deployments</div>
-        {_.isEmpty(this.state.metrics) ? <div className="no-data-msg">No data</div> : null}
+        {_.isEmpty(leastHealthyDeployments) ? null : <div className="subsection-header">Least-healthy deployments</div>}
         <Row gutter={rowGutter}>
           {
             _.map(leastHealthyDeployments, deployment => {
@@ -142,6 +161,31 @@ export default class Deployments extends React.Component {
                   pathPrefix={this.props.pathPrefix} />
               </Col>);
             })
+          }
+        </Row>
+        <Row gutter={rowGutter}>
+          { _.isEmpty(scatterplotData) ? null :
+            <div className="deployments-scatterplot">
+              <div className="scatterplot-info">
+                <div className="subsection-header">Success rate vs p99 latency</div>
+              </div>
+              <Row gutter={rowGutter}>
+                <Col span={8}>
+                  <div className="scatterplot-display">
+                    <div className="extremal-latencies">
+                      { !fastestNode ? null : nodeStats("Least latency", fastestNode) }
+                      { !slowestNode ? null : nodeStats("Most latency", slowestNode) }
+                    </div>
+                  </div>
+                </Col>
+                <Col span={16}><div className="scatterplot-chart">
+                  <ScatterPlot
+                    data={scatterplotData}
+                    lastUpdated={this.state.lastUpdated}
+                    containerClassName="scatterplot-chart" />
+                </div></Col>
+              </Row>
+            </div>
           }
         </Row>
         <div className="deployments-list">

--- a/web/app/js/components/Deployments.jsx
+++ b/web/app/js/components/Deployments.jsx
@@ -14,12 +14,11 @@ import './../../css/deployments.css';
 import 'whatwg-fetch';
 
 const maxTsToFetch = 15; // Beyond this, stop showing sparklines in table
-const getP99 = d => _.get(d, ["latency", "P99", 0, "value"]);
 let nodeStats = (description, node) => (
   <div>
     <div className="title">{description}:</div>
     <div>
-      {node.name} ({metricToFormatter["LATENCY"](getP99(node))})
+      {node.name} ({metricToFormatter["LATENCY"](_.get(node, ["latency", "P99"]))})
     </div>
   </div>
 );
@@ -136,15 +135,15 @@ export default class Deployments extends React.Component {
 
   renderPageContents() {
     let leastHealthyDeployments = this.getLeastHealthyDeployments(this.state.metrics);
-    let slowestNode = _.maxBy(this.state.metrics, getP99);
-    let fastestNode = _.minBy(this.state.metrics, getP99);
-
     let scatterplotData = _.reduce(this.state.metrics, (mem, datum) => {
       if (!_.isNil(datum.successRate) && !_.isNil(datum.latency)) {
         mem.push(datum);
       }
       return mem;
     }, []);
+
+    let slowestNode = _.maxBy(scatterplotData, 'latency.P99');
+    let fastestNode = _.minBy(scatterplotData, 'latency.P99');
 
     return (
       <div className="clearfix">

--- a/web/app/js/components/LatencyOverview.jsx
+++ b/web/app/js/components/LatencyOverview.jsx
@@ -5,7 +5,7 @@ import * as d3 from 'd3';
 import './../../css/latency-overview.css';
 import './../../css/line-graph.css';
 
-const defaultSvgWidth = 900;
+const defaultSvgWidth = 874;
 const defaultSvgHeight = 350;
 const margin = { top: 20, right: 0, bottom: 30, left: 0 };
 const dataDefaults = { P50: [], P95: [], P99: [] };

--- a/web/app/js/components/ScatterPlot.jsx
+++ b/web/app/js/components/ScatterPlot.jsx
@@ -177,9 +177,19 @@ export default class ScatterPlot extends React.Component {
     let x0 = this.xScale.invert(x - highlightBarWidth);
     let x1 = this.xScale.invert(x + highlightBarWidth);
 
-    return _(data).filter(d => {
-      return d.latency.P99 <= x1 && d.latency.P99 >= x0;
-    }).orderBy('successRate', 'desc').value();
+    if (x0 === x1) {
+      // handle case where all the x points are in one column
+      let datapointsX = this.xScale(_.first(data).latency.P99);
+      if (Math.abs(x - datapointsX < highlightBarWidth)) {
+        return data;
+      } else {
+        return [];
+      }
+    } else {
+      return _(data).filter(d => {
+        return d.latency.P99 <= x1 && d.latency.P99 >= x0;
+      }).orderBy('successRate', 'desc').value();
+    }
   }
 
   updateGraph() {

--- a/web/app/js/components/ScatterPlot.jsx
+++ b/web/app/js/components/ScatterPlot.jsx
@@ -83,7 +83,11 @@ export default class ScatterPlot extends React.Component {
       .attr("height", this.state.height);
     this.overlayNode = d3.select(".overlay").node();
 
-    // when graph is initially loaded, set highlight and sidebar to first datapoint
+    this.highlightFirstDatapoint();
+  }
+
+  highlightFirstDatapoint() {
+    // when graph is initially loaded / reloaded, set highlight and sidebar to first datapoint
     let firstDatapoint = _.first(this.props.data);
     if (firstDatapoint) {
       let firstLatency = _.get(firstDatapoint, ["latency", "P99", 0, "value"]);
@@ -195,6 +199,7 @@ export default class ScatterPlot extends React.Component {
       .style("fill", d => successRateColorScale(d.successRate))
       .style("stroke", d => successRateColorScale(d.successRate));
 
+    this.highlightFirstDatapoint();
     this.overlay
       .on("mousemove", () => {
         let currXPos = d3.mouse(this.overlayNode)[0];

--- a/web/app/js/components/ScatterPlot.jsx
+++ b/web/app/js/components/ScatterPlot.jsx
@@ -240,7 +240,10 @@ export default class ScatterPlot extends React.Component {
     if (firstLabelPosition + bbox.height > this.state.height - 50) {
       // if there are a bunch of nodes at 0, the labels could extend below the chart
       // translate upward if this is the case
-      overlayTooltipYPos -= (bbox.height);
+      overlayTooltipYPos -= bbox.height;
+
+      // re-render tooltip labels, squished together
+      this.renderOverlayTooltip(nearestDatapoints, true);
     }
 
     let overlayTooltipXPos = currXPos + highlightBarWidth / 2 + baseWidth;
@@ -259,9 +262,9 @@ export default class ScatterPlot extends React.Component {
     this.sidebar.html(innerHtml.join(''));
   }
 
-  renderOverlayTooltip(data) {
+  renderOverlayTooltip(data, ignoreNodeSpacing = false) {
     this.overlayTooltip.text('');
-    let labelWithPosition = this.computeTooltipLabelPositions(data);
+    let labelWithPosition = this.computeTooltipLabelPositions(data, ignoreNodeSpacing);
 
     _.each(labelWithPosition, d => {
       this.overlayTooltip
@@ -276,7 +279,7 @@ export default class ScatterPlot extends React.Component {
     return this.yScale(datum.successRate) + circleRadius / 2 - 5;
   }
 
-  computeTooltipLabelPositions(data) {
+  computeTooltipLabelPositions(data, ignoreNodeSpacing = false) {
     // in the case that there are multiple nodes in the highlighted area,
     // try to position each label next to its corresponding node
     // if the nodes are too close together, simply list the node labels
@@ -288,15 +291,15 @@ export default class ScatterPlot extends React.Component {
     });
 
     if (_.size(positions) > 1) {
-      let shouldAutoSpace = false;
       _.each(positions, (_d, i) => {
         if (i > 0) {
           if (positions[i].computedY - positions[i - 1].computedY < 10) {
-            shouldAutoSpace = true;
+            // labels are too close together, don't label at the node Y values
+            ignoreNodeSpacing = true;
           }
         }
       });
-      if (shouldAutoSpace) {
+      if (ignoreNodeSpacing) {
         let basePos = positions[0].computedY;
         _.each(positions, (d, i) => {
           d.computedY = basePos + i * 15;

--- a/web/app/js/components/ScatterPlot.jsx
+++ b/web/app/js/components/ScatterPlot.jsx
@@ -47,13 +47,6 @@ export default class ScatterPlot extends React.Component {
     this.sidebar = d3.select(".scatterplot-display")
       .append("div").attr("class", "sidebar-tooltip");
 
-    // overlay on which to attch mouse events
-    this.overlay = this.svg.append("rect")
-      .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
-      .attr("class", "overlay")
-      .attr("width", this.state.width)
-      .attr("height", this.state.height);
-
     this.initializeVerticalHighlight();
     this.renderAxisLabels();
     this.updateGraph();
@@ -80,6 +73,15 @@ export default class ScatterPlot extends React.Component {
       .attr("class", "vertical-highlight")
       .attr("width", highlightBarWidth)
       .attr("height", this.state.height);
+
+    // overlay on which to attach mouse events
+    // attach this after all other items are attached otherwise they block mouse events
+    this.overlay = this.svg.append("rect")
+      .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+      .attr("class", "overlay")
+      .attr("width", this.state.width)
+      .attr("height", this.state.height);
+    this.overlayNode = d3.select(".overlay").node();
 
     // when graph is initially loaded, set highlight and sidebar to first datapoint
     let firstDatapoint = _.first(this.props.data);
@@ -195,7 +197,7 @@ export default class ScatterPlot extends React.Component {
 
     this.overlay
       .on("mousemove", () => {
-        let currXPos = d3.mouse(d3.select("rect").node())[0];
+        let currXPos = d3.mouse(this.overlayNode)[0];
         this.verticalHighlight.attr("transform", "translate(" + currXPos + ", 0)");
         let nearestDatapoints = this.getNearbyDatapoints(currXPos, plotData);
 

--- a/web/app/js/components/ScatterPlot.jsx
+++ b/web/app/js/components/ScatterPlot.jsx
@@ -193,6 +193,8 @@ export default class ScatterPlot extends React.Component {
   }
 
   updateGraph() {
+    this.updateScales(this.props.data);
+
     this.scatterPlot = this.svg.selectAll(".dot")
       .data(this.props.data);
 

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -146,18 +146,15 @@ export default class TabbedMetricsTable extends React.Component {
   }
 
   preprocessMetrics() {
-    let tableData = this.props.metrics;
+    let tableData = _.cloneDeep(this.props.metrics);
     let totalRequestRate = _.sumBy(this.props.metrics, "requestRate") || 0;
 
     _.each(tableData, datum => {
       datum.totalRequests = totalRequestRate;
       datum.requestDistribution = new Percentage(datum.requestRate, datum.totalRequests);
 
-      _.each(datum.latency, (d, quantile) => {
-        _.each(d, datapoint => {
-          let latencyValue = _.isNil(datapoint.value) ? null : parseInt(datapoint.value, 10);
-          datum[quantile] = latencyValue;
-        });
+      _.each(datum.latency, (value, quantile) => {
+        datum[quantile] = value;
       });
     });
 

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -72,7 +72,10 @@ export const processRollupMetrics = (rawMetrics, targetEntity) => {
         successRate = _.get(datum, gaugeAccessor);
       } else if (datum.name === "LATENCY") {
         let latencies = _.get(datum, latencyAccessor);
-        latency = _.groupBy(latencies, 'label');
+        latency = _.reduce(latencies, (mem, ea) => {
+          mem[ea.label] = _.isNil(ea.value) ? null : parseInt(ea.value, 10);
+          return mem;
+        }, {});
       }
     });
 

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -41,9 +41,9 @@ describe('MetricUtils', () => {
           requestRate: 6.1,
           successRate: 0.3770491803278688,
           latency: {
-            P95: [ { label: 'P95', value: '953' } ],
-            P99: [ { label: 'P99', value: '990' } ],
-            P50: [ { label: 'P50', value: '537' } ],
+            P95: 953,
+            P99: 990,
+            P50: 537
           },
           added: true
         }


### PR DESCRIPTION
Attempt to revive the scatterplot we once had on the deployments overview page.
Tried to make some UI improvements to address previous problems: 
- added a hover bar and tooltip that displays all of the nodes under the bar, in descending order of successRate (to correspond with their order in the chart)
- the tooltip looked weird in the empty state so I also added the max/min latencies observed there

Also cleans up the Deployments page a little when there are not any "least healthy deployments".

The colours and the whole thing could certainly use further tweaking, which I will keep doing.

![screenshot](https://user-images.githubusercontent.com/549258/34855852-d0c1393a-f6f6-11e7-9480-61f370b24ae5.png)
