### PR TITLE
Add docker deps validation to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
         - ./bin/protoc-go.sh
         - go test -v ./...
         - go vet ./...
+
     - language: node_js
       node_js:
         - "8"
@@ -57,6 +58,19 @@ jobs:
         - cd web/app && yarn && yarn webpack
       script:
         - yarn karma start --single-run
+
+    - language: generic
+      script:
+        - |
+          (
+            . bin/_tag.sh
+            for f in $( grep -lR --include=Dockerfile\* go-deps: . ) ; do
+              validate_go_deps_tag $f
+            done
+            for f in $( grep -lR --include=Dockerfile\* proxy-deps: . ) ; do
+              validate_proxy_deps_tag $f
+            done
+          )
 
     # Push container images to Google Container Registry.
     - stage: docker-deploy

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -51,7 +51,7 @@ validate_tag() {
         echo "Tag in "$file" does not match source tree:"
         echo $dockerfile_tag" ("$file")"
         echo $deps_tag" (source)"
-        exit 3
+        return 3
     fi
 }
 

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -7,5 +7,5 @@ set -eu
 sha=$(. bin/_tag.sh ; go_deps_sha)
 
 for f in $( grep -lR --include=Dockerfile\* go-deps: . ) ; do
-    sed -Ei '' -e "s|runconduit/go-deps:[^ ]+|runconduit/go-deps:${sha}|" "$f"
+    sed -E -i'' -e "s|runconduit/go-deps:[^ ]+|runconduit/go-deps:${sha}|" "$f"
 done

--- a/bin/update-proxy-deps-shas
+++ b/bin/update-proxy-deps-shas
@@ -7,5 +7,5 @@ set -eu
 sha=$(. bin/_tag.sh ; proxy_deps_sha)
 
 for f in $( grep -lR --include=Dockerfile\* proxy-deps: . ) ; do
-    sed -Ei '' -e "s|runconduit/proxy-deps:[^ ]+|runconduit/proxy-deps:${sha}|" "$f"
+    sed -E -i'' -e "s|runconduit/proxy-deps:[^ ]+|runconduit/proxy-deps:${sha}|" "$f"
 done

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,7 +5,7 @@
 ## Build the rust proxy into a binary.
 #
 # If the RELEASE arg is set and non-empty, a release artifact is built.
-FROM gcr.io/runconduit/proxy-deps:b5aefa4c as build
+FROM gcr.io/runconduit/proxy-deps:6c797c62 as build
 WORKDIR /usr/src/conduit
 # Ranked roughly from least to most likely to change. Cargo.lock is the least likely
 # because it is supposed to be cached in the deps base image.


### PR DESCRIPTION
If docker image tags were out of date, ci would not fail until the
docker-deploy stage (master merge).

Modify ci to validate tags as part of the default ci run.