### PR TITLE
fix typo error

### DIFF
--- a/cli/cmd/get_test.go
+++ b/cli/cmd/get_test.go
@@ -41,7 +41,7 @@ func TestGetPods(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns empty list if no [ods found", func(t *testing.T) {
+	t.Run("Returns empty list if no pods found", func(t *testing.T) {
 		mockClient := &public.MockConduitApiClient{}
 
 		mockClient.ListPodsResponseToReturn = &pb.ListPodsResponse{


### PR DESCRIPTION
fix typo error, change ```[ods``` to ```pods```