### PR TITLE
Update cli subcommands to print errors when encountered

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -36,17 +36,14 @@ var completionCmd = &cobra.Command{
 	Example:   example,
 	Args:      cobra.ExactArgs(1),
 	ValidArgs: []string{"bash", "zsh"},
-	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
-
+	Run: func(cmd *cobra.Command, args []string) {
 		out, err := getCompletion(args[0])
 		if err != nil {
 			log.Fatal(err.Error())
 		} else {
 			fmt.Printf(out)
 		}
-
-		return err
-	}),
+	},
 }
 
 func init() {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/runconduit/conduit/controller/api/public"
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
@@ -54,21 +52,4 @@ func newPublicAPIClient() (pb.ApiClient, error) {
 		return nil, err
 	}
 	return public.NewExternalClient(controlPlaneNamespace, kubeApi)
-}
-
-// Exit with non-zero exit status without printing the command line usage and
-// without printing the error message.
-//
-// When a `RunE` command returns an error, Cobra will print the usage message
-// so the `RunE` function needs to handle any non-usage errors itself without
-// returning an error. `exitSilentlyOnError` can be used as the `Run` (not
-// `RunE`) function to help with this.
-//
-// TODO: This is used by the `version` command now; it should be used by other commands too.
-func exitSilentlyOnError(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
-		if err := f(cmd, args); err != nil {
-			os.Exit(2) // Reserve 1 for usage errors.
-		}
-	}
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/version"
@@ -16,19 +17,19 @@ var versionCmd = &cobra.Command{
 	Short: "Print the client and server version information",
 	Long:  "Print the client and server version information.",
 	Args:  cobra.NoArgs,
-	Run: exitSilentlyOnError(func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Client version: %s\n", version.Version)
+
 		client, err := newPublicAPIClient()
 		if err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "Error connecting to server: %s\n", err)
+			return
 		}
 
-		versions := getVersions(client)
+		fmt.Printf("Server version: %s\n", getServerVersion(client))
 
-		fmt.Printf("Client version: %s\n", versions.Client)
-		fmt.Printf("Server version: %s\n", versions.Server)
-
-		return err
-	}),
+		return
+	},
 }
 
 func init() {
@@ -36,24 +37,11 @@ func init() {
 	addControlPlaneNetworkingArgs(versionCmd)
 }
 
-type versions struct {
-	Server string
-	Client string
-}
-
-func getVersions(client pb.ApiClient) versions {
+func getServerVersion(client pb.ApiClient) string {
 	resp, err := client.Version(context.Background(), &pb.Empty{})
 	if err != nil {
-		return versions{
-			Client: version.Version,
-			Server: DefaultVersionString,
-		}
+		return DefaultVersionString
 	}
 
-	versions := versions{
-		Server: resp.GetReleaseVersion(),
-		Client: version.Version,
-	}
-
-	return versions
+	return resp.GetReleaseVersion()
 }

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -6,37 +6,34 @@ import (
 
 	"github.com/runconduit/conduit/controller/api/public"
 	pb "github.com/runconduit/conduit/controller/gen/public"
-	"github.com/runconduit/conduit/pkg/version"
 )
 
-func TestGetVersion(t *testing.T) {
-	t.Run("Returns existing versions from server and client", func(t *testing.T) {
+func TestGetServerVersion(t *testing.T) {
+	t.Run("Returns existing version from server", func(t *testing.T) {
 		expectedServerVersion := "1.2.3"
-		expectedClientVersion := version.Version
 		mockClient := &public.MockConduitApiClient{}
 		mockClient.VersionInfoToReturn = &pb.VersionInfo{
 			ReleaseVersion: expectedServerVersion,
 		}
 
-		versions := getVersions(mockClient)
+		version := getServerVersion(mockClient)
 
-		if versions.Client != expectedClientVersion || versions.Server != expectedServerVersion {
-			t.Fatalf("Expected client version to be [%s], was [%s]; expecting server version to be [%s], was [%s]",
-				versions.Client, expectedClientVersion, versions.Server, expectedServerVersion)
+		if version != expectedServerVersion {
+			t.Fatalf("Expected server version to be [%s], was [%s]",
+				expectedServerVersion, version)
 		}
 	})
 
-	t.Run("Returns undefined when cannot get server version", func(t *testing.T) {
+	t.Run("Returns unavailable when cannot get server version", func(t *testing.T) {
 		expectedServerVersion := "unavailable"
-		expectedClientVersion := version.Version
 		mockClient := &public.MockConduitApiClient{}
 		mockClient.ErrorToReturn = errors.New("expected")
 
-		versions := getVersions(mockClient)
+		version := getServerVersion(mockClient)
 
-		if versions.Client != expectedClientVersion || versions.Server != expectedServerVersion {
-			t.Fatalf("Expected client version to be [%s], was [%s]; expecting server version to be [%s], was [%s]",
-				expectedClientVersion, versions.Client, expectedServerVersion, versions.Server)
+		if version != expectedServerVersion {
+			t.Fatalf("Expected server version to be [%s], was [%s]",
+				expectedServerVersion, version)
 		}
 	})
 }

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -178,10 +178,9 @@ func newClient(apiURL *url.URL, httpClientToUse *http.Client) (pb.ApiClient, err
 }
 
 func NewInternalClient(kubernetesApiHost string) (pb.ApiClient, error) {
-	apiURL := &url.URL{
-		Scheme: "http",
-		Host:   kubernetesApiHost,
-		Path:   "/",
+	apiURL, err := url.Parse(fmt.Sprintf("http://%s/", kubernetesApiHost))
+	if err != nil {
+		return nil, err
 	}
 
 	return newClient(apiURL, http.DefaultClient)


### PR DESCRIPTION
As part of #177, the CLI tap subcommand's `Run` function was wrapped with the `exitSilentlyOnError` function. This results in no output to the command line when tap is misconfigured. For instance, if I specify an invalid resource type, I don't see any output:

```
$ bin/conduit tap configmap foo
$
```

In this branch I'm updating the tap command to start printing errors. I'm also removing the `exitSilentlyOnError` function entirely, since I'd prefer for each command to explicitly exit with its desired exit code, rather than return errors that are discarded and turned into exit codes.

Fixes #218.