### PR TITLE
Make proxy-deps multi-stage to remove the original source files

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -371,15 +371,8 @@ hard-coded SHA's:
 - [`Cargo.lock`](Cargo.lock)
 - [`proxy/Dockerfile-deps`](proxy/Dockerfile-deps)
 
-If any of these files change, update the Dockerfile SHA's with:
-
-```bash
-GO_DEPS_SHA=$(sh -c ". bin/_tag.sh && go_deps_sha")
-PROXY_DEPS_SHA=$(sh -c ". bin/_tag.sh && proxy_deps_sha")
-
-find . -type f -name 'Dockerfile*' -exec sed -i '' -e 's/gcr\.io\/runconduit\/go-deps:[^ ]*/gcr\.io\/runconduit\/go-deps:'$GO_DEPS_SHA'/g' {} \;
-find . -type f -name 'Dockerfile*' -exec sed -i '' -e 's/gcr\.io\/runconduit\/proxy-deps:[^ ]*/gcr\.io\/runconduit\/proxy-deps:'$PROXY_DEPS_SHA'/g' {} \;
-```
+The `bin/update-proxy-deps-shas` and `bin/update-go-deps-shas` must be run when their
+respective dependencies change.
 
 # Build Architecture
 

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -1,14 +1,21 @@
-# A base image including all vendored dependencies, for building go projects
+# Go dependencies
+#
+# Fetches all required Go dependencies. All Conduit sources are omitted from the resulting
+# image so that artifacts may be built frmo source over this image.
+#
+# When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.9.1
-
-# get dep
+# Fetch `dep` and ensure that all Go dependencies are vendored.
+FROM golang:1.9.1 as build
 RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.3.1/dep-linux-amd64 && chmod +x /usr/local/bin/dep
-
-# ensure all dependencies are vendored
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY . .
 RUN dep ensure && dep prune
 
-# remove all of the non dep related files
-RUN find . -not -name 'Gopkg*' -not -path './vendor*' -delete
+# Preserve dependency sources and build artifacts without maintaining conduit
+# sources/artifacts.
+FROM golang:1.9.1
+WORKDIR /go/src/github.com/runconduit/conduit
+COPY --from=build /go/src/github.com/runconduit/conduit/vendor     vendor
+COPY --from=build /go/src/github.com/runconduit/conduit/Gopkg.toml Gopkg.toml
+COPY --from=build /go/src/github.com/runconduit/conduit/Gopkg.lock Gopkg.lock

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -1,7 +1,7 @@
 # Go dependencies
 #
 # Fetches all required Go dependencies. All Conduit sources are omitted from the resulting
-# image so that artifacts may be built frmo source over this image.
+# image so that artifacts may be built from source over this image.
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -2,7 +2,7 @@
 
 set -eu
 
-# Updates the tag for `runconduit/go-deps` across all Dockerfiles in this repository.F
+# Updates the tag for `runconduit/go-deps` across all Dockerfiles in this repository.
 
 sha=$(. bin/_tag.sh ; go_deps_sha)
 

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+# Updates the tag for `runconduit/go-deps` across all Dockerfiles in this repository.F
+
+sha=$(. bin/_tag.sh ; go_deps_sha)
+
+for f in $( grep -lR --include=Dockerfile\* go-deps: . ) ; do
+    sed -Ei '' -e "s|runconduit/go-deps:[^ ]+|runconduit/go-deps:${sha}|" "$f"
+done

--- a/bin/update-proxy-deps-shas
+++ b/bin/update-proxy-deps-shas
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+# Updates the tag for `runconduit/proxy-deps` across all Dockerfiles in this repository.F
+
+sha=$(. bin/_tag.sh ; proxy_deps_sha)
+
+for f in $( grep -lR --include=Dockerfile\* proxy-deps: . ) ; do
+    sed -Ei '' -e "s|runconduit/proxy-deps:[^ ]+|runconduit/proxy-deps:${sha}|" "$f"
+done

--- a/bin/update-proxy-deps-shas
+++ b/bin/update-proxy-deps-shas
@@ -2,7 +2,7 @@
 
 set -eu
 
-# Updates the tag for `runconduit/proxy-deps` across all Dockerfiles in this repository.F
+# Updates the tag for `runconduit/proxy-deps` across all Dockerfiles in this repository.
 
 sha=$(. bin/_tag.sh ; proxy_deps_sha)
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:5c2e158c as golang
+FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
 COPY controller controller

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:c29bbc7a as golang
+FROM gcr.io/runconduit/go-deps:5c2e158c as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:c29bbc7a as golang
+FROM gcr.io/runconduit/go-deps:5c2e158c as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:5c2e158c as golang
+FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:5c2e158c as golang
+FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:c29bbc7a as golang
+FROM gcr.io/runconduit/go-deps:5c2e158c as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,8 +1,6 @@
 # Proxy build and runtime
 #
 # Builds a slim runtime image with the conduit-proxy binary.
-#
-# When this file is changed, you must run `bin/update-proxy-deps-shas`.
 
 ## Build the rust proxy into a binary.
 #

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -2,13 +2,12 @@
 #
 # Builds a slim runtime image with the conduit-proxy binary.
 #
-# When this file is changed, `proxy/Dockerfile` must be updated with a new tag, as output
-# by `( bin/_tag.sh ; proxy_deps_sha )`.
+# When this file is changed, you must run `bin/update-proxy-deps-shas`.
 
 ## Build the rust proxy into a binary.
 #
 # If the RELEASE arg is set and non-empty, a release artifact is built.
