### PR TITLE
Fix link to deployments from autocomplete not including pathPrefix

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -41,7 +41,7 @@ export default class Sidebar extends React.Component {
   }
 
   onAutocompleteSelect(deployment) {
-    let pathToDeploymentPage = `/deployment?deploy=${deployment}`;
+    let pathToDeploymentPage = `${this.props.pathPrefix}/deployment?deploy=${deployment}`;
     this.props.history.push(pathToDeploymentPage);
     this.setState({
       autocompleteValue: '',


### PR DESCRIPTION
We were not including pathPrefix in the links from the autocomplete dropdown, so when running "conduit dashboard" the prefix was lost and the link wouldn't work. Fix this.

Fixes #212