### PR TITLE
Fix uuid compile error

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -429,7 +429,7 @@ var installCmd = &cobra.Command{
 			WebReplicas:        webReplicas,
 			PrometheusReplicas: prometheusReplicas,
 			ImagePullPolicy:    imagePullPolicy,
-			UUID:               uuid.NewV4().String(),
+			UUID:               uuid.Must(uuid.NewV4()).String(),
 			CliVersion:         fmt.Sprintf("conduit/cli %s", controller.Version),
 		})
 		return nil


### PR DESCRIPTION
When I execute the following command to compile conduit cli,
```
CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /out/conduit-linux ./cli
```
An error occurred:
```
cli/cmd/install.go:432:34: multiple-value uuid.NewV4() in single-value context
```
This path is to solve this error.
 