### PR TITLE
Destinations: Recognize ".svc.cluster.local" and ".svc"

### DIFF
--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -144,8 +144,7 @@ func (s *server) localKubernetesServiceIdFromDNSName(host string) (*string, erro
 		return nil, err
 	}
 
-	// Verify that `host` ends with ".svc.$zone", ".svc.cluster.local," or ".svc",
-	// but not ".svc.".
+	// Verify that `host` ends with ".svc.$zone", ".svc.cluster.local," or ".svc".
 	matched := false
 	if len(s.k8sDNSZoneLabels) > 0 {
 		hostLabels, matched = maybeStripSuffixLabels(hostLabels, s.k8sDNSZoneLabels)

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -18,11 +18,12 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 		{"cluster.local", "", nil, true},
 		{"cluster.local", "name", nil, false},
 		{"cluster.local", "name.ns", nil, false},
-		{"cluster.local", "name.ns.svc", nil, false},
+		{"cluster.local", "name.ns.svc", &ns_name, false},
 		{"cluster.local", "name.ns.pod", nil, false},
 		{"cluster.local", "name.ns.other", nil, false},
 		{"cluster.local", "name.ns.svc.cluster", nil, false},
 		{"cluster.local", "name.ns.svc.cluster.local", &ns_name, false},
+		{"cluster.local", "name.ns.svc.other.local", nil, false},
 		{"cluster.local", "name.ns.pod.cluster.local", nil, false},
 		{"cluster.local", "name.ns.other.cluster.local", nil, false},
 		{"cluster.local", "name.ns.cluster.local", nil, false},
@@ -31,14 +32,22 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
 		{"cluster.local", "name.ns.svc.something.cluster.local", nil, false},
 		{"cluster.local", "something.name.ns.svc.cluster.local", nil, true},
-		{"k8s.example.com", "name.ns.svc.cluster.local", nil, false},
+		{"k8s.example.com", "name.ns.svc.cluster.local", &ns_name, false},
+		{"k8s.example.com", "name.ns.svc.cluster.local.k8s.example.com", nil, false},
 		{"k8s.example.com", "name.ns.svc.k8s.example.com", &ns_name, false},
 		{"k8s.example.com", "name.ns.svc.k8s.example.org", nil, false},
 		{"cluster.local", "name.ns.svc.k8s.example.com", nil, false},
 		{"", "name.ns.svc", &ns_name, false},
-		{"", "name.ns.svc.cluster.local", nil, false},
+		{"", "name.ns.svc.cluster.local", &ns_name, false},
+		{"", "name.ns.svc.cluster.local.", &ns_name, false},
+		{"", "name.ns.svc.other.local", nil, false},
 		{"example", "name.ns.svc.example", &ns_name, false},
+		{"example", "name.ns.svc.example.", &ns_name, false},
 		{"example", "name.ns.svc.example.com", nil, false},
+		{"example", "name.ns.svc.cluster.local", &ns_name, false},
+
+		// XXX: See the comment about this issue in localKubernetesServiceIdFromDNSName.
+		{"cluster.local", "name.ns.svc.", &ns_name, false},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Previously these alternative ways of addressing a service were not
recognized by Conduit. Kubernetes doesn't guarantee these ways to
work but in practice some people are relying on them working since
minikube and some (all?) cloud providers, at least, support them.

Recognize these names in the Destinations service.

Later, we'll likely change the mechanics of this, especially when
TLS support is added, but this will work for now and that future change
should be transparent. The way this was done makes it easy to do that
behavior since it doesn't touch any of the configuration files for the
controller (`conduit install`) or for the proxies (`conduit inject`).

The existing unit tests were updated and expanded for the new
behavior.

Signed-off-by: Brian Smith <brian@briansmith.org>