### PR TITLE
Add ability to change the time window for metrics fetching throughout the app

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -70,6 +70,10 @@ h2, h3, h4, h5, h6 {
   margin-bottom: 0px;
 }
 
+.time-window-btns {
+  float: right;
+}
+
 .subsection-header {
   text-transform: uppercase;
   font-size: 14px;

--- a/web/app/js/components/DeploymentDetail.jsx
+++ b/web/app/js/components/DeploymentDetail.jsx
@@ -244,7 +244,7 @@ export default class DeploymentDetail extends React.Component {
             <PageHeader
               subHeaderTitle="Deployment detail"
               subHeader={this.renderDeploymentTitle()}
-              subMessage={incompleteMeshMessage(this.state.deploy)}
+              subMessage={!this.state.added ? incompleteMeshMessage(this.state.deploy) : null}
               api={this.api} />
 
             {this.renderSections()}

--- a/web/app/js/components/DeploymentDetail.jsx
+++ b/web/app/js/components/DeploymentDetail.jsx
@@ -22,7 +22,6 @@ export default class DeploymentDetail extends React.Component {
     this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
-    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
     this.state = this.initialState(this.props.location);
   }
 
@@ -236,14 +235,6 @@ export default class DeploymentDetail extends React.Component {
     );
   }
 
-  onMetricsWindowChange() {
-    let initialState = this.initialState(this.props.location);
-    let currentState = {
-      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
-    };
-    this.setState(_.merge({}, initialState, currentState));
-  }
-
   render() {
     return (
       <div className="page-content deployment-detail">
@@ -254,7 +245,6 @@ export default class DeploymentDetail extends React.Component {
               subHeaderTitle="Deployment detail"
               subHeader={this.renderDeploymentTitle()}
               subMessage={incompleteMeshMessage(this.state.deploy)}
-              onMetricsWindowChange={this.onMetricsWindowChange}
               api={this.api} />
 
             {this.renderSections()}

--- a/web/app/js/components/DeploymentDetail.jsx
+++ b/web/app/js/components/DeploymentDetail.jsx
@@ -22,6 +22,7 @@ export default class DeploymentDetail extends React.Component {
     this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
+    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
     this.state = this.initialState(this.props.location);
   }
 
@@ -235,6 +236,14 @@ export default class DeploymentDetail extends React.Component {
     );
   }
 
+  onMetricsWindowChange() {
+    let initialState = this.initialState(this.props.location);
+    let currentState = {
+      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
+    };
+    this.setState(_.merge({}, initialState, currentState));
+  }
+
   render() {
     return (
       <div className="page-content deployment-detail">
@@ -245,6 +254,7 @@ export default class DeploymentDetail extends React.Component {
               subHeaderTitle="Deployment detail"
               subHeader={this.renderDeploymentTitle()}
               subMessage={incompleteMeshMessage(this.state.deploy)}
+              onMetricsWindowChange={this.onMetricsWindowChange}
               api={this.api} />
 
             {this.renderSections()}

--- a/web/app/js/components/DeploymentSummary.jsx
+++ b/web/app/js/components/DeploymentSummary.jsx
@@ -1,5 +1,4 @@
 import LineGraph from './LineGraph.jsx';
-import { Link } from 'react-router-dom';
 import React from 'react';
 import { metricToFormatter, toClassName } from './util/Utils.js';
 
@@ -8,7 +7,9 @@ export default class DeploymentSummary extends React.Component {
     if (this.props.noLink) {
       return this.props.data.name;
     } else {
-      return <Link to={`${this.props.pathPrefix}/deployment?deploy=${this.props.data.name}`}>{this.props.data.name}</Link>;
+      return (<this.props.api.ConduitLink
+        to={`/deployment?deploy=${this.props.data.name}`}
+        name={this.props.data.name} />);
     }
   }
 
@@ -17,7 +18,7 @@ export default class DeploymentSummary extends React.Component {
       <div className={`border-container border-neutral`}>
         <div className="border-container-content">
           <div className="summary-title">{this.title()}</div>
-          <div className="summary-info">Last 10 minutes RPS</div>
+          <div className="summary-info">RPS (last {this.props.api.getMetricsWindow()})</div>
 
           <LineGraph
             data={this.props.requestTs}

--- a/web/app/js/components/DeploymentSummary.jsx
+++ b/web/app/js/components/DeploymentSummary.jsx
@@ -18,7 +18,7 @@ export default class DeploymentSummary extends React.Component {
       <div className={`border-container border-neutral`}>
         <div className="border-container-content">
           <div className="summary-title">{this.title()}</div>
-          <div className="summary-info">RPS (last {this.props.api.getMetricsWindow()})</div>
+          <div className="summary-info">RPS (last {this.props.api.getMetricsWindowDisplayText()})</div>
 
           <LineGraph
             data={this.props.requestTs}

--- a/web/app/js/components/DeploymentsList.jsx
+++ b/web/app/js/components/DeploymentsList.jsx
@@ -30,22 +30,8 @@ export default class DeploymentsList extends React.Component {
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.loadTimeseriesFromServer = this.loadTimeseriesFromServer.bind(this);
-    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
 
-    this.state = this.initialState();
-  }
-
-  componentDidMount() {
-    this.loadFromServer();
-    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
-  }
-
-  componentWillUnmount() {
-    window.clearInterval(this.timerId);
-  }
-
-  initialState() {
-    return {
+    this.state = {
       pollingInterval: 10000, // TODO: poll based on metricsWindow size
       metrics: [],
       timeseriesByDeploy: {},
@@ -55,6 +41,15 @@ export default class DeploymentsList extends React.Component {
       loaded: false,
       error: ''
     };
+  }
+
+  componentDidMount() {
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.timerId);
   }
 
   addDeploysWithNoMetrics(deploys, metrics) {
@@ -208,24 +203,13 @@ export default class DeploymentsList extends React.Component {
     </div>);
   }
 
-  onMetricsWindowChange() {
-    let initialState = this.initialState();
-    let currentState = {
-      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
-    };
-    this.setState(_.merge({}, initialState, currentState));
-  }
-
   render() {
     return (
       <div className="page-content">
         { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
-            <PageHeader
-              header="Deployments"
-              onMetricsWindowChange={this.onMetricsWindowChange}
-              api={this.api} />
+            <PageHeader header="Deployments" api={this.api} />
             { _.isEmpty(this.state.metrics) ?
               <CallToAction numDeployments={_.size(this.state.metrics)} /> :
               this.renderPageContents()

--- a/web/app/js/components/DeploymentsList.jsx
+++ b/web/app/js/components/DeploymentsList.jsx
@@ -69,7 +69,7 @@ export default class DeploymentsList extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    let rollupRequest = this.api.fetchMetrics();
+    let rollupRequest = this.api.fetchMetrics(this.api.urlsForResource["deployment"].url().rollup);
     let podsRequest = this.api.fetchPods();
 
     // expose serverPromise for testing

--- a/web/app/js/components/DeploymentsList.jsx
+++ b/web/app/js/components/DeploymentsList.jsx
@@ -3,10 +3,10 @@ import CallToAction from './CallToAction.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import DeploymentSummary from './DeploymentSummary.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
+import PageHeader from './PageHeader.jsx';
 import React from 'react';
 import ScatterPlot from './ScatterPlot.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
-import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import { Col, Row } from 'antd';
 import { emptyMetric, getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
 import { metricToFormatter, rowGutter } from './util/Utils.js';
@@ -26,13 +26,12 @@ let nodeStats = (description, node) => (
 export default class DeploymentsList extends React.Component {
   constructor(props) {
     super(props);
-    this.api = ApiHelpers(this.props.pathPrefix);
+    this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.loadTimeseriesFromServer = this.loadTimeseriesFromServer.bind(this);
 
     this.state = {
-      metricsWindow: "10m",
       pollingInterval: 10000, // TODO: poll based on metricsWindow size
       metrics: [],
       timeseriesByDeploy: {},
@@ -70,9 +69,7 @@ export default class DeploymentsList extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    let rollupPath = `${this.props.pathPrefix}/api/metrics?window=${this.state.metricsWindow}`;
-
-    let rollupRequest = this.api.fetch(rollupPath);
+    let rollupRequest = this.api.fetchMetrics();
     let podsRequest = this.api.fetchPods();
 
     // expose serverPromise for testing
@@ -91,12 +88,12 @@ export default class DeploymentsList extends React.Component {
     // fetch only the timeseries for the 3 deployments we display at the top of the page
     let limitSparklineData = _.size(meshDeployMetrics) > maxTsToFetch;
 
-    let resourceInfo = urlsForResource(this.props.pathPrefix, this.state.metricsWindow)["deployment"];
+    let resourceInfo = this.api.urlsForResource["deployment"];
     let leastHealthyDeployments = this.getLeastHealthyDeployments(meshDeployMetrics);
 
     let tsPromises = _.map(leastHealthyDeployments, dep => {
       let tsPathForDeploy = resourceInfo.url(dep.name).ts;
-      return this.api.fetch(tsPathForDeploy);
+      return this.api.fetchMetrics(tsPathForDeploy);
     });
 
     Promise.all(tsPromises)
@@ -147,8 +144,8 @@ export default class DeploymentsList extends React.Component {
                   key={deployment.name}
                   lastUpdated={this.state.lastUpdated}
                   data={deployment}
-                  requestTs={_.get(this.state.timeseriesByDeploy, [deployment.name, "REQUEST_RATE"], [])}
-                  pathPrefix={this.props.pathPrefix} />
+                  api = {this.api}
+                  requestTs={_.get(this.state.timeseriesByDeploy, [deployment.name, "REQUEST_RATE"], [])} />
               </Col>);
             })
           }
@@ -162,8 +159,7 @@ export default class DeploymentsList extends React.Component {
             lastUpdated={this.state.lastUpdated}
             metrics={this.state.metrics}
             hideSparklines={this.state.limitSparklineData}
-            metricsWindow={this.state.metricsWindow}
-            pathPrefix={this.props.pathPrefix} />
+            api={this.api} />
         </div>
       </div>
     );
@@ -213,9 +209,7 @@ export default class DeploymentsList extends React.Component {
         { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
-            <div className="page-header">
-              <h1>Deployments</h1>
-            </div>
+            <PageHeader header="Deployments" api={this.api} />
             { _.isEmpty(this.state.metrics) ?
               <CallToAction numDeployments={_.size(this.state.metrics)} /> :
               this.renderPageContents()

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -1,0 +1,49 @@
+import _ from 'lodash';
+import React from 'react';
+import { Col, Radio, Row } from 'antd';
+
+export default class PageHeader extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onTimeWindowClick = this.onTimeWindowClick.bind(this);
+    this.state = {
+      selectedWindow: this.props.api.getMetricsWindow()
+    };
+  }
+
+  onTimeWindowClick(e) {
+    let window = e.target.value;
+    this.props.api.setMetricsWindow(window);
+    this.setState({selectedWindow: window});
+  }
+
+  render() {
+    return (
+      <div className="page-header">
+        <Row>
+          <Col span={18}>
+            {!this.props.header ? null : <h1>{this.props.header}</h1>}
+            {!this.props.subHeaderTitle ? null : <div className="subsection-header">{this.props.subHeaderTitle}</div>}
+            {!this.props.subHeader ? null : <h1>{this.props.subHeader}</h1>}
+          </Col>
+          { this.props.hideButtons ? null :
+            <Col span={6}>
+              <Radio.Group
+                className="time-window-btns"
+                value={this.state.selectedWindow}
+                onChange={this.onTimeWindowClick} >
+                {
+                  _.map(this.props.api.getValidMetricsWindows(), (w, i) => {
+                    return <Radio.Button key={`metrics-window-btn-${i}`} value={w}>{w}</Radio.Button>;
+                  })
+                }
+              </Radio.Group>
+            </Col>
+          }
+        </Row>
+
+        {!this.props.subMessage ? null : <div>{this.props.subMessage}</div>}
+      </div>
+    );
+  }
+}

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -15,7 +15,6 @@ export default class PageHeader extends React.Component {
     let window = e.target.value;
     this.props.api.setMetricsWindow(window);
     this.setState({selectedWindow: window});
-    _.isNil(this.props.onMetricsWindowChange) ? null : this.props.onMetricsWindowChange();
   }
 
   render() {

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -17,9 +17,9 @@ export default class PageHeader extends React.Component {
     this.setState({selectedWindow: window});
   }
 
+  // don't use time window changing until the results of Telemetry Scalability are in
+  // https://github.com/runconduit/conduit/milestone/4
   renderMetricWindowButtons() {
-    // don't use time window changing until the results of Telemetry Scalability are in
-    // https://github.com/runconduit/conduit/milestone/4
     if (this.props.hideButtons) {
       return null;
     } else {

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -1,5 +1,6 @@
+import _ from 'lodash';
 import React from 'react';
-import { Col, Row } from 'antd';
+import { Col, Radio, Row } from 'antd';
 
 export default class PageHeader extends React.Component {
   constructor(props) {
@@ -16,6 +17,27 @@ export default class PageHeader extends React.Component {
     this.setState({selectedWindow: window});
   }
 
+  renderMetricWindowButtons() {
+    // don't use time window changing until the results of Telemetry Scalability are in
+    // https://github.com/runconduit/conduit/milestone/4
+    if (this.props.hideButtons) {
+      return null;
+    } else {
+      return (<Col span={6}>
+        <Radio.Group
+          className="time-window-btns"
+          value={this.state.selectedWindow}
+          onChange={this.onTimeWindowClick} >
+          {
+            _.map(this.props.api.getValidMetricsWindows(), (w, i) => {
+              return <Radio.Button key={`metrics-window-btn-${i}`} value={w}>{w}</Radio.Button>;
+            })
+          }
+        </Radio.Group>
+      </Col>);
+    }
+  }
+
   render() {
     return (
       <div className="page-header">
@@ -25,20 +47,7 @@ export default class PageHeader extends React.Component {
             {!this.props.subHeaderTitle ? null : <div className="subsection-header">{this.props.subHeaderTitle}</div>}
             {!this.props.subHeader ? null : <h1>{this.props.subHeader}</h1>}
           </Col>
-          {/* { this.props.hideButtons ? null :
-            <Col span={6}>
-              <Radio.Group
-                className="time-window-btns"
-                value={this.state.selectedWindow}
-                onChange={this.onTimeWindowClick} >
-                {
-                  _.map(this.props.api.getValidMetricsWindows(), (w, i) => {
-                    return <Radio.Button key={`metrics-window-btn-${i}`} value={w}>{w}</Radio.Button>;
-                  })
-                }
-              </Radio.Group>
-            </Col>
-          } */}
+          {/* {this.renderMetricWindowButtons()} */}
         </Row>
 
         {!this.props.subMessage ? null : <div>{this.props.subMessage}</div>}

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -15,6 +15,7 @@ export default class PageHeader extends React.Component {
     let window = e.target.value;
     this.props.api.setMetricsWindow(window);
     this.setState({selectedWindow: window});
+    _.isNil(this.props.onMetricsWindowChange) ? null : this.props.onMetricsWindowChange();
   }
 
   render() {

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -1,6 +1,5 @@
-import _ from 'lodash';
 import React from 'react';
-import { Col, Radio, Row } from 'antd';
+import { Col, Row } from 'antd';
 
 export default class PageHeader extends React.Component {
   constructor(props) {
@@ -26,7 +25,7 @@ export default class PageHeader extends React.Component {
             {!this.props.subHeaderTitle ? null : <div className="subsection-header">{this.props.subHeaderTitle}</div>}
             {!this.props.subHeader ? null : <h1>{this.props.subHeader}</h1>}
           </Col>
-          { this.props.hideButtons ? null :
+          {/* { this.props.hideButtons ? null :
             <Col span={6}>
               <Radio.Group
                 className="time-window-btns"
@@ -39,7 +38,7 @@ export default class PageHeader extends React.Component {
                 }
               </Radio.Group>
             </Col>
-          }
+          } */}
         </Row>
 
         {!this.props.subMessage ? null : <div>{this.props.subMessage}</div>}

--- a/web/app/js/components/Paths.jsx
+++ b/web/app/js/components/Paths.jsx
@@ -1,15 +1,15 @@
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
+import PageHeader from './PageHeader.jsx';
 import { processRollupMetrics } from './util/MetricUtils.js';
 import React from 'react';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
-import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import 'whatwg-fetch';
 
 export default class Paths extends React.Component {
   constructor(props) {
     super(props);
-    this.api = ApiHelpers(this.props.pathPrefix);
+    this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.state = this.initialState();
@@ -28,7 +28,6 @@ export default class Paths extends React.Component {
     return {
       lastUpdated: 0,
       pollingInterval: 10000,
-      metricsWindow: "1m",
       metrics: [],
       pendingRequests: false,
       loaded: false,
@@ -42,9 +41,9 @@ export default class Paths extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    let urls = urlsForResource(this.props.pathPrefix, this.state.metricsWindow);
+    let urls = this.api.urlsForResource;
 
-    this.api.fetch(urls["path"].url().rollup).then(r => {
+    this.api.fetchMetrics(urls["path"].url().rollup).then(r => {
       let metrics = processRollupMetrics(r.metrics, "path");
 
       this.setState({
@@ -70,16 +69,13 @@ export default class Paths extends React.Component {
         { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
         { !this.state.loaded ? <ConduitSpinner /> :
           <div>
-            <div className="page-header">
-              <h1>Paths</h1>
-            </div>
+            <PageHeader header="Paths" api={this.api} />
 
             <TabbedMetricsTable
               resource="path"
               metrics={this.state.metrics}
               lastUpdated={this.state.lastUpdated}
-              pathPrefix={this.props.pathPrefix}
-              metricsWindow={this.state.metricsWindow}
+              api={this.api}
               sortable={true}
               hideSparklines={true} />
           </div>

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -15,7 +15,6 @@ export default class PodDetail extends React.Component {
     this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
-    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
     this.state = this.initialState(this.props.location);
   }
 
@@ -38,7 +37,6 @@ export default class PodDetail extends React.Component {
   initialState(location) {
     let urlParams = new URLSearchParams(location.search);
     let pod = urlParams.get("pod");
-
     return {
       lastUpdated: 0,
       pollingInterval: 10000,
@@ -124,14 +122,6 @@ export default class PodDetail extends React.Component {
     ];
   }
 
-  onMetricsWindowChange() {
-    let initialState = this.initialState(this.props.location);
-    let currentState = {
-      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
-    };
-    this.setState(_.merge({}, initialState, currentState));
-  }
-
   render() {
     return (
       <div className="page-content pod-detail">
@@ -141,7 +131,6 @@ export default class PodDetail extends React.Component {
             <PageHeader
               subHeaderTitle="Pod detail"
               subHeader={this.state.pod}
-              onMetricsWindowChange={this.onMetricsWindowChange}
               api={this.api} />
             {this.renderSections()}
           </div>

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -15,6 +15,7 @@ export default class PodDetail extends React.Component {
     this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
+    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
     this.state = this.initialState(this.props.location);
   }
 
@@ -37,6 +38,7 @@ export default class PodDetail extends React.Component {
   initialState(location) {
     let urlParams = new URLSearchParams(location.search);
     let pod = urlParams.get("pod");
+
     return {
       lastUpdated: 0,
       pollingInterval: 10000,
@@ -122,6 +124,14 @@ export default class PodDetail extends React.Component {
     ];
   }
 
+  onMetricsWindowChange() {
+    let initialState = this.initialState(this.props.location);
+    let currentState = {
+      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
+    };
+    this.setState(_.merge({}, initialState, currentState));
+  }
+
   render() {
     return (
       <div className="page-content pod-detail">
@@ -131,6 +141,7 @@ export default class PodDetail extends React.Component {
             <PageHeader
               subHeaderTitle="Pod detail"
               subHeader={this.state.pod}
+              onMetricsWindowChange={this.onMetricsWindowChange}
               api={this.api} />
             {this.renderSections()}
           </div>

--- a/web/app/js/components/ResourceMetricsOverview.jsx
+++ b/web/app/js/components/ResourceMetricsOverview.jsx
@@ -15,12 +15,14 @@ export default class ResourceMetricsOverview extends React.Component {
               name="Request rate"
               metric="REQUEST_RATE"
               lastUpdated={this.props.lastUpdated}
+              window={this.props.window}
               timeseries={_.get(this.props.timeseries, "REQUEST_RATE", [])} />
           </Col>
           <Col span={8}>
             <ResourceOverviewMetric
               name="Success rate"
               metric="SUCCESS_RATE"
+              window={this.props.window}
               lastUpdated={this.props.lastUpdated}
               timeseries={_.get(this.props.timeseries, "SUCCESS_RATE", [])} />
           </Col>

--- a/web/app/js/components/ResourceOverviewMetric.jsx
+++ b/web/app/js/components/ResourceOverviewMetric.jsx
@@ -3,7 +3,7 @@ import LineGraph from './LineGraph.jsx';
 import React from 'react';
 import { metricToFormatter, toClassName } from './util/Utils.js';
 
-export default class EntityOverviewMetric extends React.Component {
+export default class ResourceOverviewMetric extends React.Component {
   render() {
     let lastDatapoint = _.last(this.props.timeseries) || {};
     let metric = _.get(lastDatapoint, "value");
@@ -15,7 +15,7 @@ export default class EntityOverviewMetric extends React.Component {
           <div className="summary-container clearfix">
             <div className="metric-info">
               <div className="summary-title">{this.props.name}</div>
-              <div className="summary-info">Last 10 minutes performance</div>
+              <div className="summary-info">last {this.props.window}</div>
             </div>
             <div className="metric-value">{displayMetric}</div>
           </div>

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -54,23 +54,9 @@ export default class ServiceMesh extends React.Component {
     super(props);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.handleApiError = this.handleApiError.bind(this);
-    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
     this.api = this.props.api;
 
-    this.state = this.initialState();
-  }
-
-  componentDidMount() {
-    this.loadFromServer();
-    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
-  }
-
-  componentWillUnmount() {
-    window.clearInterval(this.timerId);
-  }
-
-  initialState() {
-    return {
+    this.state = {
       pollingInterval: 2000,
       metrics: [],
       deploys: [],
@@ -80,6 +66,15 @@ export default class ServiceMesh extends React.Component {
       loaded: false,
       error: ''
     };
+  }
+
+  componentDidMount() {
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.timerId);
   }
 
   loadFromServer() {
@@ -327,14 +322,6 @@ export default class ServiceMesh extends React.Component {
     }
   }
 
-  onMetricsWindowChange() {
-    let initialState = this.initialState();
-    let currentState = {
-      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
-    };
-    this.setState(_.merge({}, initialState, currentState));
-  }
-
   render() {
     return (
       <div className="page-content">
@@ -344,7 +331,6 @@ export default class ServiceMesh extends React.Component {
             <PageHeader
               header="Service mesh overview"
               hideButtons={this.proxyCount() === 0}
-              onMetricsWindowChange={this.onMetricsWindowChange}
               api={this.api} />
             {this.renderOverview()}
             {this.renderControlPlane()}

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -54,18 +54,10 @@ export default class ServiceMesh extends React.Component {
     super(props);
     this.loadFromServer = this.loadFromServer.bind(this);
     this.handleApiError = this.handleApiError.bind(this);
+    this.onMetricsWindowChange = this.onMetricsWindowChange.bind(this);
     this.api = this.props.api;
 
-    this.state = {
-      pollingInterval: 2000,
-      metrics: [],
-      deploys: [],
-      components: [],
-      lastUpdated: 0,
-      pendingRequests: false,
-      loaded: false,
-      error: ''
-    };
+    this.state = this.initialState();
   }
 
   componentDidMount() {
@@ -75,6 +67,19 @@ export default class ServiceMesh extends React.Component {
 
   componentWillUnmount() {
     window.clearInterval(this.timerId);
+  }
+
+  initialState() {
+    return {
+      pollingInterval: 2000,
+      metrics: [],
+      deploys: [],
+      components: [],
+      lastUpdated: 0,
+      pendingRequests: false,
+      loaded: false,
+      error: ''
+    };
   }
 
   loadFromServer() {
@@ -322,6 +327,14 @@ export default class ServiceMesh extends React.Component {
     }
   }
 
+  onMetricsWindowChange() {
+    let initialState = this.initialState();
+    let currentState = {
+      pendingRequests: this.state.pendingRequests // let pending requests complete, until we have a way of cancelling them
+    };
+    this.setState(_.merge({}, initialState, currentState));
+  }
+
   render() {
     return (
       <div className="page-content">
@@ -331,6 +344,7 @@ export default class ServiceMesh extends React.Component {
             <PageHeader
               header="Service mesh overview"
               hideButtons={this.proxyCount() === 0}
+              onMetricsWindowChange={this.onMetricsWindowChange}
               api={this.api} />
             {this.renderOverview()}
             {this.renderControlPlane()}

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -1,7 +1,5 @@
 import _ from 'lodash';
-import { ApiHelpers } from './util/ApiHelpers.js';
 import { getPodsByDeployment } from './util/MetricUtils.js';
-import { Link } from 'react-router-dom';
 import logo from './../../img/reversed_logo.png';
 import React from 'react';
 import Version from './Version.jsx';
@@ -13,7 +11,7 @@ const searchBarWidth = 240;
 export default class Sidebar extends React.Component {
   constructor(props) {
     super(props);
-    this.api = ApiHelpers(this.props.pathPrefix);
+    this.api = this.props.api;
     this.filterDeployments = this.filterDeployments.bind(this);
     this.onAutocompleteSelect = this.onAutocompleteSelect.bind(this);
     this.loadFromServer();
@@ -60,12 +58,12 @@ export default class Sidebar extends React.Component {
 
   render() {
     let normalizedPath = this.props.location.pathname.replace(this.props.pathPrefix, "");
-
+    let ConduitLink = this.api.ConduitLink;
     return (
       <div className="sidebar">
         <div className="list-container">
           <div className="sidebar-headers">
-            <Link to={`${this.props.pathPrefix}/servicemesh`}><img src={logo} /></Link>
+            <ConduitLink to="/servicemesh" name={<img src={logo} />} />
           </div>
 
           <AutoComplete
@@ -79,16 +77,16 @@ export default class Sidebar extends React.Component {
 
           <Menu className="sidebar-menu" theme="dark" selectedKeys={[normalizedPath]}>
             <Menu.Item className="sidebar-menu-item" key="/servicemesh">
-              <Link to={`${this.props.pathPrefix}/servicemesh`}>Service mesh</Link>
+              <ConduitLink to="/servicemesh" name="Service mesh" />
             </Menu.Item>
             <Menu.Item className="sidebar-menu-item" key="/deployments">
-              <Link to={`${this.props.pathPrefix}/deployments`}>Deployments</Link>
+              <ConduitLink to="/deployments" name="Deployments" />
             </Menu.Item>
             <Menu.Item className="sidebar-menu-item" key="/routes">
-              <Link to={`${this.props.pathPrefix}/routes`}>Routes</Link>
+              <ConduitLink to="/routes" name="Routes" />
             </Menu.Item>
             <Menu.Item className="sidebar-menu-item" key="/docs">
-              <Link to="https://conduit.io/docs/" target="_blank">Documentation</Link>
+              <ConduitLink to="https://conduit.io/docs/" absolute="true" target="_blank" name="Documentation" />
             </Menu.Item>
           </Menu>
 

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -63,7 +63,7 @@ export default class Sidebar extends React.Component {
       <div className="sidebar">
         <div className="list-container">
           <div className="sidebar-headers">
-            <ConduitLink to="/servicemesh" name={<img src={logo} />} />
+            <ConduitLink to="/servicemesh"><img src={logo} /></ConduitLink>
           </div>
 
           <AutoComplete
@@ -77,16 +77,16 @@ export default class Sidebar extends React.Component {
 
           <Menu className="sidebar-menu" theme="dark" selectedKeys={[normalizedPath]}>
             <Menu.Item className="sidebar-menu-item" key="/servicemesh">
-              <ConduitLink to="/servicemesh" name="Service mesh" />
+              <ConduitLink to="/servicemesh">Service mesh</ConduitLink>
             </Menu.Item>
             <Menu.Item className="sidebar-menu-item" key="/deployments">
-              <ConduitLink to="/deployments" name="Deployments" />
+              <ConduitLink to="/deployments">Deployments</ConduitLink>
             </Menu.Item>
             <Menu.Item className="sidebar-menu-item" key="/routes">
-              <ConduitLink to="/routes" name="Routes" />
+              <ConduitLink to="/routes">Routes</ConduitLink>
             </Menu.Item>
             <Menu.Item className="sidebar-menu-item" key="/docs">
-              <ConduitLink to="https://conduit.io/docs/" absolute="true" target="_blank" name="Documentation" />
+              <ConduitLink to="https://conduit.io/docs/" absolute="true">Documentation</ConduitLink>
             </Menu.Item>
           </Menu>
 

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { Link } from 'react-router-dom';
 import React from 'react';
 import { Table, Tooltip } from 'antd';
 
@@ -37,12 +36,12 @@ const StatusDot = ({status, multilineDots, columnName}) => (
 );
 
 const columns = {
-  resourceName: (shouldLink, pathPrefix) => {
+  resourceName: (shouldLink, ConduitLink) => {
     return {
       title: "Deployment",
       dataIndex: "name",
       key: "name",
-      render: name => shouldLink ? <Link to={`${pathPrefix}/deployment?deploy=${name}`}>{name}</Link> : name
+      render: name => shouldLink ? <ConduitLink to={`/deployment?deploy=${name}`} name={name} /> : name
     };
   },
   pods: {
@@ -85,7 +84,7 @@ export default class StatusTable extends React.Component {
 
   render() {
     let tableCols = [
-      columns.resourceName(this.props.shouldLink, this.props.pathPrefix),
+      columns.resourceName(this.props.shouldLink, this.props.api.ConduitLink),
       columns.pods,
       columns.status(this.props.statusColumnTitle)
     ];

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -41,7 +41,7 @@ const columns = {
       title: "Deployment",
       dataIndex: "name",
       key: "name",
-      render: name => shouldLink ? <ConduitLink to={`/deployment?deploy=${name}`} name={name} /> : name
+      render: name => shouldLink ? <ConduitLink to={`/deployment?deploy=${name}`}>{name}</ConduitLink> : name
     };
   },
   pods: {

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -185,7 +185,7 @@ export default class TabbedMetricsTable extends React.Component {
 
   getSparklineColumn(metricName) {
     return {
-      title: "10 minute history",
+      title: `History (last ${this.api.getMetricsWindow()})`,
       key: metricName,
       className: "numeric",
       render: d => {

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -1,10 +1,8 @@
 import _ from 'lodash';
 import LineGraph from './LineGraph.jsx';
-import { Link } from 'react-router-dom';
 import Percentage from './util/Percentage.js';
 import { processTimeseriesMetrics } from './util/MetricUtils.js';
 import React from 'react';
-import { ApiHelpers, urlsForResource } from './util/ApiHelpers.js';
 import { metricToFormatter, toClassName } from './util/Utils.js';
 import { Table, Tabs } from 'antd';
 
@@ -23,16 +21,16 @@ const resourceInfo = {
   "path": { title: "path", url: null }
 };
 
-const generateColumns = sortable => {
+const generateColumns = (sortable, ConduitLink) => {
   return {
-    resourceName: (resource, pathPrefix) => {
+    resourceName: resource => {
       return {
         title: resource.title,
         dataIndex: "name",
         key: "name",
         sorter: sortable ? (a, b) => (a.name || "").localeCompare(b.name) : false,
         render: name => !resource.url ? name :
-          <Link to={`${pathPrefix}${resource.url}${name}`}>{name}</Link>
+          <ConduitLink to={`${resource.url}${name}`} name={name} />
       };
     },
     successRate: {
@@ -91,14 +89,14 @@ const numericSort = (a, b) => (_.isNil(a) ? -1 : a) - (_.isNil(b) ? -1 : b);
 
 const metricToColumns = baseCols => {
   return {
-    requestRate: (resource, pathPrefix) => [
-      baseCols.resourceName(resource, pathPrefix),
+    requestRate: resource => [
+      baseCols.resourceName(resource),
       baseCols.requests,
       resource.title === "deployment" ? null : baseCols.requestDistribution
     ],
-    successRate: (resource, pathPrefix) => [baseCols.resourceName(resource, pathPrefix), baseCols.successRate],
-    latency: (resource, pathPrefix) => [
-      baseCols.resourceName(resource, pathPrefix),
+    successRate: resource => [baseCols.resourceName(resource), baseCols.successRate],
+    latency: resource => [
+      baseCols.resourceName(resource),
       baseCols.latencyP50,
       baseCols.latencyP95,
       baseCols.latencyP99
@@ -115,11 +113,11 @@ const nameToDataKey = {
 export default class TabbedMetricsTable extends React.Component {
   constructor(props) {
     super(props);
-    this.api = ApiHelpers(this.props.pathPrefix);
+    this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
 
-    let tsHelper = urlsForResource(this.props.pathPrefix, this.props.metricsWindow)[this.props.resource];
+    let tsHelper = this.api.urlsForResource[this.props.resource];
 
     this.state = {
       timeseries: {},
@@ -128,7 +126,6 @@ export default class TabbedMetricsTable extends React.Component {
       metricsUrl: tsHelper.url(this.props.resourceName),
       error: '',
       lastUpdated: this.props.lastUpdated,
-      metricsWindow: "10s",
       pollingInterval: 10000,
       pendingRequests: false
     };
@@ -167,7 +164,7 @@ export default class TabbedMetricsTable extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    this.api.fetch(this.state.metricsUrl.ts)
+    this.api.fetchMetrics(this.state.metricsUrl.ts)
       .then(tsResp => {
         let tsByEntity = processTimeseriesMetrics(tsResp.metrics, this.state.groupBy);
         this.setState({
@@ -212,8 +209,8 @@ export default class TabbedMetricsTable extends React.Component {
 
   renderTable(metric) {
     let resource = resourceInfo[this.props.resource];
-    let columnDefinitions = metricToColumns(generateColumns(this.props.sortable));
-    let columns = _.compact(columnDefinitions[metric](resource, this.props.pathPrefix));
+    let columnDefinitions = metricToColumns(generateColumns(this.props.sortable, this.props.api.ConduitLink));
+    let columns = _.compact(columnDefinitions[metric](resource));
     if (!this.props.hideSparklines) {
       columns.push(this.getSparklineColumn(metric));
     }

--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -30,7 +30,7 @@ const generateColumns = (sortable, ConduitLink) => {
         key: "name",
         sorter: sortable ? (a, b) => (a.name || "").localeCompare(b.name) : false,
         render: name => !resource.url ? name :
-          <ConduitLink to={`${resource.url}${name}`} name={name} />
+          <ConduitLink to={`${resource.url}${name}`}>{name}</ConduitLink>
       };
     },
     successRate: {

--- a/web/app/js/components/UpstreamDownstream.jsx
+++ b/web/app/js/components/UpstreamDownstream.jsx
@@ -26,8 +26,7 @@ export default class UpstreamDownstreamTables extends React.Component {
                   hideSparklines={numUpstreams > maxTsToFetch}
                   lastUpdated={this.props.lastUpdated}
                   metrics={this.props.upstreamMetrics}
-                  metricsWindow={this.props.metricsWindow}
-                  pathPrefix={this.props.pathPrefix} />
+                  api={this.props.api} />
               </div>
           }
           {
@@ -44,8 +43,7 @@ export default class UpstreamDownstreamTables extends React.Component {
                   hideSparklines={numDownstreams > maxTsToFetch}
                   lastUpdated={this.props.lastUpdated}
                   metrics={this.props.downstreamMetrics}
-                  metricsWindow={this.props.metricsWindow}
-                  pathPrefix={this.props.pathPrefix} />
+                  api={this.props.api} />
               </div>
           }
         </Col>

--- a/web/app/js/components/Version.jsx
+++ b/web/app/js/components/Version.jsx
@@ -1,4 +1,4 @@
-import { ApiHelpers } from './util/ApiHelpers.js';
+import { ApiHelpers } from './util/ApiHelpers.jsx';
 import { Link } from 'react-router-dom';
 import React from 'react';
 import './../../css/version.css';

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -145,8 +145,9 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
   // prefix all links in the app with `pathPrefix`
   const ConduitLink = props => {
     let {to, name, absolute} = props;
+
     if (absolute) {
-      return <Link to={to}>{name}</Link>;
+      return <Link to={to} target="_blank">{name}</Link>;
     } else {
       return <Link to={`${pathPrefix}${to}`}>{name}</Link>;
     }

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -24,7 +24,11 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
 
   const fetchMetrics = (path = metricsPath()) => {
     if (path.indexOf("window") === -1) {
-      path = `${path}&window=${getMetricsWindow()}`;
+      if (path.indexOf("?") === -1) {
+        path = `${path}?window=${getMetricsWindow()}`;
+      } else {
+        path = `${path}&window=${getMetricsWindow()}`;
+      }
     }
     return apiFetch(path);
   };

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -6,7 +6,6 @@ import 'whatwg-fetch';
 export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
   let metricsWindow = defaultMetricsWindow;
   const podsPath = `/api/pods`;
-  const metricsPath = () => `/api/metrics?window=${metricsWindow}`;
 
   const validMetricsWindows = {
     "10s": "10 minutes",
@@ -22,7 +21,7 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
     return fetch(path).then(handleFetchErr).then(r => r.json());
   };
 
-  const fetchMetrics = (path = metricsPath()) => {
+  const fetchMetrics = path => {
     if (path.indexOf("window") === -1) {
       if (path.indexOf("?") === -1) {
         path = `${path}?window=${getMetricsWindow()}`;

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -145,12 +145,12 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
 
   // prefix all links in the app with `pathPrefix`
   const ConduitLink = props => {
-    let {to, name, absolute} = props;
+    let {to, absolute} = props;
 
     if (absolute) {
-      return <Link to={to} target="_blank">{name}</Link>;
+      return <Link to={to} target="_blank">{props.children}</Link>;
     } else {
-      return <Link to={`${pathPrefix}${to}`}>{name}</Link>;
+      return <Link to={`${pathPrefix}${to}`}>{props.children}</Link>;
     }
   };
 

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -9,10 +9,10 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
   const metricsPath = () => `/api/metrics?window=${metricsWindow}`;
 
   const validMetricsWindows = {
-    "10s": true,
-    "1m": true,
-    "10m": true,
-    "1h": true
+    "10s": "10 minutes",
+    "1m": "1 minute",
+    "10m": "10 minutes",
+    "1h": "1 hour"
   };
 
   const apiFetch = path => {
@@ -45,6 +45,7 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
   };
 
   const getMetricsWindow = () => metricsWindow;
+  const getMetricsWindowDisplayText = () => validMetricsWindows[metricsWindow];
 
   const setMetricsWindow = window => {
     if (!validMetricsWindows[window]) return;
@@ -160,6 +161,7 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
     getMetricsWindow,
     setMetricsWindow,
     getValidMetricsWindows: () => _.keys(validMetricsWindows),
+    getMetricsWindowDisplayText,
     urlsForResource: urlsForResource,
     ConduitLink
   };

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -1,3 +1,4 @@
+import { ApiHelpers } from './components/util/ApiHelpers.jsx';
 import DeploymentDetail from './components/DeploymentDetail.jsx';
 import DeploymentsList from './components/DeploymentsList.jsx';
 import { Layout } from 'antd';
@@ -13,7 +14,7 @@ import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import './../css/styles.css';
 
 let appMain = document.getElementById('main');
-let appData = appMain.dataset;
+let appData = !appMain ? {} : appMain.dataset;
 
 let pathPrefix = "";
 let proxyPathMatch = window.location.pathname.match(/\/api\/v1\/namespaces\/.*\/proxy/g);
@@ -21,23 +22,25 @@ if (proxyPathMatch) {
   pathPrefix = proxyPathMatch[0];
 }
 
+let api = ApiHelpers(pathPrefix);
+
 ReactDOM.render((
   <BrowserRouter>
     <Layout>
       <Layout.Sider width="310">
-        <Route render={routeProps => <Sidebar {...routeProps} goVersion={appData.goVersion} releaseVersion={appData.releaseVersion} pathPrefix={pathPrefix} uuid={appData.uuid} />} />
+        <Route render={routeProps => <Sidebar {...routeProps} goVersion={appData.goVersion} releaseVersion={appData.releaseVersion} api={api} pathPrefix={pathPrefix} uuid={appData.uuid} />} />
       </Layout.Sider>
       <Layout>
         <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
           <div className="main-content">
             <Switch>
               <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
-              <Route path={`${pathPrefix}/servicemesh`} render={() => <ServiceMesh pathPrefix={pathPrefix} releaseVersion={appData.releaseVersion} />} />
-              <Route path={`${pathPrefix}/deployments`} render={() => <DeploymentsList pathPrefix={pathPrefix} />} />
-              <Route path={`${pathPrefix}/deployment`} render={props => <DeploymentDetail pathPrefix={pathPrefix} location={props.location} />} />
-              <Route path={`${pathPrefix}/paths`} render={props => <Paths pathPrefix={pathPrefix} location={props.location} />} />
-              <Route path={`${pathPrefix}/pod`} render={props => <PodDetail pathPrefix={pathPrefix} location={props.location} />} />
-              <Route path={`${pathPrefix}/routes`} render={() => <Routes pathPrefix={pathPrefix} />} />
+              <Route path={`${pathPrefix}/servicemesh`} render={() => <ServiceMesh api={api} releaseVersion={appData.releaseVersion} />} />
+              <Route path={`${pathPrefix}/deployments`} render={() => <DeploymentsList api={api} />} />
+              <Route path={`${pathPrefix}/deployment`} render={props => <DeploymentDetail api={api} location={props.location} />} />
+              <Route path={`${pathPrefix}/paths`} render={props => <Paths api={api} location={props.location} />} />
+              <Route path={`${pathPrefix}/pod`} render={props => <PodDetail api={api} location={props.location} />} />
+              <Route path={`${pathPrefix}/routes`} render={() => <Routes />} />
               <Route component={NoMatch} />
             </Switch>
           </div>

--- a/web/app/test/ApiHelpersTest.jsx
+++ b/web/app/test/ApiHelpersTest.jsx
@@ -1,0 +1,144 @@
+/* eslint-disable */
+import 'raf/polyfill'; // the polyfill import must be first
+import Adapter from 'enzyme-adapter-react-16';
+import { ApiHelpers } from '../js/components/util/ApiHelpers.jsx';
+import Enzyme from 'enzyme';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { routerWrap } from './testHelpers.jsx';
+import sinon from 'sinon';
+import sinonStubPromise from 'sinon-stub-promise';
+/* eslint-enable */
+
+Enzyme.configure({ adapter: new Adapter() });
+sinonStubPromise(sinon);
+
+describe('ApiHelpers', () => {
+  let api, fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(window, 'fetch');
+    fetchStub.returnsPromise().resolves({
+      ok: true,
+      json: () => Promise.resolve({ metrics: [] })
+    });
+    api = ApiHelpers("");
+  });
+
+  afterEach(() => {
+    api = null;
+    window.fetch.restore();
+  });
+
+  describe('getMetricsWindow/setMetricsWindow', () => {
+    it('sets a default metricsWindow', () => {
+      expect(api.getMetricsWindow()).to.equal('10m');
+    });
+
+    it('changes the metricsWindow on valid window input', () => {
+      expect(api.getMetricsWindow()).to.equal('10m');
+
+      api.setMetricsWindow('10s');
+      expect(api.getMetricsWindow()).to.equal('10s');
+
+      api.setMetricsWindow('1m');
+      expect(api.getMetricsWindow()).to.equal('1m');
+
+      api.setMetricsWindow('10m');
+      expect(api.getMetricsWindow()).to.equal('10m');
+    });
+
+    it('does not change metricsWindow on invalid window size', () => {
+      expect(api.getMetricsWindow()).to.equal('10m');
+
+      api.setMetricsWindow('10h');
+      expect(api.getMetricsWindow()).to.equal('10m');
+    });
+  });
+
+  describe('ConduitLink', () => {
+    it('wraps a relative link with the pathPrefix', () => {
+      api = ApiHelpers('/my/path/prefix');
+      let linkProps = { to: "/myrelpath", name: "Informative Link Title" };
+      let conduitLink = mount(routerWrap(api.ConduitLink, linkProps));
+
+      expect(conduitLink.find("Link")).to.have.length(1);
+      expect(conduitLink.html()).to.contain('href="/my/path/prefix/myrelpath"');
+      expect(conduitLink.html()).to.contain(linkProps.name);
+    });
+
+    it('wraps a relative link with no pathPrefix', () => {
+      api = ApiHelpers('');
+      let linkProps = { to: "/myrelpath", name: "Informative Link Title" };
+      let conduitLink = mount(routerWrap(api.ConduitLink, linkProps));
+
+      expect(conduitLink.find("Link")).to.have.length(1);
+      expect(conduitLink.html()).to.contain('href="/myrelpath"');
+      expect(conduitLink.html()).to.contain(linkProps.name);
+    });
+
+    it('leaves an absolute link unchanged', () => {
+      api = ApiHelpers('/my/path/prefix');
+      let linkProps = { absolute: "true", to: "http://xkcd.com", name: "Best Webcomic" };
+      let conduitLink = mount(routerWrap(api.ConduitLink, linkProps));
+
+      expect(conduitLink.find("Link")).to.have.length(1);
+      expect(conduitLink.html()).to.contain('href="http://xkcd.com"');
+      expect(conduitLink.html()).to.contain(linkProps.name);
+    });
+  });
+
+  describe('fetch', () => {
+    it('adds pathPrefix to a metrics request', () => {
+      api = ApiHelpers('/the/path/prefix');
+      api.fetchMetrics('/resource/foo');
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.args[0][0]).to.equal('/the/path/prefix/resource/foo&window=10m');
+    });
+
+    it('requests from / when there is no path prefix', () => {
+      api = ApiHelpers('');
+      api.fetchMetrics('/resource/foo');
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.args[0][0]).to.equal('/resource/foo&window=10m');
+    });
+  });
+
+  describe('fetchMetrics', () => {
+    it('adds pathPrefix and metricsWindow to a metrics request', () => {
+      api.fetchMetrics('/my/path');
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.args[0][0]).to.equal('/my/path&window=10m');
+    });
+  });
+
+  describe('fetchPods', () => {
+    it('fetches the pods from the api', () => {
+      api = ApiHelpers("/random/prefix");
+      api.fetchPods();
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.args[0][0]).to.equal('/random/prefix/api/pods');
+    });
+  });
+
+  describe('urlsForResource', () => {
+    it('returns the correct timeseries and metric rollup urls for deployment overviews', () => {
+      api = ApiHelpers('/go/my/own/way');
+      let deploymentUrls = api.urlsForResource["deployment"].url("myDeploy");
+
+      expect(deploymentUrls.ts).to.equal('/api/metrics?&timeseries=true&target_deploy=myDeploy');
+      expect(deploymentUrls.rollup).to.equal('/api/metrics?&target_deploy=myDeploy');
+    });
+
+    it('returns the correct timeseries and metric rollup urls for upstream deployments', () => {
+      let deploymentUrls = api.urlsForResource["upstream_deployment"].url("farUp");
+
+      expect(deploymentUrls.ts).to.equal('/api/metrics?&aggregation=source_deploy&target_deploy=farUp&timeseries=true');
+      expect(deploymentUrls.rollup).to.equal('/api/metrics?&aggregation=source_deploy&target_deploy=farUp');
+    });
+  });
+});

--- a/web/app/test/ApiHelpersTest.jsx
+++ b/web/app/test/ApiHelpersTest.jsx
@@ -59,32 +59,32 @@ describe('ApiHelpers', () => {
   describe('ConduitLink', () => {
     it('wraps a relative link with the pathPrefix', () => {
       api = ApiHelpers('/my/path/prefix');
-      let linkProps = { to: "/myrelpath", name: "Informative Link Title" };
+      let linkProps = { to: "/myrelpath", children: ["Informative Link Title"] };
       let conduitLink = mount(routerWrap(api.ConduitLink, linkProps));
 
       expect(conduitLink.find("Link")).to.have.length(1);
       expect(conduitLink.html()).to.contain('href="/my/path/prefix/myrelpath"');
-      expect(conduitLink.html()).to.contain(linkProps.name);
+      expect(conduitLink.html()).to.contain(linkProps.children[0]);
     });
 
     it('wraps a relative link with no pathPrefix', () => {
       api = ApiHelpers('');
-      let linkProps = { to: "/myrelpath", name: "Informative Link Title" };
+      let linkProps = { to: "/myrelpath", children: ["Informative Link Title"] };
       let conduitLink = mount(routerWrap(api.ConduitLink, linkProps));
 
       expect(conduitLink.find("Link")).to.have.length(1);
       expect(conduitLink.html()).to.contain('href="/myrelpath"');
-      expect(conduitLink.html()).to.contain(linkProps.name);
+      expect(conduitLink.html()).to.contain(linkProps.children[0]);
     });
 
     it('leaves an absolute link unchanged', () => {
       api = ApiHelpers('/my/path/prefix');
-      let linkProps = { absolute: "true", to: "http://xkcd.com", name: "Best Webcomic" };
+      let linkProps = { absolute: "true", to: "http://xkcd.com", children: ["Best Webcomic"] };
       let conduitLink = mount(routerWrap(api.ConduitLink, linkProps));
 
       expect(conduitLink.find("Link")).to.have.length(1);
       expect(conduitLink.html()).to.contain('href="http://xkcd.com"');
-      expect(conduitLink.html()).to.contain(linkProps.name);
+      expect(conduitLink.html()).to.contain(linkProps.children[0]);
     });
   });
 

--- a/web/app/test/ApiHelpersTest.jsx
+++ b/web/app/test/ApiHelpersTest.jsx
@@ -125,10 +125,11 @@ describe('ApiHelpers', () => {
 
   describe('fetchMetrics', () => {
     it('adds pathPrefix and metricsWindow to a metrics request', () => {
+      api = ApiHelpers('/the/prefix');
       api.fetchMetrics('/my/path');
 
       expect(fetchStub.calledOnce).to.be.true;
-      expect(fetchStub.args[0][0]).to.equal('/my/path?window=10m');
+      expect(fetchStub.args[0][0]).to.equal('/the/prefix/my/path?window=10m');
     });
 
     it('adds a ?window= if metricsWindow is the only param', () => {
@@ -145,7 +146,7 @@ describe('ApiHelpers', () => {
       expect(fetchStub.args[0][0]).to.equal('/metrics?foo=3&bar="me"&window=10m');
     });
 
-    it('does not add another &window= there is already a window param', () => {
+    it('does not add another &window= if there is already a window param', () => {
       api.fetchMetrics('/metrics?foo=3&window=24h&bar="me"');
 
       expect(fetchStub.calledOnce).to.be.true;

--- a/web/app/test/DeploymentDetailTest.jsx
+++ b/web/app/test/DeploymentDetailTest.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable */
-import 'raf/polyfill';
+import 'raf/polyfill'; // the polyfill import must be first
+import { ApiHelpers } from '../js/components/util/ApiHelpers.jsx';
 import Adapter from 'enzyme-adapter-react-16';
 import DeploymentDetail from '../js/components/DeploymentDetail.jsx';
 import Enzyme from 'enzyme';

--- a/web/app/test/testHelpers.jsx
+++ b/web/app/test/testHelpers.jsx
@@ -1,12 +1,17 @@
 import _ from 'lodash';
+import { ApiHelpers } from '../js/components/util/ApiHelpers.jsx';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Route, Router } from 'react-router';
 
+const componentDefaultProps = { api: ApiHelpers("") };
+
 export function routerWrap(Component, extraProps={}, route="/", currentLoc="/") {
+  const createElement = (Component, props) => <Component {...(_.merge({}, componentDefaultProps, props, extraProps))} />;
   return (
-    <Router history={createMemoryHistory(currentLoc)} createElement={(Component, props) => <Component {...(_.merge({}, props, extraProps))} />}>
-      <Route path={route} component={Component} />
+    <Router history={createMemoryHistory(currentLoc)} createElement={createElement}>
+      <Route
+        path={route} render={props => <Component {...(_.merge({}, componentDefaultProps, props, extraProps))} />} />
     </Router>
   );
 }

--- a/web/app/test/testHelpers.jsx
+++ b/web/app/test/testHelpers.jsx
@@ -7,11 +7,10 @@ import { Route, Router } from 'react-router';
 const componentDefaultProps = { api: ApiHelpers("") };
 
 export function routerWrap(Component, extraProps={}, route="/", currentLoc="/") {
-  const createElement = (Component, props) => <Component {...(_.merge({}, componentDefaultProps, props, extraProps))} />;
+  const createElement = (ComponentToWrap, props) => <ComponentToWrap {...(_.merge({}, componentDefaultProps, props, extraProps))} />;
   return (
     <Router history={createMemoryHistory(currentLoc)} createElement={createElement}>
-      <Route
-        path={route} render={props => <Component {...(_.merge({}, componentDefaultProps, props, extraProps))} />} />
+      <Route path={route} render={props => createElement(Component, props)} />
     </Router>
   );
 }


### PR DESCRIPTION
### Changes
- Consolidate the usage of `pathPrefix` and `metricsWindow` into `ApiHelpers.jsx`.
  - This allows us to stop passing around metricsWindow and pathPrefix in each component in the app.
  - This also allows us to set the metricsWindow and have this setting stay as we navigate around the app
- Wrap all app `Link`s in a `ConduitLink` that includes the `pathPrefix`, so that we don't need `pathPrefix` everywhere
- Add tests for ApiHelpers

![screen shot 2018-01-30 at 4 52 48 pm](https://user-images.githubusercontent.com/549258/35600290-0c6d2954-05e2-11e8-9719-1b4011172b5e.png)

### Current issues
- Until the telemetry service is refactored, the 1h time window is probably never going to return metrics. Also, 10s is probably not going to make a lot of sense as an option you want to view.
- Currently, it's not super evident that your time window change has been received when you click the buttons. We could clear the metrics for the page and show a spinner immediately, which would give the user feedback. I've tried this in af320b0

### Future work enabled by this branch
- setting the `pollingInterval` based on the `metricsWindow` (#241)
- wrapping the api calls in a cancelable promise, which will allow us to stop setting state after component unmount (#242, #157)