### PR TITLE
Set conduit version to match conduit docker tags

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -125,38 +125,32 @@ These commands assume a working
 
 ```bash
 # build all docker images, using minikube as our docker repo
-# this command will also place conduit executables in target/cli/
 DOCKER_TRACE=1 bin/mkube bin/docker-build
 
-# note: depending on your OS, use one of these three conduit executables:
-# target/cli/darwin/conduit
-# target/cli/linux/conduit
-# target/cli/windows/conduit
-
 # install conduit
-target/cli/darwin/conduit install --version $(bin/root-tag) | kubectl apply -f -
+bin/conduit install | kubectl apply -f -
 
 # verify cli and server versions
-target/cli/darwin/conduit version
+bin/conduit version
 
 # validate installation
 kubectl --namespace=conduit get all
-target/cli/darwin/conduit check
+bin/conduit check
 
 # view conduit dashboard
-target/cli/darwin/conduit dashboard
+bin/conduit dashboard
 
 # install the demo app
-curl https://raw.githubusercontent.com/runconduit/conduit-examples/master/emojivoto/emojivoto.yml | conduit inject - --skip-inbound-ports=80 | kubectl apply -f -
+curl https://raw.githubusercontent.com/runconduit/conduit-examples/master/emojivoto/emojivoto.yml | bin/conduit inject - --skip-inbound-ports=80 | kubectl apply -f -
 
 # view demo app
 minikube -n emojivoto service web-svc --url
 
 # view details per deployment
-target/cli/darwin/conduit stat deployments
+bin/conduit stat deployments
 
 # view a live pipeline of requests
-target/cli/darwin/conduit tap deploy emojivoto/voting-svc
+bin/conduit tap deploy emojivoto/voting-svc
 ```
 
 ## Go

--- a/BUILD.md
+++ b/BUILD.md
@@ -141,7 +141,7 @@ bin/conduit check
 bin/conduit dashboard
 
 # install the demo app
-curl https://raw.githubusercontent.com/runconduit/conduit-examples/master/emojivoto/emojivoto.yml | bin/conduit inject - --skip-inbound-ports=80 | kubectl apply -f -
+curl https://raw.githubusercontent.com/runconduit/conduit-examples/master/emojivoto/emojivoto.yml | bin/conduit inject - | kubectl apply -f -
 
 # view demo app
 minikube -n emojivoto service web-svc --url

