### PR TITLE
Remove font colouring on the call to action

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -69,7 +69,6 @@
 
 .call-to-action .action {
   font-size: inherit;
-  color: var(--white);
 }
 
 .conduit-autocomplete {


### PR DESCRIPTION
Remove inadvertent colour change.

In #184 I made this line's css valid, but that means the text turned white, which we didn't actually want. remove this line.