### PR TITLE
proxy: add timeout to peeking protocol detection

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -34,6 +34,12 @@ pub struct Config {
     /// The maximum amount of time to wait for a connection to the private peer.
     pub private_connect_timeout: Duration,
 
+    /// The maximum amount of time to peek inbound connections to detect protocol.
+    pub public_peek_timeout: Duration,
+
+    /// The maximum amount of time to peek outbound connections to detect protocol.
+    pub private_peek_timeout: Duration,
+
     /// The path to "/etc/resolv.conf"
     pub resolv_conf_path: PathBuf,
 
@@ -139,6 +145,8 @@ pub const ENV_PUBLIC_LISTENER: &str = "CONDUIT_PROXY_PUBLIC_LISTENER";
 pub const ENV_CONTROL_LISTENER: &str = "CONDUIT_PROXY_CONTROL_LISTENER";
 const ENV_PRIVATE_CONNECT_TIMEOUT: &str = "CONDUIT_PROXY_PRIVATE_CONNECT_TIMEOUT";
 const ENV_PUBLIC_CONNECT_TIMEOUT: &str = "CONDUIT_PROXY_PUBLIC_CONNECT_TIMEOUT";
+const ENV_PRIVATE_PEEK_TIMEOUT: &str = "CONDUIT_PROXY_PRIVATE_PEEK_TIMEOUT";
+const ENV_PUBLIC_PEEK_TIMEOUT: &str = "CONDUIT_PROXY_PUBLIC_PEEK_TIMEOUT";
 
 const ENV_NODE_NAME: &str = "CONDUIT_PROXY_NODE_NAME";
 const ENV_POD_NAME: &str = "CONDUIT_PROXY_POD_NAME";
@@ -157,6 +165,8 @@ const DEFAULT_PRIVATE_LISTENER: &str = "tcp://127.0.0.1:4140";
 const DEFAULT_PUBLIC_LISTENER: &str = "tcp://0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTENER: &str = "tcp://0.0.0.0:4190";
 const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
+const DEFAULT_PUBLIC_PEEK_TIMEOUT_MS: u64 = 2;
+const DEFAULT_PRIVATE_PEEK_TIMEOUT_MS: u64 = 2;
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
 // ===== impl Config =====
@@ -174,6 +184,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let private_forward = parse(strings, ENV_PRIVATE_FORWARD, str::parse);
         let public_connect_timeout = parse(strings, ENV_PUBLIC_CONNECT_TIMEOUT, parse_number);
         let private_connect_timeout = parse(strings, ENV_PRIVATE_CONNECT_TIMEOUT, parse_number);
+        let public_peek_timeout = parse(strings, ENV_PUBLIC_PEEK_TIMEOUT, parse_number);
+        let private_peek_timeout = parse(strings, ENV_PRIVATE_PEEK_TIMEOUT, parse_number);
         let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
         let event_buffer_capacity = parse(strings, ENV_EVENT_BUFFER_CAPACITY, parse_number);
         let metrics_flush_interval_secs =
@@ -215,6 +227,12 @@ impl<'a> TryFrom<&'a Strings> for Config {
             private_connect_timeout:
                 Duration::from_millis(private_connect_timeout?
                                           .unwrap_or(DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS)),
+            public_peek_timeout:
+                Duration::from_millis(public_peek_timeout?
+                                          .unwrap_or(DEFAULT_PUBLIC_PEEK_TIMEOUT_MS)),
+            private_peek_timeout:
+                Duration::from_millis(private_peek_timeout?
+                                          .unwrap_or(DEFAULT_PRIVATE_PEEK_TIMEOUT_MS)),
             resolv_conf_path: resolv_conf_path?
                 .unwrap_or(DEFAULT_RESOLV_CONF.into())
                 .into(),

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -187,6 +187,12 @@ pub struct Peek<T> {
     inner: Option<(Connection, T)>,
 }
 
+impl<T> Peek<T> {
+    pub fn into_inner(self) -> Option<(Connection, T)> {
+        self.inner
+    }
+}
+
 impl<T: AsMut<[u8]>> Future for Peek<T> {
     type Item = (Connection, T, usize);
     type Error = std::io::Error;

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -199,6 +199,7 @@ where
                 inbound_listener,
                 Inbound::new(default_addr, bind),
                 config.private_connect_timeout,
+                config.private_peek_timeout,
                 ctx,
                 sensors.clone(),
                 get_original_dst.clone(),
@@ -230,6 +231,7 @@ where
                 outbound_listener,
                 outgoing,
                 tcp_connect_timeout,
+                config.public_peek_timeout,
                 ctx,
                 sensors,
                 get_original_dst,
@@ -293,6 +295,7 @@ fn serve<R, B, E, F, G>(
     bound_port: BoundPort,
     recognize: R,
     tcp_connect_timeout: Duration,
+    peek_timeout: Duration,
     proxy_ctx: Arc<ctx::Proxy>,
     sensors: telemetry::Sensors,
     get_orig_dst: G,
@@ -328,6 +331,7 @@ where
         get_orig_dst,
         stack,
         tcp_connect_timeout,
+        peek_timeout,
         executor.clone(),
     );
 

--- a/proxy/src/transparency/protocol.rs
+++ b/proxy/src/transparency/protocol.rs
@@ -14,6 +14,10 @@ impl Protocol {
     ///
     /// If no protocol can be determined, returns `None`.
     pub fn detect(bytes: &[u8]) -> Option<Protocol> {
+        if bytes.len() == 0 {
+            return None;
+        }
+
         // http2 is easiest to detect
         if bytes.len() >= H2_PREFACE.len() {
             if &bytes[..H2_PREFACE.len()] == H2_PREFACE {

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -62,11 +62,11 @@ where
         get_orig_dst: G,
         stack: S,
         tcp_connect_timeout: Duration,
+        peek_timeout: Duration,
         executor: Handle,
     ) -> Self {
         let recv_body_svc = HttpBodyNewSvc::new(stack.clone());
         let tcp = tcp::Proxy::new(tcp_connect_timeout, sensors.clone(), &executor);
-        let peek_timeout = Duration::from_millis(2);
         Server {
             executor: executor.clone(),
             get_orig_dst,

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -250,6 +250,29 @@ fn tcp_with_no_orig_dst() {
 }
 
 #[test]
+fn tcp_with_no_peek() {
+    let _ = env_logger::init();
+
+    let msg = "server starts handshake";
+    let srv = server::tcp()
+        .accept_write(move || {
+            "server starts handshake"
+        })
+        .run();
+    let ctrl = controller::new().run();
+    let proxy = proxy::new()
+        .controller(ctrl)
+        .outbound(srv)
+        .run();
+
+    let client = client::tcp(proxy.outbound);
+
+    // we never write, just read
+    let tcp_client = client.connect();
+    assert_eq!(tcp_client.read(), msg.as_bytes())
+}
+
+#[test]
 fn http11_upgrade_not_supported() {
     let _ = env_logger::init();
 


### PR DESCRIPTION
If we timeout trying to peek the connection, we just assume no protocol detection can happen, and treat as TCP.