### PR TITLE
Use cargo frozen flag in build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,15 @@ jobs:
 
     # Compile the application and run tests.
     - stage: test
-
       language: rust
       rust: stable
       cache:
         cargo: true
+      install:
+        - cargo fetch --locked
       script:
-        - cargo check
-        - cargo test
+        - cargo check --frozen
+        - cargo test --frozen
 
     - language: go
       go: 1.9

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -20,8 +20,8 @@ COPY proto ./proto
 COPY proxy ./proxy
 ARG RELEASE
 RUN if [ -z "$RELEASE" ]; \
-    then cargo build -p conduit-proxy           && mv target/debug/conduit-proxy   target/conduit-proxy ; \
-    else cargo build -p conduit-proxy --release && mv target/release/conduit-proxy target/conduit-proxy ; \
+    then cargo build --frozen -p conduit-proxy           && mv target/debug/conduit-proxy   target/conduit-proxy ; \
+    else cargo build --frozen -p conduit-proxy --release && mv target/release/conduit-proxy target/conduit-proxy ; \
     fi
 
 ## Install the proxy binary into the base runtime image.

--- a/proxy/Dockerfile-deps
+++ b/proxy/Dockerfile-deps
@@ -20,9 +20,9 @@ COPY tower-grpc ./tower-grpc
 COPY Cargo.toml Cargo.lock ./
 COPY proto ./proto
 COPY proxy ./proxy
-RUN cargo fetch
-RUN cargo build -p conduit-proxy
-RUN cargo build -p conduit-proxy --release
+RUN cargo fetch --locked
+RUN cargo build --frozen -p conduit-proxy
+RUN cargo build --frozen -p conduit-proxy --release
 
 # Preserve dependency sources and build artifacts without maintaining conduit
 # sources/artifacts.


### PR DESCRIPTION
The cargo commands in our docker and ci scripts were at risk for
modifying Cargo.lock and cache.

Using cargo's --frozen flag (and --locked during fetch) ensures our
build is consistent with what's defined across Cargo.toml, Cargo.lock,
and cached build artifacts.