### PR TITLE
Simplify and refactor k8s labels and annnotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ jobs:
         - bin/docker-push $CONDUIT_TAG
         - bin/docker-retag-all $CONDUIT_TAG master && bin/docker-push master
         - target/cli/linux/conduit install --version=$CONDUIT_TAG |tee conduit.yml
-        - kubectl -n conduit apply -f conduit.yml --prune --selector='conduit.io/plane=control'
+        - kubectl -n conduit apply -f conduit.yml --prune --selector='conduit.io/control-plane-component'
 
 notifications:
   email:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -240,6 +240,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/sergi/go-diff"
+  packages = ["diffmatchpatch"]
+  revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
@@ -349,6 +355,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b9949249a1b88b851ea33a371af8a547536aacc14c0f642f7741a8cd6fac66ea"
+  inputs-digest = "902019db7e0b8a324ccaaa9dd06470f8639063a41a7b80eaafa56088c92ac7d5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -7,5 +7,6 @@ set -eu
 sha=$(. bin/_tag.sh ; go_deps_sha)
 
 for f in $( grep -lR --include=Dockerfile\* go-deps: . ) ; do
-    sed -E -i'' -e "s|runconduit/go-deps:[^ ]+|runconduit/go-deps:${sha}|" "$f"
+    sed -E -i.bak -e "s|runconduit/go-deps:[^ ]+|runconduit/go-deps:${sha}|" "$f"
+    rm "$f".bak
 done

--- a/bin/update-proxy-deps-shas
+++ b/bin/update-proxy-deps-shas
@@ -7,5 +7,6 @@ set -eu
 sha=$(. bin/_tag.sh ; proxy_deps_sha)
 
 for f in $( grep -lR --include=Dockerfile\* proxy-deps: . ) ; do
-    sed -E -i'' -e "s|runconduit/proxy-deps:[^ ]+|runconduit/proxy-deps:${sha}|" "$f"
+    sed -E -i.bak -e "s|runconduit/proxy-deps:[^ ]+|runconduit/proxy-deps:${sha}|" "$f"
+    rm "$f".bak
 done

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+FROM gcr.io/runconduit/go-deps:7bceac7a as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo -o /out/conduit-dar
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /out/conduit-linux -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
 RUN CGO_ENABLED=0 GOOS=windows go build -a -installsuffix cgo -o /out/conduit-windows -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
 
-## export without sources & depdenndencies
+## export without sources & dependencies
 FROM gcr.io/runconduit/base:2017-10-30.01
 COPY --from=golang /out /out
 WORKDIR /out

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/runconduit/conduit/pkg/k8s"
 	"github.com/runconduit/conduit/pkg/version"
 	"github.com/spf13/cobra"
 	batchV1 "k8s.io/api/batch/v1"
