### PR TITLE
Use stdout as writer for tap command, fixes #136

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -73,13 +72,7 @@ Valid targets include:
 			return err
 		}
 
-		output, err := requestTapFromApi(client, args[1], validatedResourceType, partialReq)
-		if err != nil {
-			return err
-		}
-		_, err = fmt.Print(output)
-
-		return err
+		return requestTapFromApi(os.Stdout, client, args[1], validatedResourceType, partialReq)
 	},
 }
 
@@ -97,7 +90,7 @@ func init() {
 	tapCmd.PersistentFlags().StringVar(&path, "path", "", "Display requests with paths that start with this prefix")
 }
 
-func requestTapFromApi(client pb.ApiClient, targetName string, resourceType string, req *pb.TapRequest) (string, error) {
+func requestTapFromApi(w io.Writer, client pb.ApiClient, targetName string, resourceType string, req *pb.TapRequest) error {
 	switch resourceType {
 	case k8s.KubernetesDeployments:
 		req.Target = &pb.TapRequest_Deployment{
@@ -109,36 +102,32 @@ func requestTapFromApi(client pb.ApiClient, targetName string, resourceType stri
 			Pod: targetName,
 		}
 	default:
-		return "", fmt.Errorf("unsupported resourceType [%s]", resourceType)
+		return fmt.Errorf("unsupported resourceType [%s]", resourceType)
 	}
 
 	rsp, err := client.Tap(context.Background(), req)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return renderTap(rsp)
+	return renderTap(w, rsp)
 }
 
-func renderTap(rsp pb.Api_TapClient) (string, error) {
-	var buffer bytes.Buffer
-	w := tabwriter.NewWriter(&buffer, 0, 0, 0, ' ', tabwriter.AlignRight)
-	err := writeTapEvenToBuffer(rsp, w)
+func renderTap(w io.Writer, tapClient pb.Api_TapClient) error {
+	tableWriter := tabwriter.NewWriter(w, 0, 0, 0, ' ', tabwriter.AlignRight)
+	err := writeTapEventsToBuffer(tapClient, tableWriter)
 	if err != nil {
-		return "", err
+		return err
 	}
-	w.Flush()
+	tableWriter.Flush()
 
-	// strip left padding on the first column
-	out := string(buffer.Bytes())
-
-	return out, nil
+	return nil
 
 }
 
-func writeTapEvenToBuffer(rsp pb.Api_TapClient, w *tabwriter.Writer) error {
+func writeTapEventsToBuffer(tapClient pb.Api_TapClient, w *tabwriter.Writer) error {
 	for {
-		event, err := rsp.Recv()
+		event, err := tapClient.Recv()
 		if err == io.EOF {
 			break
 		}

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -72,7 +73,8 @@ func TestRequestTapFromApi(t *testing.T) {
 			Path:      path,
 		}
 
-		output, err := requestTapFromApi(mockApiClient, targetName, resourceType, partialReq)
+		writer := bytes.NewBufferString("")
+		err := requestTapFromApi(writer, mockApiClient, targetName, resourceType, partialReq)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -82,7 +84,7 @@ func TestRequestTapFromApi(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		expectedContent := string(goldenFileBytes)
-
+		output := writer.String()
 		if expectedContent != output {
 			t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
 		}
@@ -114,8 +116,9 @@ func TestRequestTapFromApi(t *testing.T) {
 			Authority: authority,
 			Path:      path,
 		}
+		writer := bytes.NewBufferString("")
 
-		output, err := requestTapFromApi(mockApiClient, targetName, resourceType, partialReq)
+		err := requestTapFromApi(writer, mockApiClient, targetName, resourceType, partialReq)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -125,7 +128,7 @@ func TestRequestTapFromApi(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		expectedContent := string(goldenFileBytes)
-
+		output := writer.String()
 		if expectedContent != output {
 			t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
 		}
@@ -157,8 +160,10 @@ func TestRequestTapFromApi(t *testing.T) {
 			Authority: authority,
 			Path:      path,
 		}
+		writer := bytes.NewBufferString("")
 
-		output, err := requestTapFromApi(mockApiClient, targetName, resourceType, partialReq)
+		err := requestTapFromApi(writer, mockApiClient, targetName, resourceType, partialReq)
+		output := writer.String()
 		if err == nil {
 			t.Fatalf("Expecting error, got nothing but outpus [%s]", output)
 		}


### PR DESCRIPTION
The previous implementation was only writing to the buffer after the command completed, but `tap` never completes so nothing ever got written.