### PR TITLE
proxy: fix h1 streams to trigger response end events

### DIFF
--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -166,7 +166,7 @@ where
         match self.inner {
             ClientServiceInner::Http1(ref h1) => {
                 let is_body_empty = req.body().is_end_stream();
-                let mut req = hyper::Request::from(req.map(BodyStream));
+                let mut req = hyper::Request::from(req.map(BodyStream::new));
                 if is_body_empty {
                     req.headers_mut().set(hyper::header::ContentLength(0));
                 }

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -54,4 +54,50 @@ fn inbound_sends_telemetry() {
 }
 
 #[test]
+fn http1_inbound_sends_telemetry() {
+    let _ = env_logger::init();
+
+    info!("running test server");
+    let srv = server::http1().route("/hey", "hello").run();
+
+    let mut ctrl = controller::new();
+    let reports = ctrl.reports();
+    let proxy = proxy::new()
+        .controller(ctrl.run())
+        .inbound(srv)
+        .metrics_flush_interval(Duration::from_millis(500))
+        .run();
+    let client = client::http1(proxy.inbound, "test.conduit.local");
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey"), "hello");
+
+    info!("awaiting report");
+    let report = reports.wait().next().unwrap().unwrap();
+    // proxy inbound
+    assert_eq!(report.proxy, 0);
+    // requests
+    assert_eq!(report.requests.len(), 1);
+    let req = &report.requests[0];
+    assert_eq!(req.ctx.as_ref().unwrap().authority, "test.conduit.local");
+    assert_eq!(req.ctx.as_ref().unwrap().path, "/hey");
+    //assert_eq!(req.ctx.as_ref().unwrap().method, GET);
+    assert_eq!(req.count, 1);
+    assert_eq!(req.responses.len(), 1);
+    // responses
+    let res = &req.responses[0];
+    assert_eq!(res.ctx.as_ref().unwrap().http_status_code, 200);
+    assert_eq!(res.response_latencies.len(), 1);
+    assert_eq!(res.ends.len(), 1);
+    // ends
+    let ends = &res.ends[0];
+    assert_eq!(ends.streams.len(), 1);
+    // streams
+    let stream = &ends.streams[0];
+    assert_eq!(stream.bytes_sent, 5);
+    assert_eq!(stream.frames_sent, 1);
+}
+
+#[test]
 fn telemetry_report_errors_are_ignored() {}
+


### PR DESCRIPTION
Response End events were only triggered after polling the trailers of
a response, but when the Response is given to a hyper h1 server, it
doesn't know about trailers, so they were never polled!

The fix is that the `BodyStream` glue will now poll the wrapped body for
trailers after it sees the end of the data, before telling hyper the
stream is over. This ensures a ResponseEnd event is emitted.

Includes a proxy telemetry test over h1 connections.