### PR TITLE
Print user's system information when status command encounters an error

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
 	"strings"
 
 	"github.com/runconduit/conduit/controller/api/public"
@@ -19,13 +18,14 @@ import (
 
 const lineWidth = 80
 
+var sysInfo bool
+
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check your Conduit installation for potential problems.",
 	Long: `Check your Conduit installation for potential problems. The check command will perform various checks of your
 local system, the Conduit control plane, and connectivity between those. The process will exit with non-zero check if
 problems were found.`,
-	Args: cobra.NoArgs,
 	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
 
 		sh := shell.NewUnixShell()
@@ -141,5 +141,6 @@ func statusCheckResultWasError(w io.Writer) error {
 
 func init() {
 	RootCmd.AddCommand(checkCmd)
+	checkCmd.Flags().BoolVarP(&sysInfo, "sys-info", "s", false, "Print system information for debugging purposes")
 	addControlPlaneNetworkingArgs(checkCmd)
 }

--- a/pkg/k8s/kubectl_test.go
+++ b/pkg/k8s/kubectl_test.go
@@ -19,6 +19,7 @@ func TestKubectlVersion(t *testing.T) {
 			"Client Version: v2.7.1\nServer Version: v1.8.0":        {{2, 7, 1}, {1, 8, 0}},
 			"Client Version: v2.0.1\nServer Version: v1.8.0":        {{2, 0, 1}, {1, 8, 0}},
 			"Client Version: v1.9.0-beta.2\nServer Version: v1.8.0": {{1, 9, 0}, {1, 8, 0}},
+			"Client Version: v1.8.4\n":                              {{1, 8, 4}, {0, 0, 0}},
 		}
 
 		shell := &shell.MockShell{}

--- a/pkg/k8s/kubectl_test.go
+++ b/pkg/k8s/kubectl_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestKubectlVersion(t *testing.T) {
 	t.Run("Correctly parses a Version string", func(t *testing.T) {
-		versions := map[string][3]int{
-			"Client Version: v1.8.4":        {1, 8, 4},
-			"Client Version: v2.7.1":        {2, 7, 1},
-			"Client Version: v2.0.1":        {2, 0, 1},
-			"Client Version: v1.9.0-beta.2": {1, 9, 0},
+		versions := map[string][2][3]int{
+			"Client Version: v1.8.4\nServer Version: v1.8.0":        {{1, 8, 4}, {1, 8, 0}},
+			"Client Version: v2.7.1\nServer Version: v1.8.0":        {{2, 7, 1}, {1, 8, 0}},
+			"Client Version: v2.0.1\nServer Version: v1.8.0":        {{2, 0, 1}, {1, 8, 0}},
+			"Client Version: v1.9.0-beta.2\nServer Version: v1.8.0": {{1, 9, 0}, {1, 8, 0}},
 		}
 
 		shell := &shell.MockShell{}
@@ -35,8 +35,11 @@ func TestKubectlVersion(t *testing.T) {
 				t.Fatalf("Error parsing string: %v", err)
 			}
 
-			if actualVersion != expectedVersion {
-				t.Fatalf("Expecting %s to be parsed into %v but got %v", k, expectedVersion, actualVersion)
+			if actualVersion.Client != expectedVersion[0] {
+				t.Fatalf("Expecting %s to be parsed into %v but got %v", k, expectedVersion[0], actualVersion.Client)
+			}
+			if actualVersion.Server != expectedVersion[1] {
+				t.Fatalf("Expecting %s to be parsed into %v but got %v", k, expectedVersion[1], actualVersion.Server)
 			}
 		}
 	})


### PR DESCRIPTION
As described in #139, when the conduit status check encounters an error of some kind, we need a way useful information in order to diagnose issues that may be causing the error. This PR displays version information for Conduit, k8s and the user's system build. There needs to be some discussion on whether this information is enough of if we need more info that could be useful in debugging

This is what the currently looks like:
```
kubectl: is in $PATH............................................................[ok]
kubectl: has compatible version.................................................[ok]
kubectl: can talk to Kubernetes cluster.........................................[ok]
kubernetes-api: can initialize the client.......................................[ok]
kubernetes-api: can query the Kubernetes API....................................[ok]
conduit-api: can retrieve status via gRPC.......................................[ERROR] -- POST to Conduit API endpoint [https://192.168.99.100:8443/api/v1/namespaces/conduit/services/http:api:http/proxy/api/v1/SelfCheck] returned HTTP status [404 Not Found]

Status check results are [ERROR]

----- System Information -----
conduit_server_version=v0.1.1
conduit_client_version:=v0.1.1
k8s_client_version=v1.8.4
k8s_server_version=v1.8.0
uname=Darwin Kernel Version 16.7.0: Mon Nov 13 21:56:25 PST 2017; root:xnu-3789.72.11~1/RELEASE_X86_64

```
fixes #139 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>