@@ -19,20 +20,16 @@ import (
 )
 
 var (
-	initImage                     string
-	proxyImage                    string
-	proxyUID                      int64
-	inboundPort                   uint
-	outboundPort                  uint
-	ignoreInboundPorts            []uint
-	ignoreOutboundPorts           []uint
-	proxyControlPort              uint
-	proxyAPIPort                  uint
-	proxyLogLevel                 string
-	conduitCreatedByAnnotation    = "conduit.io/created-by"
-	conduitProxyVersionAnnotation = "conduit.io/proxy-version"
-	conduitControlLabel           = "conduit.io/controller"
-	conduitPlaneLabel             = "conduit.io/plane"
+	initImage           string
+	proxyImage          string
+	proxyUID            int64
+	inboundPort         uint
+	outboundPort        uint
+	ignoreInboundPorts  []uint
+	ignoreOutboundPorts []uint
+	proxyControlPort    uint
+	proxyAPIPort        uint
+	proxyLogLevel       string
 )
 
 var injectCmd = &cobra.Command{
@@ -290,14 +287,13 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 	if t.Annotations == nil {
 		t.Annotations = make(map[string]string)
 	}
-	t.Annotations[conduitCreatedByAnnotation] = fmt.Sprintf("conduit/cli %s", version.Version)
-	t.Annotations[conduitProxyVersionAnnotation] = conduitVersion
+	t.Annotations[k8s.CreatedByAnnotation] = k8s.CreatedByAnnotationValue()
+	t.Annotations[k8s.ProxyVersionAnnotation] = conduitVersion
 
 	if t.Labels == nil {
 		t.Labels = make(map[string]string)
 	}
-	t.Labels[conduitControlLabel] = controlPlaneNamespace
-	t.Labels[conduitPlaneLabel] = "data"
+	t.Labels[k8s.ControllerNSLabel] = controlPlaneNamespace
 	t.Spec.Containers = append(t.Spec.Containers, sidecar)
 	return enhancedPodTemplateSpec{
 		t,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func TestRender(t *testing.T) {
+	t.Run("Should render an install config", func(t *testing.T) {
+		goldenFileBytes, err := ioutil.ReadFile("testdata/install_output.golden")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		expectedContent := string(goldenFileBytes)
+
+		var buf bytes.Buffer
+
+		config := installConfig{
+			Namespace:                "Namespace",
+			ControllerImage:          "ControllerImage",
+			WebImage:                 "WebImage",
+			PrometheusImage:          "PrometheusImage",
+			ControllerReplicas:       1,
+			WebReplicas:              2,
+			PrometheusReplicas:       3,
+			ImagePullPolicy:          "ImagePullPolicy",
+			UUID:                     "UUID",
+			CliVersion:               "CliVersion",
+			ControllerLogLevel:       "ControllerLogLevel",
+			ControllerComponentLabel: "ControllerComponentLabel",
+			CreatedByAnnotation:      "CreatedByAnnotation",
+		}
+
+		err = render(config, &buf)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		content := buf.String()
+
+		if content != expectedContent {
+			dmp := diffmatchpatch.New()
+			diffs := dmp.DiffMain(content, expectedContent, true)
+			patches := dmp.PatchMake(expectedContent, diffs)
+			patchText := dmp.PatchToText(patches)
+			t.Fatalf("Unexpected output:\n%+v", patchText)
+		}
+	})
+}

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1,0 +1,378 @@
+### Namespace ###
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: Namespace
+
+### Service Account Controller ###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: conduit-controller
+  namespace: Namespace
+
+### RBAC ###
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: conduit-controller
+rules:
+- apiGroups: ["extensions"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "endpoints", "services"]
+  verbs: ["list", "get", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: conduit-controller
+  namespace: Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: conduit-controller
+subjects:
+- kind: ServiceAccount
+  name: conduit-controller
+  namespace: Namespace
+
+### Service Account Prometheus ###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: conduit-prometheus
+  namespace: Namespace
+
+### RBAC ###
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: conduit-prometheus
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: conduit-prometheus
+  namespace: Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: conduit-prometheus
+subjects:
+- kind: ServiceAccount
+  name: conduit-prometheus
+  namespace: Namespace
+
+### Controller ###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: api
+  namespace: Namespace
+  labels:
+    app: controller
+    ControllerComponentLabel: controller
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  type: ClusterIP
+  selector:
+    app: controller
+  ports:
+  - name: http
+    port: 8085
+    targetPort: 8085
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: proxy-api
+  namespace: Namespace
+  labels:
+    app: controller
+    ControllerComponentLabel: controller
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  type: ClusterIP
+  selector:
+    app: controller
+  ports:
+  - name: grpc
+    port: 8086
+    targetPort: 8086
+
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: controller
+  namespace: Namespace
+  labels:
+    app: controller
+    ControllerComponentLabel: controller
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: controller
+        ControllerComponentLabel: controller
+      annotations:
+        CreatedByAnnotation: CliVersion
+    spec:
+      serviceAccount: conduit-controller
+      containers:
+      - name: public-api
+        ports:
+        - name: http
+          containerPort: 8085
+        - name: admin-http
+          containerPort: 9995
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "public-api"
+        - "-addr=:8085"
+        - "-metrics-addr=:9995"
+        - "-telemetry-addr=127.0.0.1:8087"
+        - "-tap-addr=127.0.0.1:8088"
+        - "-log-level=ControllerLogLevel"
+      - name: destination
+        ports:
+        - name: grpc
+          containerPort: 8089
+        - name: admin-http
+          containerPort: 9999
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "destination"
+        - "-addr=:8089"
+        - "-metrics-addr=:9999"
+        - "-log-level=ControllerLogLevel"
+      - name: proxy-api
+        ports:
+        - name: grpc
+          containerPort: 8086
+        - name: admin-http
+          containerPort: 9996
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "proxy-api"
+        - "-addr=:8086"
+        - "-metrics-addr=:9996"
+        - "-destination-addr=:8089"
+        - "-telemetry-addr=:8087"
+        - "-log-level=ControllerLogLevel"
+      - name: tap
+        ports:
+        - name: grpc
+          containerPort: 8088
+        - name: admin-http
+          containerPort: 9998
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "tap"
+        - "-addr=:8088"
+        - "-metrics-addr=:9998"
+        - "-log-level=ControllerLogLevel"
+      - name: telemetry
+        ports:
+        - name: grpc
+          containerPort: 8087
+        - name: admin-http
+          containerPort: 9997
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "telemetry"
+        - "-addr=:8087"
+        - "-metrics-addr=:9997"
+        - "-ignore-namespaces=kube-system"
+        - "-prometheus-url=http://prometheus:9090"
+        - "-log-level=ControllerLogLevel"
+
+### Web ###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: web
+  namespace: Namespace
+  labels:
+    app: web
+    ControllerComponentLabel: web
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  type: ClusterIP
+  selector:
+    app: web
+  ports:
+  - name: http
+    port: 8084
+    targetPort: 8084
+  - name: admin-http
+    port: 9994
+    targetPort: 9994
+
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: web
+  namespace: Namespace
+  labels:
+    app: web
+    ControllerComponentLabel: web
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: web
+        ControllerComponentLabel: web
+      annotations:
+        CreatedByAnnotation: CliVersion
+    spec:
+      containers:
+      - name: web
+        ports:
+        - name: http
+          containerPort: 8084
+        - name: admin-http
+          containerPort: 9994
+        image: WebImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "-addr=:8084"
+        - "-metrics-addr=:9994"
+        - "-api-addr=api:8085"
+        - "-static-dir=/dist"
+        - "-template-dir=/templates"
+        - "-uuid=UUID"
+        - "-log-level=ControllerLogLevel"
+
+### Prometheus ###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: Namespace
+  labels:
+    app: prometheus
+    ControllerComponentLabel: prometheus
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  type: ClusterIP
+  selector:
+    app: prometheus
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090
+
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: prometheus
+  namespace: Namespace
+  labels:
+    app: prometheus
+    ControllerComponentLabel: prometheus
+  annotations:
+    CreatedByAnnotation: CliVersion
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        ControllerComponentLabel: prometheus
+      annotations:
+        CreatedByAnnotation: CliVersion
+    spec:
+      serviceAccount: conduit-prometheus
+      volumes:
+      - name: prometheus-config
+        configMap:
+          name: prometheus-config
+      containers:
+      - name: prometheus
+        ports:
+        - name: http
+          containerPort: 9090
+        volumeMounts:
+        - name: prometheus-config
+          mountPath: /etc/prometheus
+          readOnly: true
+        image: PrometheusImage
+        imagePullPolicy: ImagePullPolicy
+        args:
+        - "-storage.local.retention=6h"
+        - "-storage.local.memory-chunks=500000"
+        - "-config.file=/etc/prometheus/prometheus.yml"
+
+      # TODO remove/replace?
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args: ["proxy", "-p", "8001"]
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus-config
+  namespace: Namespace
+  labels:
+    app: prometheus
+    ControllerComponentLabel: prometheus
+  annotations:
+    CreatedByAnnotation: CliVersion
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 10s
+      evaluation_interval: 10s
+
+    scrape_configs:
+    - job_name: 'prometheus'
+      static_configs:
+      - targets: ['localhost:9090']
+
+    - job_name: 'controller'
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ['Namespace']
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: ^admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: job

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+FROM gcr.io/runconduit/go-deps:7bceac7a as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller

--- a/controller/api/public/http_server_test.go
+++ b/controller/api/public/http_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"reflect"
 	"testing"
@@ -65,13 +66,13 @@ func TestServer(t *testing.T) {
 		grpcServer: mockGrpcServer,
 	}
 
-	httpServer := &http.Server{
-		Addr:    "localhost:8889",
-		Handler: handler,
+	listener, err := net.Listen("tcp", "localhost:8889")
+	if err != nil {
+		t.Fatalf("Could not start listener: %v", err)
 	}
 
 	go func() {
-		err := httpServer.ListenAndServe()
+		err := http.Serve(listener, handler)
 		if err != nil {
 			t.Fatalf("Could not start server: %v", err)
 		}

--- a/controller/telemetry/server.go
+++ b/controller/telemetry/server.go
@@ -20,6 +20,7 @@ import (
 	public "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/controller/k8s"
 	"github.com/runconduit/conduit/controller/util"
+	pkgK8s "github.com/runconduit/conduit/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -238,8 +239,8 @@ func (s *server) ListPods(ctx context.Context, req *read.ListPodsRequest) (*publ
 			status = "Terminating"
 		}
 
-		plane, _ := pod.Labels["conduit.io/plane"]
-		controller, _ := pod.Labels["conduit.io/controller"]
+		controllerComponent := pod.Labels[pkgK8s.ControllerComponentLabel]
+		controllerNS := pod.Labels[pkgK8s.ControllerNSLabel]
 
 		item := &public.Pod{
 			Name:                pod.Namespace + "/" + pod.Name,
@@ -247,8 +248,8 @@ func (s *server) ListPods(ctx context.Context, req *read.ListPodsRequest) (*publ
 			Status:              status,
 			PodIP:               pod.Status.PodIP,
 			Added:               added,
-			ControllerNamespace: controller,
-			ControlPlane:        plane == "control",
+			ControllerNamespace: controllerNS,
+			ControlPlane:        controllerComponent != "",
 		}
 		if added {
 			since := time.Since(updated)

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -1,0 +1,44 @@
+/*
+Kubernetes labels and annotations used in Conduit's control plane and data plane
+Kubernetes configs.
+*/
+
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/runconduit/conduit/pkg/version"
+)
+
+const (
+	/*
+	 * Labels
+	 */
+
+	// ControllerComponentLabel identifies this object as a component of Conduit's
+	// control plane (e.g. web, controller).
+	ControllerComponentLabel = "conduit.io/control-plane-component"
+
+	// ControllerNSLabel is injected into mesh-enabled apps, identifying the
+	// namespace of the Conduit control plane.
+	ControllerNSLabel = "conduit.io/control-plane-ns"
+
+	/*
+	 * Annotations
+	 */
+
+	// CreatedByAnnotation indicates the source of the injected data plane
+	// (e.g. conduit/cli v0.1.3).
+	CreatedByAnnotation = "conduit.io/created-by"
+
+	// ProxyVersionAnnotation indicates the version of the injected data plane
+	// (e.g. v0.1.3).
+	ProxyVersionAnnotation = "conduit.io/proxy-version"
+)
+
+// CreatedByAnnotationValue returns the value associated with
+// CreatedByAnnotation.
+func CreatedByAnnotationValue() string {
+	return fmt.Sprintf("conduit/cli %s", version.Version)
+}

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+FROM gcr.io/runconduit/go-deps:7bceac7a as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -5,7 +5,7 @@
 ## Build the rust proxy into a binary.
 #
 # If the RELEASE arg is set and non-empty, a release artifact is built.
-FROM gcr.io/runconduit/proxy-deps:fb72d14b as build
+FROM gcr.io/runconduit/proxy-deps:b84ed5d0 as build
 WORKDIR /usr/src/conduit
 # Ranked roughly from least to most likely to change. Cargo.lock is the least likely
 # because it is supposed to be cached in the deps base image.

--- a/proxy/Dockerfile-deps
+++ b/proxy/Dockerfile-deps
@@ -4,7 +4,7 @@
 # are omitted from the resulting image so that artifacts may be built from source over
 # this image.
 #
-# When this file is changed, you must run `bin/update-go-deps-shas`.
+# When this file is changed, you must run `bin/update-proxy-deps-shas`.
 
 # Compile the application to ensure we've obtained all build dependencies and that they
 # compile.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:dac3fae6 as golang
+FROM gcr.io/runconduit/go-deps:7bceac7a as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
The conduit.io/* k8s labels and annotations we're redundant in some
cases, and not flexible enough in others.

This change modifies the labels in the following ways:
`conduit.io/plane: control` => `conduit.io/controller-component: web`
`conduit.io/controller: conduit` => `conduit.io/controller-ns: conduit`
`conduit.io/plane: data` => (remove, redundant with `conduit.io/controller-ns`)
It also centralizes all k8s labels and annotations into
pkg/k8s/labels.go, and adds tests for the install command.

Part of #201

Signed-off-by: Andrew Seigner <siggy@buoyant.io>