--- a/bin/_log.sh
+++ b/bin/_log.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-# debug logging is enabled by default and may be disabled with BUILD_DEBUG=
-#export BUILD_DEBUG="${BUILD_DEBUG:-}"
+# build debug logging is disabled by default; enable with BUILD_DEBUG=1
+# shell trace logging is disabled by default; enable with TRACE=1
 
 export TRACE="${TRACE:-}"
 if [ -n "$TRACE" ]; then

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -3,7 +3,7 @@
 set -eu
 
 git_sha_head() {
-    git rev-parse HEAD | cut -c 1-8
+    git rev-parse --short=8 HEAD
 }
 
 proxy_deps_sha() {

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -18,6 +18,10 @@ clean_head() {
     git diff-index --quiet HEAD --
 }
 
+named_tag() {
+    echo "$(git name-rev --tags --name-only $(git_sha HEAD))"
+}
+
 head_root_tag() {
     if clean_head ; then
         clean_head_root_tag
@@ -28,7 +32,11 @@ head_root_tag() {
 
 clean_head_root_tag() {
     if clean_head ; then
-        echo "git-$(git_sha HEAD)"
+        if [ "$(named_tag)" != "undefined" ]; then
+            echo "$(named_tag)"
+        else
+            echo "git-$(git_sha HEAD)"
+        fi
     else
         echo "Commit unstaged changes." >&2
         exit 3

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-git_sha() {
-    git rev-parse "$1" | cut -c 1-8
+git_sha_head() {
+    git rev-parse HEAD | cut -c 1-8
 }
 
 proxy_deps_sha() {
@@ -19,14 +19,14 @@ clean_head() {
 }
 
 named_tag() {
-    echo "$(git name-rev --tags --name-only $(git_sha HEAD))"
+    echo "$(git name-rev --tags --name-only $(git_sha_head))"
 }
 
 head_root_tag() {
     if clean_head ; then
         clean_head_root_tag
     else
-        echo "dev-$(git_sha HEAD)-$USER"
+        echo "dev-$(git_sha_head)-$USER"
     fi
 }
 
@@ -35,7 +35,7 @@ clean_head_root_tag() {
         if [ "$(named_tag)" != "undefined" ]; then
             echo "$(named_tag)"
         else
-            echo "git-$(git_sha HEAD)"
+            echo "git-$(git_sha_head)"
         fi
     else
         echo "Commit unstaged changes." >&2

--- a/bin/conduit
+++ b/bin/conduit
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+system=$(uname -s)
+
+if [[ $system = "Darwin"* ]]; then
+  bin=target/cli/darwin/conduit
+elif [[ $system = "Linux"* ]]; then
+  bin=target/cli/linux/conduit
+elif [[ $system = "Windows"* ]]; then
+  bin=target/cli/windows/conduit
+else
+  echo "unknown system: $system" >&2
+  exit 1
+fi
+
+# build conduit executable if it does not exist
+if [[ ! -f $bin ]]; then
+  bin/docker-build-cli-bin >/dev/null
+fi
+
+exec $bin $@

--- a/bin/conduit
+++ b/bin/conduit
@@ -1,23 +1,21 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 system=$(uname -s)
 
-if [[ $system = "Darwin"* ]]; then
+if [ "$system" = "Darwin" ]; then
   bin=target/cli/darwin/conduit
-elif [[ $system = "Linux"* ]]; then
+elif [ "$system" = "Linux" ]; then
   bin=target/cli/linux/conduit
-elif [[ $system = "Windows"* ]]; then
-  bin=target/cli/windows/conduit
 else
   echo "unknown system: $system" >&2
   exit 1
 fi
 
 # build conduit executable if it does not exist
-if [[ ! -f $bin ]]; then
+if [ ! -f $bin ]; then
   bin/docker-build-cli-bin >/dev/null
 fi
 
-exec $bin $@
+exec $bin "$@"

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -19,9 +19,9 @@ validate_go_deps_tag $dockerfile
     bin/docker-build-go-deps
 ) >/dev/null
 
-
-docker_build cli-bin $(head_root_tag) $dockerfile
-IMG=$(docker_repo cli-bin):$(head_root_tag)
+tag="$(head_root_tag)"
+docker_build cli-bin $tag $dockerfile --build-arg CONDUIT_VERSION=$tag
+IMG=$(docker_repo cli-bin):$tag
 ID=$(docker create "$IMG")
 
 # copy the newly built conduit cli binaries to the local system

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -19,4 +19,5 @@ validate_go_deps_tag $dockerfile
     bin/docker-build-go-deps
 ) >/dev/null
 
-docker_build controller "$(head_root_tag)" $dockerfile
+tag="$(head_root_tag)"
+docker_build controller $tag $dockerfile --build-arg CONDUIT_VERSION=$tag

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -19,4 +19,5 @@ validate_go_deps_tag $dockerfile
     bin/docker-build-go-deps
 ) >/dev/null
 
-docker_build web "$(head_root_tag)" $dockerfile
+tag="$(head_root_tag)"
+docker_build web $tag $dockerfile --build-arg CONDUIT_VERSION=$tag

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,15 +1,14 @@
 ## compile binaries
 FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
 COPY controller controller
 COPY pkg pkg
-ARG CONDUIT_VERSION
-RUN sed -i "s/unknown/$CONDUIT_VERSION/" pkg/version/version.go
 RUN mkdir -p /out
-RUN CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -o /out/conduit-darwin ./cli
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /out/conduit-linux ./cli
-RUN CGO_ENABLED=0 GOOS=windows go build -a -installsuffix cgo -o /out/conduit-windows ./cli
+RUN CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -o /out/conduit-darwin -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /out/conduit-linux -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
+RUN CGO_ENABLED=0 GOOS=windows go build -a -installsuffix cgo -o /out/conduit-windows -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
 
 ## export without sources & depdenndencies
 FROM gcr.io/runconduit/base:2017-10-30.01

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -4,6 +4,8 @@ WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
 COPY controller controller
 COPY pkg pkg
+ARG CONDUIT_VERSION
+RUN sed -i "s/unknown/$CONDUIT_VERSION/" pkg/version/version.go
 RUN mkdir -p /out
 RUN CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -o /out/conduit-darwin ./cli
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /out/conduit-linux ./cli

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/runconduit/conduit/controller"
+	"github.com/runconduit/conduit/pkg/version"
 	"github.com/spf13/cobra"
 	batchV1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
@@ -234,7 +234,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 
 	initContainer := v1.Container{
 		Name:            "conduit-init",
-		Image:           fmt.Sprintf("%s:%s", initImage, version),
+		Image:           fmt.Sprintf("%s:%s", initImage, conduitVersion),
 		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 		Args:            initArgs,
 		SecurityContext: &v1.SecurityContext{
@@ -247,7 +247,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 
 	sidecar := v1.Container{
 		Name:            "conduit-proxy",
-		Image:           fmt.Sprintf("%s:%s", proxyImage, version),
+		Image:           fmt.Sprintf("%s:%s", proxyImage, conduitVersion),
 		ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
 		SecurityContext: &v1.SecurityContext{
 			RunAsUser: &proxyUID,
@@ -289,8 +289,8 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 	if t.Annotations == nil {
 		t.Annotations = make(map[string]string)
 	}
-	t.Annotations[conduitCreatedByAnnotation] = fmt.Sprintf("conduit/cli %s", controller.Version)
-	t.Annotations[conduitProxyVersionAnnotation] = version
+	t.Annotations[conduitCreatedByAnnotation] = fmt.Sprintf("conduit/cli %s", version.Version)
+	t.Annotations[conduitProxyVersionAnnotation] = conduitVersion
 
 	if t.Labels == nil {
 		t.Labels = make(map[string]string)
@@ -375,7 +375,7 @@ type enhancedDaemonSet struct {
 
 func init() {
 	RootCmd.AddCommand(injectCmd)
-	injectCmd.PersistentFlags().StringVarP(&version, "conduit-version", "v", controller.Version, "tag to be used for conduit images")
+	injectCmd.PersistentFlags().StringVarP(&conduitVersion, "conduit-version", "v", version.Version, "tag to be used for conduit images")
 	injectCmd.PersistentFlags().StringVar(&initImage, "init-image", "gcr.io/runconduit/proxy-init", "Conduit init container image name")
 	injectCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", "gcr.io/runconduit/proxy", "Conduit proxy container image name")
 	injectCmd.PersistentFlags().StringVar(&imagePullPolicy, "image-pull-policy", "IfNotPresent", "Docker image pull policy")

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"text/template"
 
-	"github.com/runconduit/conduit/controller"
+	"github.com/runconduit/conduit/pkg/version"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 )
@@ -400,7 +400,7 @@ type installConfig struct {
 }
 
 var (
-	version            string
+	conduitVersion     string
 	dockerRegistry     string
 	controllerReplicas uint
 	webReplicas        uint
@@ -422,15 +422,15 @@ var installCmd = &cobra.Command{
 		}
 		template.Execute(os.Stdout, installConfig{
 			Namespace:          controlPlaneNamespace,
-			ControllerImage:    fmt.Sprintf("%s/controller:%s", dockerRegistry, version),
-			WebImage:           fmt.Sprintf("%s/web:%s", dockerRegistry, version),
+			ControllerImage:    fmt.Sprintf("%s/controller:%s", dockerRegistry, conduitVersion),
+			WebImage:           fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
 			PrometheusImage:    "prom/prometheus:v1.8.1",
 			ControllerReplicas: controllerReplicas,
 			WebReplicas:        webReplicas,
 			PrometheusReplicas: prometheusReplicas,
 			ImagePullPolicy:    imagePullPolicy,
 			UUID:               uuid.NewV4().String(),
-			CliVersion:         fmt.Sprintf("conduit/cli %s", controller.Version),
+			CliVersion:         fmt.Sprintf("conduit/cli %s", version.Version),
 		})
 		return nil
 	},
@@ -446,8 +446,8 @@ func validate() error {
 	if !alphaNumDash.MatchString(controlPlaneNamespace) {
 		return fmt.Errorf("%s is not a valid namespace", controlPlaneNamespace)
 	}
-	if !alphaNumDashDot.MatchString(version) {
-		return fmt.Errorf("%s is not a valid version", version)
+	if !alphaNumDashDot.MatchString(conduitVersion) {
+		return fmt.Errorf("%s is not a valid version", conduitVersion)
 	}
 	if !alphaNumDashDotSlash.MatchString(dockerRegistry) {
 		return fmt.Errorf("%s is not a valid Docker registry", dockerRegistry)
@@ -460,7 +460,7 @@ func validate() error {
 
 func init() {
 	RootCmd.AddCommand(installCmd)
-	installCmd.PersistentFlags().StringVarP(&version, "version", "v", controller.Version, "Conduit version to install")
+	installCmd.PersistentFlags().StringVarP(&conduitVersion, "version", "v", version.Version, "Conduit version to install")
 	installCmd.PersistentFlags().StringVarP(&dockerRegistry, "registry", "r", "gcr.io/runconduit", "Docker registry to pull images from")
 	installCmd.PersistentFlags().UintVar(&controllerReplicas, "controller-replicas", 1, "replicas of the controller to deploy")
 	installCmd.PersistentFlags().UintVar(&webReplicas, "web-replicas", 1, "replicas of the web server to deploy")

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/runconduit/conduit/controller"
 	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -45,14 +45,14 @@ func getVersions(client pb.ApiClient) versions {
 	resp, err := client.Version(context.Background(), &pb.Empty{})
 	if err != nil {
 		return versions{
-			Client: controller.Version,
+			Client: version.Version,
 			Server: DefaultVersionString,
 		}
 	}
 
 	versions := versions{
 		Server: resp.GetReleaseVersion(),
-		Client: controller.Version,
+		Client: version.Version,
 	}
 
 	return versions

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -4,15 +4,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/runconduit/conduit/controller"
 	"github.com/runconduit/conduit/controller/api/public"
 	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/pkg/version"
 )
 
 func TestGetVersion(t *testing.T) {
 	t.Run("Returns existing versions from server and client", func(t *testing.T) {
 		expectedServerVersion := "1.2.3"
-		expectedClientVersion := controller.Version
+		expectedClientVersion := version.Version
 		mockClient := &public.MockConduitApiClient{}
 		mockClient.VersionInfoToReturn = &pb.VersionInfo{
 			ReleaseVersion: expectedServerVersion,
@@ -28,7 +28,7 @@ func TestGetVersion(t *testing.T) {
 
 	t.Run("Returns undefined when cannot get server version", func(t *testing.T) {
 		expectedServerVersion := "unavailable"
-		expectedClientVersion := controller.Version
+		expectedClientVersion := version.Version
 		mockClient := &public.MockConduitApiClient{}
 		mockClient.ErrorToReturn = errors.New("expected")
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,12 +1,11 @@
 ## compile controller services
 FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller
 COPY pkg pkg
-ARG CONDUIT_VERSION
-RUN sed -i "s/unknown/$CONDUIT_VERSION/" pkg/version/version.go
 # use `install` so that we produce multiple binaries
-RUN CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo ./controller/cmd/...
+RUN CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./controller/cmd/...
 
 ## package runtime
 FROM gcr.io/runconduit/base:2017-10-30.01

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -3,6 +3,8 @@ FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller
 COPY pkg pkg
+ARG CONDUIT_VERSION
+RUN sed -i "s/unknown/$CONDUIT_VERSION/" pkg/version/version.go
 # use `install` so that we produce multiple binaries
 RUN CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo ./controller/cmd/...
 

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/runconduit/conduit/controller"
 	"github.com/runconduit/conduit/controller/api/util"
 	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
 	tapPb "github.com/runconduit/conduit/controller/gen/controller/tap"
 	telemPb "github.com/runconduit/conduit/controller/gen/controller/telemetry"
 	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -120,7 +120,7 @@ func (s *grpcServer) Stat(ctx context.Context, req *pb.MetricRequest) (*pb.Metri
 }
 
 func (_ *grpcServer) Version(ctx context.Context, req *pb.Empty) (*pb.VersionInfo, error) {
-	return &pb.VersionInfo{GoVersion: runtime.Version(), ReleaseVersion: controller.Version, BuildDate: "1970-01-01T00:00:00Z"}, nil
+	return &pb.VersionInfo{GoVersion: runtime.Version(), ReleaseVersion: version.Version, BuildDate: "1970-01-01T00:00:00Z"}, nil
 }
 
 func (s *grpcServer) ListPods(ctx context.Context, req *pb.Empty) (*pb.ListPodsResponse, error) {

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/destination"
+	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,7 +19,10 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9999", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
+	printVersion := version.VersionFlag()
+
 	flag.Parse()
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	log.SetLevel(log.DebugLevel) // TODO: make configurable
 

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -19,12 +19,18 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9999", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
+	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
-
 	flag.Parse()
-	version.MaybePrintVersionAndExit(*printVersion)
 
-	log.SetLevel(log.DebugLevel) // TODO: make configurable
+	// set global log level
+	level, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("invalid log-level: %s", *logLevel)
+	}
+	log.SetLevel(level)
+
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -19,12 +19,18 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9996", "address to serve scrapable metrics on")
 	telemetryAddr := flag.String("telemetry-addr", ":8087", "address of telemetry service")
 	destinationAddr := flag.String("destination-addr", ":8089", "address of destination service")
+	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
-
 	flag.Parse()
-	version.MaybePrintVersionAndExit(*printVersion)
 
-	log.SetLevel(log.DebugLevel) // TODO: make configurable
+	// set global log level
+	level, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("invalid log-level: %s", *logLevel)
+	}
+	log.SetLevel(level)
+
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/api/proxy"
 	"github.com/runconduit/conduit/controller/destination"
+	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,7 +19,10 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9996", "address to serve scrapable metrics on")
 	telemetryAddr := flag.String("telemetry-addr", ":8087", "address of telemetry service")
 	destinationAddr := flag.String("destination-addr", ":8089", "address of destination service")
+	printVersion := version.VersionFlag()
+
 	flag.Parse()
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	log.SetLevel(log.DebugLevel) // TODO: make configurable
 

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -21,9 +21,17 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9995", "address to serve scrapable metrics on")
 	telemetryAddr := flag.String("telemetry-addr", ":8087", "address of telemetry service")
 	tapAddr := flag.String("tap-addr", ":8088", "address of tap service")
+	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
-
 	flag.Parse()
+
+	// set global log level
+	level, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("invalid log-level: %s", *logLevel)
+	}
+	log.SetLevel(level)
+
 	version.MaybePrintVersionAndExit(*printVersion)
 
 	stop := make(chan os.Signal, 1)

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/runconduit/conduit/controller/api/public"
 	"github.com/runconduit/conduit/controller/tap"
 	"github.com/runconduit/conduit/controller/telemetry"
+	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -20,7 +21,10 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9995", "address to serve scrapable metrics on")
 	telemetryAddr := flag.String("telemetry-addr", ":8087", "address of telemetry service")
 	tapAddr := flag.String("tap-addr", ":8088", "address of tap service")
+	printVersion := version.VersionFlag()
+
 	flag.Parse()
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/tap"
+	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,7 +19,10 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	tapPort := flag.Uint("tap-port", 4190, "proxy tap port to connect to")
+	printVersion := version.VersionFlag()
+
 	flag.Parse()
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	log.SetLevel(log.DebugLevel) // TODO: make configurable
 	stop := make(chan os.Signal, 1)

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -19,12 +19,19 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	tapPort := flag.Uint("tap-port", 4190, "proxy tap port to connect to")
+	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
-
 	flag.Parse()
+
+	// set global log level
+	level, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("invalid log-level: %s", *logLevel)
+	}
+	log.SetLevel(level)
+
 	version.MaybePrintVersionAndExit(*printVersion)
 
-	log.SetLevel(log.DebugLevel) // TODO: make configurable
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 

--- a/controller/cmd/telemetry/main.go
+++ b/controller/cmd/telemetry/main.go
@@ -20,12 +20,19 @@ func main() {
 	prometheusUrl := flag.String("prometheus-url", "http://127.0.0.1:9090", "prometheus url")
 	ignoredNamespaces := flag.String("ignore-namespaces", "", "comma separated list of namespaces to not list pods from")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
+	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
-
 	flag.Parse()
+
+	// set global log level
+	level, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.Fatalf("invalid log-level: %s", *logLevel)
+	}
+	log.SetLevel(level)
+
 	version.MaybePrintVersionAndExit(*printVersion)
 
-	log.SetLevel(log.DebugLevel) // TODO: make configurable
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 

--- a/controller/cmd/telemetry/main.go
+++ b/controller/cmd/telemetry/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/telemetry"
+	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,7 +20,10 @@ func main() {
 	prometheusUrl := flag.String("prometheus-url", "http://127.0.0.1:9090", "prometheus url")
 	ignoredNamespaces := flag.String("ignore-namespaces", "", "comma separated list of namespaces to not list pods from")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
+	printVersion := version.VersionFlag()
+
 	flag.Parse()
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	log.SetLevel(log.DebugLevel) // TODO: make configurable
 	stop := make(chan os.Signal, 1)

--- a/controller/version.go
+++ b/controller/version.go
@@ -1,3 +1,0 @@
-package controller
-
-const Version = "v0.1.3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: controller/Dockerfile
+      args:
+      - CONDUIT_VERSION=latest
     ports:
     - "8089:8089"
     - "9999:9999"
@@ -20,6 +22,8 @@ services:
     build:
       context: .
       dockerfile: controller/Dockerfile
+      args:
+      - CONDUIT_VERSION=latest
     ports:
     - "8088:8088"
     - "9998:9998"
@@ -35,6 +39,8 @@ services:
     build:
       context: .
       dockerfile: controller/Dockerfile
+      args:
+      - CONDUIT_VERSION=latest
     ports:
     - "8087:8087"
     - "9997:9997"
@@ -51,6 +57,8 @@ services:
     build:
       context: .
       dockerfile: controller/Dockerfile
+      args:
+      - CONDUIT_VERSION=latest
     ports:
     - "8086:8086"
     - "9996:9996"
@@ -65,6 +73,8 @@ services:
     build:
       context: .
       dockerfile: controller/Dockerfile
+      args:
+      - CONDUIT_VERSION=latest
     ports:
     - "8085:8085"
     - "9995:9995"
@@ -79,6 +89,8 @@ services:
     build:
       context: .
       dockerfile: web/Dockerfile
+      args:
+      - CONDUIT_VERSION=latest
     ports:
     - "8084:8084"
     - "9994:9994"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 // DO NOT EDIT
-// This const is updated automatically as part of the build process
-const Version = "unknown"
+// This var is updated automatically as part of the build process
+var Version = "unknown"
 
 func VersionFlag() *bool {
 	return flag.Bool("version", false, "print version and exit")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // DO NOT EDIT
@@ -19,4 +21,5 @@ func MaybePrintVersionAndExit(printVersion bool) {
 		fmt.Println(Version)
 		os.Exit(0)
 	}
+	log.Infof("running conduit version %s", Version)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,22 @@
+package version
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// DO NOT EDIT
+// This const is updated automatically as part of the build process
+const Version = "unknown"
+
+func VersionFlag() *bool {
+	return flag.Bool("version", false, "print version and exit")
+}
+
+func MaybePrintVersionAndExit(printVersion bool) {
+	if printVersion {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,13 +13,12 @@ RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
 FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller
 COPY pkg pkg
-ARG CONDUIT_VERSION
-RUN sed -i "s/unknown/$CONDUIT_VERSION/" pkg/version/version.go
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o web/web ./web
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o web/web -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./web
 
 ## package it all up
 FROM gcr.io/runconduit/base:2017-10-30.01

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,6 +17,8 @@ WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller
 COPY pkg pkg
+ARG CONDUIT_VERSION
+RUN sed -i "s/unknown/$CONDUIT_VERSION/" pkg/version/version.go
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o web/web ./web
 
 ## package it all up

--- a/web/app/js/components/Version.jsx
+++ b/web/app/js/components/Version.jsx
@@ -71,7 +71,7 @@ export default class Version extends React.Component {
   render() {
     return (
       <div className="version">
-        Currently running Conduit {this.props.releaseVersion}<br />
+        Running Conduit {this.props.releaseVersion}<br />
         {this.renderVersionCheck()}
       </div>
     );

--- a/web/main.go
+++ b/web/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/api/public"
+	"github.com/runconduit/conduit/pkg/version"
 	"github.com/runconduit/conduit/web/srv"
 	log "github.com/sirupsen/logrus"
 )
@@ -26,8 +27,10 @@ func main() {
 	reload := flag.Bool("reload", true, "reloading set to true or false")
 	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	webpackDevServer := flag.String("webpack-dev-server", "", "use webpack to serve static assets; frontend will use this instead of static-dir")
+	printVersion := version.VersionFlag()
 
 	flag.Parse()
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	// set global log level
 	level, err := log.ParseLevel(*logLevel)

--- a/web/main.go
+++ b/web/main.go
@@ -25,12 +25,10 @@ func main() {
 	staticDir := flag.String("static-dir", "app/dist", "directory to search for static files")
 	uuid := flag.String("uuid", "", "unqiue Conduit install id")
 	reload := flag.Bool("reload", true, "reloading set to true or false")
-	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	webpackDevServer := flag.String("webpack-dev-server", "", "use webpack to serve static assets; frontend will use this instead of static-dir")
+	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
-
 	flag.Parse()
-	version.MaybePrintVersionAndExit(*printVersion)
 
 	// set global log level
 	level, err := log.ParseLevel(*logLevel)
@@ -38,6 +36,8 @@ func main() {
 		log.Fatalf("invalid log-level: %s", *logLevel)
 	}
 	log.SetLevel(level)
+
+	version.MaybePrintVersionAndExit(*printVersion)
 
 	_, _, err = net.SplitHostPort(*kubernetesApiHost) // Verify kubernetesApiHost is of the form host:port.
 	if err != nil {


### PR DESCRIPTION
In this branch I'm modifying the go `bin/docker-build*` scripts to pass the docker tag as an argument to the docker build command, and using the argument to set the conduit version in all of the binaries that are built. This allows us to stop hardcoding the conduit version in `controller/version.go`.

As part of this change I'm also changing the way in which the image tag is determined, such that if you're building from a clean commit that corresponds to a git tag, we use the git tag instead. This allows us to build stable image versions for release, corresponding to the release tag.

I've also added a `bin/conduit` script that will run the architecture-appropriate conduit executable, and I've updated the instructions in BUILD.md to use that script.

And finally, I've added command-line flags to the web and controller executables, for printing the build version and exiting.

Fixes #172.
Fixes #211.
Fixes #146.