-FROM gcr.io/runconduit/proxy-deps:daa576f2 as build
+FROM gcr.io/runconduit/proxy-deps:98588d89 as build
 WORKDIR /usr/src/conduit
 # Ranked roughly from least to most likely to change. Cargo.lock is the least likely
 # because it is supposed to be cached in the deps base image.

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,7 +1,6 @@
 # Proxy build and runtime
 #
-# Fetches all required rust dependencies and caches library artifacts. All sources are
-# omitted from the resulting image so that.
+# Builds a slim runtime image with the conduit-proxy binary.
 #
 # When this file is changed, `proxy/Dockerfile` must be updated with a new tag, as output
 # by `( bin/_tag.sh ; proxy_deps_sha )`.

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,9 +1,18 @@
-## compile rust proxy
-FROM gcr.io/runconduit/proxy-deps:e01062fe as build
+# Proxy build and runtime
+#
+# Fetches all required rust dependencies and caches library artifacts. All sources are
+# omitted from the resulting image so that.
+#
+# When this file is changed, `proxy/Dockerfile` must be updated with a new tag, as output
+# by `( bin/_tag.sh ; proxy_deps_sha )`.
+
+## Build the rust proxy into a binary.
+#
+# If the RELEASE arg is set and non-empty, a release artifact is built.
+FROM gcr.io/runconduit/proxy-deps:daa576f2 as build
 WORKDIR /usr/src/conduit
 # Ranked roughly from least to most likely to change. Cargo.lock is the least likely
 # because it is supposed to be cached in the deps base image.
-COPY Cargo.toml Cargo.lock ./
 COPY codegen ./codegen
 COPY futures-mpsc-lossy ./futures-mpsc-lossy
 COPY tower-h2 ./tower-h2
@@ -19,7 +28,7 @@ RUN if [ -z "$RELEASE" ]; \
     else cargo build -p conduit-proxy --release && mv target/release/conduit-proxy target/conduit-proxy ; \
     fi
 
-## package runtime
+## Install the proxy binary into the base runtime image.
 FROM gcr.io/runconduit/base:2017-10-30.01
 COPY --from=build /usr/src/conduit/target/conduit-proxy /usr/local/bin/conduit-proxy
 ENV CONDUIT_PROXY_LOG=info

--- a/proxy/Dockerfile-deps
+++ b/proxy/Dockerfile-deps
@@ -1,11 +1,10 @@
 # Proxy dependencies
 #
 # Fetches all required rust dependencies and caches library artifacts. All Conduit sources
-# are omitted from the resulting image so that artifacts may be built frmo source over
+# are omitted from the resulting image so that artifacts may be built from source over
 # this image.
 #
-# When this file is changed, `proxy/Dockerfile` must be updated with a new tag, as output
-# by `( bin/_tag.sh ; proxy_deps_sha )`.
+# When this file is changed, you must run `bin/update-go-deps-shas`.
 
 # Compile the application to ensure we've obtained all build dependencies and that they
 # compile.

--- a/proxy/Dockerfile-deps
+++ b/proxy/Dockerfile-deps
@@ -1,14 +1,15 @@
-# WARNING: because whether or not to build a new deps image is based on 
-#          the SHA of `Cargo.lock`, changes to this Dockerfile will NOT 
-#          cause a new deps image to be built. If you change anything in 
-#          this file, it is necessary to also change `Cargo.lock`, such 
-#          as by appending a newline, to cause the deps image to be 
-#          rebuilt.
+# Proxy dependencies
 #
-#          See https://github.com/runconduit/conduit/issues/115 for more
-#          information.
+# Fetches all required rust dependencies and caches library artifacts. All Conduit sources
+# are omitted from the resulting image so that artifacts may be built frmo source over
+# this image.
+#
+# When this file is changed, `proxy/Dockerfile` must be updated with a new tag, as output
+# by `( bin/_tag.sh ; proxy_deps_sha )`.
 
-FROM rust:1.23.0
+# Compile the application to ensure we've obtained all build dependencies and that they
+# compile.
+FROM rust:1.23.0 as build
 WORKDIR /usr/src/conduit
 COPY codegen ./codegen
 COPY futures-mpsc-lossy ./futures-mpsc-lossy
@@ -20,8 +21,16 @@ COPY tower-grpc ./tower-grpc
 COPY Cargo.toml Cargo.lock ./
 COPY proto ./proto
 COPY proxy ./proxy
+RUN cargo fetch
+RUN cargo build -p conduit-proxy
+RUN cargo build -p conduit-proxy --release
 
-# Cache as much as possible; but don't keep aroud the artifact or things might get
-# confusing.
-RUN cargo build -p conduit-proxy           && rm target/debug/conduit-proxy
-RUN cargo build -p conduit-proxy --release && rm target/release/conduit-proxy
+# Preserve dependency sources and build artifacts without maintaining conduit
+# sources/artifacts.
+FROM rust:1.23.0
+WORKDIR /usr/src/conduit
+COPY --from=build $CARGO_HOME                           $CARGO_HOME
+COPY --from=build /usr/src/conduit/target/debug/deps    target/debug/deps
+COPY --from=build /usr/src/conduit/target/release/deps  target/release/deps
+COPY --from=build /usr/src/conduit/Cargo.toml           Cargo.toml
+COPY --from=build /usr/src/conduit/Cargo.lock           Cargo.lock

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:c29bbc7a as golang
+FROM gcr.io/runconduit/go-deps:5c2e158c as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:5c2e158c as golang
+FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller


### PR DESCRIPTION
Previously, proxy-deps included the entire source tree for local rust
projects. This can cause build conflicts when files are renamed.

By adopting a multi-stage build for the proxy-deps image, we can be sure
that we only preserve essential dependencies & manifests in the
proxy-deps image.

Fix #159