### PR TITLE
Remove DOCKER_FORCE_BUILD, disable symbolic tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,13 +106,14 @@ jobs:
       before_script:
         - gcloud docker --authorize-only
         - bin/docker-pull-deps
+        - bin/docker-pull master
         - |
           export CONDUIT_TAG=$(. bin/_tag.sh ; clean_head_root_tag)
           echo "CONDUIT_TAG=${CONDUIT_TAG}"
         - export PROXY_RELEASE=1 BUILD_DEBUG=1 DOCKER_TRACE=1
 
       script:
-        - bin/docker-build $CONDUIT_TAG
+        - bin/docker-build
 
       after_success:
         - bin/docker-push-deps

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -25,16 +25,8 @@ docker_repo() {
     echo "$name"
 }
 
-docker_tags() {
-    image="$1"
-    docker image ls "${image}" | sed 1d | awk '{print $2}'
-}
-
 docker_build() {
-    dir="$1"
-    shift
-
-    repo="$1"
+    repo=$(docker_repo "$1")
     shift
 
     tag="$1"
@@ -50,57 +42,14 @@ docker_build() {
         output="/dev/stderr"
     fi
 
-    # Even when we haven't built an image locally, we can try to use a known prior version
-    # of the image to prevent rebuilding layers.
-    if [ -n "${DOCKER_BUILD_CACHE_FROM_TAG:-}" ]; then
-        if [ -n "$extra" ]; then
-            extra="$extra "
-        fi
-        extra="${extra}--cache-from='$repo:${DOCKER_BUILD_CACHE_FROM_TAG}'"
-    fi
-
-    log_debug "  :; docker build $dir -t $repo:$tag -f $file $extra"
-    docker build "$dir" \
+    log_debug "  :; docker build . -t $repo:$tag -f $file $extra"
+    docker build . \
         -t "$repo:$tag" \
         -f "$file" \
         $extra \
         > "$output"
 
     echo "$repo:$tag"
-}
-
-# Builds a docker image if it doesn't exist and/or can't be found.
-#
-# If the `tag` is 'latest', an image will always be built.
-docker_maybe_build() {
-    dir="$1"
-    shift
-
-    repo="$1"
-    shift
-
-    tag="$1"
-    shift
-
-    file="$1"
-    shift
-
-    extra="$@"
-
-    if [ -z "${DOCKER_FORCE_BUILD:-}" ]; then
-        docker pull "${repo}:${tag}" >/dev/null 2>&1 || true
-
-        for t in $(docker_tags "${repo}:${tag}") ; do
-            if [ "$t" = "$tag" ]; then
-                docker tag "${repo}:${tag}" "${repo}:latest" >/dev/null
-
-                echo "${repo}:${tag}"
-                return 0
-            fi
-        done
-    fi
-
-    docker_build "$dir" "$repo" "$tag" "$file" $extra
 }
 
 docker_pull() {

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -14,22 +14,25 @@ go_deps_sha() {
     cat Gopkg.lock Dockerfile-go-deps | shasum - | awk '{print $1}' |cut -c 1-8
 }
 
-dir_tag() {
-    dir="$1"
-    echo "git-$(git log -n 1 --format="%h" "$dir")"
+clean_head() {
+    git diff-index --quiet HEAD --
 }
 
-clean_head_root_tag() {
-    if git diff-index --quiet HEAD -- ; then
-        echo "git-$(git_sha HEAD)"
+head_root_tag() {
+    if clean_head ; then
+        clean_head_root_tag
     else
-        echo "Commit unstaged changes or set an explicit build tag." >&2
-        exit 3
+        echo "dev-$(git_sha HEAD)-$USER"
     fi
 }
 
-master_root_tag() {
-    echo "git-$(git_sha master)"
+clean_head_root_tag() {
+    if clean_head ; then
+        echo "git-$(git_sha HEAD)"
+    else
+        echo "Commit unstaged changes." >&2
+        exit 3
+    fi
 }
 
 validate_tag() {

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -2,20 +2,13 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
 
-bin/docker-build-controller  "$tag"
-bin/docker-build-web         "$tag"
-bin/docker-build-proxy       "$tag"
-bin/docker-build-proxy-init  "$tag"
-bin/docker-build-cli         "$tag"
+bin/docker-build-controller
+bin/docker-build-web
+bin/docker-build-proxy
+bin/docker-build-proxy-init
+bin/docker-build-cli

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -1,14 +1,20 @@
 #!/bin/sh
 
-# Builds our base runtime docker image.
+# Builds (or pulls) our base runtime docker image.
 
 set -eu
 
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    exit 64
+fi
+
 . bin/_docker.sh
 
-tag="${1:-2017-10-30.01}"
+tag="2017-10-30.01"
 
-docker_maybe_build . \
-    "$(docker_repo base)" \
-    "${tag}" \
-    Dockerfile-base
+if (docker_pull base "${tag}"); then
+    echo "$(docker_repo base):${tag}"
+else
+    docker_build base "${tag}" Dockerfile-base
+fi

--- a/bin/docker-build-cli
+++ b/bin/docker-build-cli
@@ -2,23 +2,15 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
 
+. bin/_docker.sh
+. bin/_tag.sh
 
 # Build gcr.io/runconduit/cli-bin, which is used by cli/Dockerfile.
-bin/docker-build-cli-bin "${tag}" >/dev/null
+bin/docker-build-cli-bin >/dev/null
 
-docker_maybe_build . \
-    "$(docker_repo cli)" \
-    "${tag}" \
-    cli/Dockerfile
+docker_build cli "$(head_root_tag)" cli/Dockerfile

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -2,36 +2,30 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
+
+. bin/_docker.sh
+. bin/_tag.sh
 
 dockerfile=cli/Dockerfile-bin
 
 validate_go_deps_tag $dockerfile
 
 (
-    unset DOCKER_FORCE_BUILD
     bin/docker-build-base
     bin/docker-build-go-deps
 ) >/dev/null
 
-IMG=$(docker_maybe_build . \
-    "$(docker_repo cli-bin)" \
-    "${tag}" \
-    $dockerfile)
 
+docker_build cli-bin $(head_root_tag) $dockerfile
+IMG=$(docker_repo cli-bin):$(head_root_tag)
 ID=$(docker create "$IMG")
 
-for OS in linux macos ; do
+# copy the newly built conduit cli binaries to the local system
+for OS in darwin linux windows ; do
     DIR="target/cli/${OS}"
     mkdir -p "$DIR"
 

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -2,29 +2,21 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
+
+. bin/_docker.sh
+. bin/_tag.sh
 
 dockerfile=controller/Dockerfile
 
 validate_go_deps_tag $dockerfile
 
 (
-    unset DOCKER_FORCE_BUILD
     bin/docker-build-base
     bin/docker-build-go-deps
 ) >/dev/null
 
-docker_maybe_build . \
-    "$(docker_repo controller)" \
-    "${tag}" \
-    $dockerfile
+docker_build controller "$(head_root_tag)" $dockerfile

--- a/bin/docker-build-go-deps
+++ b/bin/docker-build-go-deps
@@ -1,13 +1,21 @@
 #!/bin/sh
 
+# Builds (or pulls) our go-deps docker image.
+
 set -eu
+
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    exit 64
+fi
 
 . bin/_docker.sh
 . bin/_tag.sh
 
-image=$(docker_maybe_build . \
-    "$(docker_repo go-deps)" \
-    "$(go_deps_sha)" \
-    Dockerfile-go-deps)
+tag=$(go_deps_sha)
 
-echo "$image"
+if (docker_pull go-deps "${tag}"); then
+    echo "$(docker_repo go-deps):${tag}"
+else
+    docker_build go-deps "${tag}" Dockerfile-go-deps
+fi

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -2,31 +2,21 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
+
+. bin/_docker.sh
+. bin/_tag.sh
 
 dockerfile=proxy/Dockerfile
 
 validate_proxy_deps_tag $dockerfile
 
 (
-    unset DOCKER_FORCE_BUILD
     bin/docker-build-base
     bin/docker-build-proxy-deps
 ) >/dev/null
 
-# Build release images by default
-docker_build . \
-    "$(docker_repo proxy)" \
-    "${tag}" \
-    $dockerfile \
-    --build-arg="RELEASE=${PROXY_RELEASE:-1}"
+docker_build proxy "$(head_root_tag)" $dockerfile --build-arg="RELEASE=${PROXY_RELEASE:-1}"

--- a/bin/docker-build-proxy-deps
+++ b/bin/docker-build-proxy-deps
@@ -1,13 +1,21 @@
 #!/bin/sh
 
+# Builds (or pulls) our proxy-deps docker image.
+
 set -eu
+
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    exit 64
+fi
 
 . bin/_docker.sh
 . bin/_tag.sh
 
-image=$(docker_maybe_build . \
-    "$(docker_repo proxy-deps)" \
-    "$(proxy_deps_sha)" \
-    proxy/Dockerfile-deps)
+tag=$(proxy_deps_sha)
 
-echo "$image"
+if (docker_pull proxy-deps "${tag}"); then
+    echo "$(docker_repo proxy-deps):${tag}"
+else
+    docker_build proxy-deps "${tag}" proxy/Dockerfile-deps
+fi

--- a/bin/docker-build-proxy-init
+++ b/bin/docker-build-proxy-init
@@ -2,29 +2,21 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
+
+. bin/_docker.sh
+. bin/_tag.sh
 
 dockerfile=proxy-init/Dockerfile
 
 validate_go_deps_tag $dockerfile
 
 (
-    unset DOCKER_FORCE_BUILD
     bin/docker-build-base
     bin/docker-build-go-deps
 ) >/dev/null
 
-docker_maybe_build . \
-    "$(docker_repo proxy-init)" \
-    "${tag}" \
-    $dockerfile
+docker_build proxy-init "$(head_root_tag)" $dockerfile

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -2,29 +2,21 @@
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64
 fi
+
+. bin/_docker.sh
+. bin/_tag.sh
 
 dockerfile=web/Dockerfile
 
 validate_go_deps_tag $dockerfile
 
 (
-    unset DOCKER_FORCE_BUILD
     bin/docker-build-base
     bin/docker-build-go-deps
 ) >/dev/null
 
-docker_maybe_build . \
-    "$(docker_repo web)" \
-    "${tag}" \
-    $dockerfile
+docker_build web "$(head_root_tag)" $dockerfile

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -5,21 +5,14 @@ set -eu
 . bin/_docker.sh
 . bin/_tag.sh
 
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
-    tag="${1:-}"
-else
-    echo "usage: $(basename $0) [tag]" >&2
-    exit 64
-fi
-
 docker_image() {
     repo="$(docker_repo "$1")"
     docker image ls \
         --format "{{printf \"%-16s %-10s\" \"$1\" \"${2}\"}} {{.Size | printf \"%6s\"}}  {{.ID}}  {{.CreatedAt}}" \
         "${repo}:${2}"
 }
+
+tag=$(head_root_tag)
 
 docker_image controller   "${tag}"
 docker_image proxy        "${tag}"

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -2,14 +2,10 @@
 
 set -eu
 
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
+if [ $# -eq 1 ]; then
     tag="${1:-}"
 else
-    echo "usage: $(basename $0) [tag]" >&2
+    echo "usage: $(basename $0) tag" >&2
     exit 64
 fi
 

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -5,6 +5,6 @@ set -eu
 . bin/_docker.sh
 . bin/_tag.sh
 
-docker_pull base         2017-10-30.01     || true
-docker_pull go-deps      "$(go_deps_sha)"    || true
-docker_pull proxy-deps   "$(proxy_deps_sha)"    || true
+docker_pull base       2017-10-30.01       || true
+docker_pull go-deps    "$(go_deps_sha)"    || true
+docker_pull proxy-deps "$(proxy_deps_sha)" || true

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -2,14 +2,10 @@
 
 set -eu
 
-. bin/_tag.sh
-
-if [ $# -eq 0 ]; then
-    tag="$(clean_head_root_tag)"
-elif [ $# -eq 1 ]; then
+if [ $# -eq 1 ]; then
     tag="${1:-}"
 else
-    echo "usage: $(basename $0) [tag]" >&2
+    echo "usage: $(basename $0) tag" >&2
     exit 64
 fi
 

--- a/bin/root-tag
+++ b/bin/root-tag
@@ -2,4 +2,4 @@
 
 . bin/_tag.sh
 
-clean_head_root_tag
+head_root_tag

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -5,8 +5,9 @@ COPY cli cli
 COPY controller controller
 COPY pkg pkg
 RUN mkdir -p /out
+RUN CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -o /out/conduit-darwin ./cli
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /out/conduit-linux ./cli
-RUN CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -o /out/conduit-macos ./cli
+RUN CGO_ENABLED=0 GOOS=windows go build -a -installsuffix cgo -o /out/conduit-windows ./cli
 
 ## export without sources & depdenndencies
 FROM gcr.io/runconduit/base:2017-10-30.01


### PR DESCRIPTION
Remove DOCKER_FORCE_BUILD, disable symbolic tags

DOCKER_FORCE_BUILD, combined with symbolic tags, added complexity and
risk of running unintended versions of the code.

This change removes DOCKER_FORCE_BUILD, and sets all Docker tags
programmatically. The decision to pull or build has been moved up the
stack from _docker.sh to the docker-build-* scripts. Workflows that
want to favor docker pulls (like ci), can do so explicitly via
docker-pull.

fixes #141

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

---

### Previous summary for posterity

DOCKER_FORCE_BUILD=1 is a common development build pattern.

Replace (and invert) DOCKER_FORCE_BUILD with DOCKER_TRY_PULL. Default behavior
(with DOCKER_TRY_PULL unset) is to only rely on local docker repo for cached
images. DOCKER_TRY_PULL is enabled in CI. Also remove
DOCKER_BUILD_CACHE_FROM_TAG as it was unused.

fixes #141

# Performance validation

Tested the build before/after code change, with and without force flag, and on empty local docker repo, and subsequent build:

|                 | 1st build | 2nd build |
|-----------------|-----------|-----------|
| no force/before |     3m35s |        8s |
| no force/after  |     3m36s |        8s |
| force/before    |     6m05s |        8s |
| force/after     |     6m03s |        8s |
