### PR TITLE
Revive searchbar: Add autocomplete search bar back into sidebar

### DIFF
--- a/web/app/js/components/Deployments.jsx
+++ b/web/app/js/components/Deployments.jsx
@@ -73,7 +73,7 @@ export default class Deployments extends React.Component {
     let rollupPath = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}`;
 
     let rollupRequest = this.api.fetch(rollupPath);
-    let podsRequest = this.api.fetchPods(this.props.pathPrefix);
+    let podsRequest = this.api.fetchPods();
 
     // expose serverPromise for testing
     this.serverPromise = Promise.all([rollupRequest, podsRequest])

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -89,7 +89,7 @@ export default class ServiceMesh extends React.Component {
 
     let rollupRequest = this.api.fetch(rollupPath);
     let timeseriesRequest = this.api.fetch(timeseriesPath);
-    let podsRequest = this.api.fetchPods(this.props.pathPrefix);
+    let podsRequest = this.api.fetchPods();
 
     this.serverPromise = Promise.all([rollupRequest, timeseriesRequest, podsRequest])
       .then(([metrics, ts, pods]) => {

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -1,11 +1,60 @@
+import _ from 'lodash';
+import { ApiHelpers } from './util/ApiHelpers.js';
 import { Link } from 'react-router-dom';
 import logo from './../../img/reversed_logo.png';
-import { Menu } from 'antd';
 import React from 'react';
 import Version from './Version.jsx';
+import { AutoComplete, Menu } from 'antd';
 import './../../css/sidebar.css';
 
+const searchBarWidth = 240;
+
 export default class Sidebar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.api = ApiHelpers(this.props.pathPrefix);
+    this.filterDeployments = this.filterDeployments.bind(this);
+    this.onAutocompleteSelect = this.onAutocompleteSelect.bind(this);
+    this.loadFromServer();
+
+    this.state = {
+      autocompleteValue: '',
+      deployments: []
+    };
+  }
+
+  loadFromServer() {
+    this.api.fetchPods().then(r => {
+      let deploys =  _(r.pods)
+        .groupBy('deployment')
+        .keys()
+        .sort().value();
+      this.setState({
+        deployments: deploys,
+        filteredDeployments: deploys
+      });
+    }).catch(this.handleApiError);
+  }
+
+  handleApiError(e) {
+    console.warn(e.message);
+  }
+
+  onAutocompleteSelect(deployment) {
+    let pathToDeploymentPage = `/deployment?deploy=${deployment}`;
+    this.props.history.push(pathToDeploymentPage);
+    this.setState({ autocompleteValue: '' });
+  }
+
+  filterDeployments(search) {
+    this.setState({
+      autocompleteValue: search,
+      filteredDeployments: _.filter(this.state.deployments, d => {
+        return d.indexOf(search) !== -1;
+      })
+    });
+  }
+
   render() {
     let normalizedPath = this.props.location.pathname.replace(this.props.pathPrefix, "");
 
@@ -15,6 +64,15 @@ export default class Sidebar extends React.Component {
           <div className="sidebar-headers">
             <Link to={`${this.props.pathPrefix}/servicemesh`}><img src={logo} /></Link>
           </div>
+
+          <AutoComplete
+            value={this.state.autocompleteValue}
+            dataSource={this.state.filteredDeployments}
+            style={{ width: searchBarWidth }}
+            onSelect={this.onAutocompleteSelect}
+            onSearch={this.filterDeployments}
+            placeholder="Search by deployment" />
+
           <Menu className="sidebar-menu" theme="dark" selectedKeys={[normalizedPath]}>
             <Menu.Item className="sidebar-menu-item" key="/servicemesh">
               <Link to={`${this.props.pathPrefix}/servicemesh`}>Service mesh</Link>
@@ -29,6 +87,7 @@ export default class Sidebar extends React.Component {
               <Link to="https://conduit.io/docs/" target="_blank">Documentation</Link>
             </Menu.Item>
           </Menu>
+
           <Version
             releaseVersion={this.props.releaseVersion}
             uuid={this.props.uuid} />

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { ApiHelpers } from './util/ApiHelpers.js';
+import { getPodsByDeployment } from './util/MetricUtils.js';
 import { Link } from 'react-router-dom';
 import logo from './../../img/reversed_logo.png';
 import React from 'react';
@@ -25,10 +26,8 @@ export default class Sidebar extends React.Component {
 
   loadFromServer() {
     this.api.fetchPods().then(r => {
-      let deploys =  _(r.pods)
-        .groupBy('deployment')
-        .keys()
-        .sort().value();
+      let deploys =  _.map(getPodsByDeployment(r.pods), 'name');
+
       this.setState({
         deployments: deploys,
         filteredDeployments: deploys


### PR DESCRIPTION
* Makes a request to `/pods` and populates sidebar autocomplete with the deployments from there.
* Also clean up calls to apiHelpers.fetchPods() which doesn't take an argument

![screen shot 2018-01-16 at 3 59 20 pm](https://user-images.githubusercontent.com/549258/35018439-641d780a-fad6-11e7-8e64-8045c6c944d3.png)
