### PR TITLE
Classify non-gRPC status codes for HTTP telemetry

### DIFF
--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -246,16 +246,46 @@ func main() {
 		sourceIp := randomPod(allPods, nil)
 		targetIp := randomPod(allPods, sourceIp)
 
-		// gRPC
 		req := &pb.ReportRequest{
 			Process: &pb.Process{
 				ScheduledInstance:  "hello-1mfa0",
 				ScheduledNamespace: "people",
 			},
-			ClientTransports: []*pb.ClientTransport{},
-			ServerTransports: []*pb.ServerTransport{},
-			Proxy:            pb.ReportRequest_INBOUND,
+			ClientTransports: []*pb.ClientTransport{
+				// TCP
+				&pb.ClientTransport{
+					TargetAddr: &common.TcpAddress{
+						Ip:   targetIp,
+						Port: randomPort(),
+					},
+					Connects: count,
+					Disconnects: []*pb.TransportSummary{
+						&pb.TransportSummary{
+							DurationMs: uint64(randomCount()),
+							BytesSent:  uint64(randomCount()),
+						},
+					},
+					Protocol: common.Protocol_TCP,
+				},
+			},
+			ServerTransports: []*pb.ServerTransport{
+				// TCP
+				&pb.ServerTransport{
+					SourceIp: sourceIp,
+					Connects: count,
+					Disconnects: []*pb.TransportSummary{
+						&pb.TransportSummary{
+							DurationMs: uint64(randomCount()),
+							BytesSent:  uint64(randomCount()),
+						},
+					},
+					Protocol: common.Protocol_TCP,
+				},
+			},
+			Proxy: pb.ReportRequest_INBOUND,
 			Requests: []*pb.RequestScope{
+
+				// gRPC
 				&pb.RequestScope{
 					Ctx: &pb.RequestCtx{
 						SourceIp: sourceIp,
@@ -278,24 +308,8 @@ func main() {
 						},
 					},
 				},
-			},
-		}
 
-		_, err = client.Report(context.Background(), req)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		// HTTP/2
-		req = &pb.ReportRequest{
-			Process: &pb.Process{
-				ScheduledInstance:  "hello-h2-1mfa0",
-				ScheduledNamespace: "people-h2",
-			},
-			ClientTransports: []*pb.ClientTransport{},
-			ServerTransports: []*pb.ServerTransport{},
-			Proxy:            pb.ReportRequest_INBOUND,
-			Requests: []*pb.RequestScope{
+				// HTTP/2
 				&pb.RequestScope{
 					Ctx: &pb.RequestCtx{
 						SourceIp: sourceIp,
@@ -319,49 +333,6 @@ func main() {
 					},
 				},
 			},
-		}
-
-		_, err = client.Report(context.Background(), req)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		// TCP
-		req = &pb.ReportRequest{
-			Process: &pb.Process{
-				ScheduledInstance:  "hello-tcp-1mfa0",
-				ScheduledNamespace: "people-tcp",
-			},
-			ClientTransports: []*pb.ClientTransport{
-				&pb.ClientTransport{
-					TargetAddr: &common.TcpAddress{
-						Ip:   targetIp,
-						Port: randomPort(),
-					},
-					Connects: count,
-					Disconnects: []*pb.TransportSummary{
-						&pb.TransportSummary{
-							DurationMs: uint64(randomCount()),
-							BytesSent:  uint64(randomCount()),
-						},
-					},
-					Protocol: common.Protocol_TCP,
-				},
-			},
-			ServerTransports: []*pb.ServerTransport{
-				&pb.ServerTransport{
-					SourceIp: sourceIp,
-					Connects: count,
-					Disconnects: []*pb.TransportSummary{
-						&pb.TransportSummary{
-							DurationMs: uint64(randomCount()),
-							BytesSent:  uint64(randomCount()),
-						},
-					},
-					Protocol: common.Protocol_TCP,
-				},
-			},
-			Proxy: pb.ReportRequest_INBOUND,
 		}
 
 		_, err = client.Report(context.Background(), req)

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -146,6 +146,19 @@ func randomH2Eos(count uint32) (eos []*pb.EosScope) {
 	return
 }
 
+func randomH2Responses(count uint32) (rsps []*pb.ResponseScope) {
+	for i := uint32(0); i < count; i++ {
+		eos = append(rsps, &pb.ResponseScope{
+			Ctx: &pb.ResponseCtx{
+				HttpStatusCode: randomHttpResponseCode(),
+			},
+			ResponseLatencies: randomLatencies(count),
+			Ends:              randomH2Eos(count),
+		})
+	}
+	return
+}
+
 func randomGrpcResponseCode() uint32 {
 	return uint32(grpcResponseCodes[rand.Intn(len(grpcResponseCodes))])
 }
@@ -265,7 +278,7 @@ func main() {
 						},
 						Authority: "world.greeting:7778",
 						Method:    &common.HttpMethod{Type: &common.HttpMethod_Registered_{Registered: common.HttpMethod_GET}},
-						Path:      "/World/Greeting",
+						Path:      "/World/GreetingGrpc",
 					},
 					Count: count,
 					Responses: []*pb.ResponseScope{
@@ -305,7 +318,7 @@ func main() {
 						},
 						Authority: "world.greeting:7778",
 						Method:    &common.HttpMethod{Type: &common.HttpMethod_Registered_{Registered: common.HttpMethod_GET}},
-						Path:      "/World/Greeting",
+						Path:      "/World/GreetingH2",
 					},
 					Count: count,
 					Responses: []*pb.ResponseScope{

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -24,10 +24,72 @@ import (
 /* A simple script for posting simulated telemetry data to the proxy api */
 
 var (
-	responseCodes = []codes.Code{
+	grpcResponseCodes = []codes.Code{
 		codes.OK,
 		codes.PermissionDenied,
 		codes.Unavailable,
+	}
+
+	httpResponseCodes = []int{
+		http.StatusContinue,
+		http.StatusSwitchingProtocols,
+		http.StatusProcessing,
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusAccepted,
+		http.StatusNonAuthoritativeInfo,
+		http.StatusNoContent,
+		http.StatusResetContent,
+		http.StatusPartialContent,
+		http.StatusMultiStatus,
+		http.StatusAlreadyReported,
+		http.StatusIMUsed,
+		http.StatusMultipleChoices,
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusSeeOther,
+		http.StatusNotModified,
+		http.StatusUseProxy,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusPaymentRequired,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusNotAcceptable,
+		http.StatusProxyAuthRequired,
+		http.StatusRequestTimeout,
+		http.StatusConflict,
+		http.StatusGone,
+		http.StatusLengthRequired,
+		http.StatusPreconditionFailed,
+		http.StatusRequestEntityTooLarge,
+		http.StatusRequestURITooLong,
+		http.StatusUnsupportedMediaType,
+		http.StatusRequestedRangeNotSatisfiable,
+		http.StatusExpectationFailed,
+		http.StatusTeapot,
+		http.StatusUnprocessableEntity,
+		http.StatusLocked,
+		http.StatusFailedDependency,
+		http.StatusUpgradeRequired,
+		http.StatusPreconditionRequired,
+		http.StatusTooManyRequests,
+		http.StatusRequestHeaderFieldsTooLarge,
+		http.StatusUnavailableForLegalReasons,
+		http.StatusInternalServerError,
+		http.StatusNotImplemented,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusHTTPVersionNotSupported,
+		http.StatusVariantAlsoNegotiates,
+		http.StatusInsufficientStorage,
+		http.StatusLoopDetected,
+		http.StatusNotExtended,
+		http.StatusNetworkAuthenticationRequired,
 	}
 
 	streamSummary = &pb.StreamSummary{
@@ -60,12 +122,12 @@ func randomLatencies(count uint32) (latencies []*pb.Latency) {
 	return
 }
 
-func randomEos(count uint32) (eos []*pb.EosScope) {
-	responseCodes := make(map[uint32]uint32)
+func randomGrpcEos(count uint32) (eos []*pb.EosScope) {
+	grpcResponseCodes := make(map[uint32]uint32)
 	for i := uint32(0); i < count; i++ {
-		responseCodes[randomResponseCode()] += 1
+		grpcResponseCodes[randomGrpcResponseCode()] += 1
 	}
-	for code, streamCount := range responseCodes {
+	for code, streamCount := range grpcResponseCodes {
 		eos = append(eos, &pb.EosScope{
 			Ctx:     &pb.EosCtx{End: &pb.EosCtx_GrpcStatusCode{GrpcStatusCode: code}},
 			Streams: streamSummaries(streamCount),
@@ -74,8 +136,22 @@ func randomEos(count uint32) (eos []*pb.EosScope) {
 	return
 }
 
-func randomResponseCode() uint32 {
-	return uint32(responseCodes[rand.Intn(len(responseCodes))])
+func randomH2Eos(count uint32) (eos []*pb.EosScope) {
+	for i := uint32(0); i < count; i++ {
+		eos = append(eos, &pb.EosScope{
+			Ctx:     &pb.EosCtx{End: &pb.EosCtx_Other{Other: true}},
+			Streams: streamSummaries(i),
+		})
+	}
+	return
+}
+
+func randomGrpcResponseCode() uint32 {
+	return uint32(grpcResponseCodes[rand.Intn(len(grpcResponseCodes))])
+}
+
+func randomHttpResponseCode() uint32 {
+	return uint32(httpResponseCodes[rand.Intn(len(httpResponseCodes))])
 }
 
 func streamSummaries(count uint32) (summaries []*pb.StreamSummary) {
@@ -170,7 +246,7 @@ func main() {
 		sourceIp := randomPod(allPods, nil)
 		targetIp := randomPod(allPods, sourceIp)
 
-		// HTTP
+		// gRPC
 		req := &pb.ReportRequest{
 			Process: &pb.Process{
 				ScheduledInstance:  "hello-1mfa0",
@@ -198,7 +274,47 @@ func main() {
 								HttpStatusCode: http.StatusOK,
 							},
 							ResponseLatencies: randomLatencies(count),
-							Ends:              randomEos(count),
+							Ends:              randomGrpcEos(count),
+						},
+					},
+				},
+			},
+		}
+
+		_, err = client.Report(context.Background(), req)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// HTTP/2
+		req = &pb.ReportRequest{
+			Process: &pb.Process{
+				ScheduledInstance:  "hello-h2-1mfa0",
+				ScheduledNamespace: "people-h2",
+			},
+			ClientTransports: []*pb.ClientTransport{},
+			ServerTransports: []*pb.ServerTransport{},
+			Proxy:            pb.ReportRequest_INBOUND,
+			Requests: []*pb.RequestScope{
+				&pb.RequestScope{
+					Ctx: &pb.RequestCtx{
+						SourceIp: sourceIp,
+						TargetAddr: &common.TcpAddress{
+							Ip:   targetIp,
+							Port: randomPort(),
+						},
+						Authority: "world.greeting:7778",
+						Method:    &common.HttpMethod{Type: &common.HttpMethod_Registered_{Registered: common.HttpMethod_GET}},
+						Path:      "/World/Greeting",
+					},
+					Count: count,
+					Responses: []*pb.ResponseScope{
+						&pb.ResponseScope{
+							Ctx: &pb.ResponseCtx{
+								HttpStatusCode: http.StatusOK,
+							},
+							ResponseLatencies: randomLatencies(count),
+							Ends:              randomH2Eos(count),
 						},
 					},
 				},

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -146,19 +146,6 @@ func randomH2Eos(count uint32) (eos []*pb.EosScope) {
 	return
 }
 
-func randomH2Responses(count uint32) (rsps []*pb.ResponseScope) {
-	for i := uint32(0); i < count; i++ {
-		eos = append(rsps, &pb.ResponseScope{
-			Ctx: &pb.ResponseCtx{
-				HttpStatusCode: randomHttpResponseCode(),
-			},
-			ResponseLatencies: randomLatencies(count),
-			Ends:              randomH2Eos(count),
-		})
-	}
-	return
-}
-
 func randomGrpcResponseCode() uint32 {
 	return uint32(grpcResponseCodes[rand.Intn(len(grpcResponseCodes))])
 }
@@ -324,7 +311,7 @@ func main() {
 					Responses: []*pb.ResponseScope{
 						&pb.ResponseScope{
 							Ctx: &pb.ResponseCtx{
-								HttpStatusCode: http.StatusOK,
+								HttpStatusCode: randomHttpResponseCode(),
 							},
 							ResponseLatencies: randomLatencies(count),
 							Ends:              randomH2Eos(count),

--- a/controller/telemetry/server.go
+++ b/controller/telemetry/server.go
@@ -406,7 +406,7 @@ func responseLabelsFor(responseScope *write.ResponseScope, eosScope *write.EosSc
 	case *write.EosCtx_Other:
 		// The stream did not end with a `grpc-status` trailer (i.e., it was
 		// not a gRPC message). Classify based on the response's HTTP status.
-		if responseScope.Ctx.HttpStatusCode < http.StatusBadRequest {
+		if responseScope.Ctx.HttpStatusCode < http.StatusInternalServerError {
 			classification = "success"
 		}
 	}

--- a/controller/telemetry/server.go
+++ b/controller/telemetry/server.go
@@ -397,7 +397,15 @@ func responseLabelsFor(responseScope *write.ResponseScope, eosScope *write.EosSc
 	classification := "failure"
 	switch x := eosScope.Ctx.End.(type) {
 	case *write.EosCtx_GrpcStatusCode:
+		// The stream ended with a `grpc-status` trailer.
+		// Classify based on the gRPC status code.
 		if x.GrpcStatusCode == uint32(codes.OK) {
+			classification = "success"
+		}
+	case *write.EosCtx_Other:
+		// The stream did not end with a `grpc-status` trailer (i.e., it was
+		// not a gRPC message). Classify based on the response's HTTP status.
+		if responseScope.Ctx.HttpStatusCode < 400 {
 			classification = "success"
 		}
 	}

--- a/controller/telemetry/server.go
+++ b/controller/telemetry/server.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"sync"
 	"time"
@@ -405,7 +406,7 @@ func responseLabelsFor(responseScope *write.ResponseScope, eosScope *write.EosSc
 	case *write.EosCtx_Other:
 		// The stream did not end with a `grpc-status` trailer (i.e., it was
 		// not a gRPC message). Classify based on the response's HTTP status.
-		if responseScope.Ctx.HttpStatusCode < 400 {
+		if responseScope.Ctx.HttpStatusCode < http.StatusBadRequest {
 			classification = "success"
 		}
 	}


### PR DESCRIPTION
Currently, all "success"/"failure" classifications in the telemetry API are made based on the `grpc-status` trailer. If the trailer is not present, then a request is assumed to have failed. As we start proxying non-gRPC traffic, the controller needs to also be aware of HTTP status codes, so that non-gRPC requests are not assumed to always fail.

I've modified the telemetry API server to classify requests based on their HTTP status codes when the `grpc-status` trailer is not present. 

I've also modified the `simulate-proxy` script to generate fake HTTP/2 traffic without the `grpc-status` trailer.

Closes #196