### PR TITLE
Use cargo:rerun-if-changed to avoid recompiling protos

### DIFF
--- a/proxy/build.rs
+++ b/proxy/build.rs
@@ -25,10 +25,8 @@ fn build_control() {
         .build(server_files, dirs)
         .unwrap();
 
-    // recompile protobufs only if any of the proto files changes...
-    for file in dirs.iter().chain(client_files).chain(server_files) {
+    // recompile protobufs only if any of the proto files changes.
+    for file in client_files.iter().chain(server_files) {
         println!("cargo:rerun-if-changed={}", file);
     }
-    /// ...or if the build script itself changes.
-    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/proxy/build.rs
+++ b/proxy/build.rs
@@ -24,4 +24,11 @@ fn build_control() {
         .enable_server(true)
         .build(server_files, dirs)
         .unwrap();
+
+    // recompile protobufs only if any of the proto files changes...
+    for file in dirs.iter().chain(client_files).chain(server_files) {
+        println!("cargo:rerun-if-changed={}", file);
+    }
+    /// ...or if the build script itself changes.
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
As @seanmonstar noticed, the build script will currently re-compile all the protobufs regardless of whether or not they have changed, making the build much slower. 

This PR modifies it to emit `cargo:rerun-if-changed=` for all the protobuf files, so they will only be regenerated if one of them changes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>