### PR TITLE
Use dots reporter instead of nyan reporter in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
       install:
         - cd web/app && yarn && yarn webpack
       script:
-        - yarn karma start --single-run
+        - yarn karma start --single-run --reporters dots
 
     - language: generic
       script:


### PR DESCRIPTION
### Problem
The nyan reporter is nice in dev, but on travis.org, it looks weird:
![screen shot 2018-01-30 at 5 55 26 pm](https://user-images.githubusercontent.com/549258/35601284-0ccbb7c6-05e7-11e8-9445-05e217a68a8e.png)


### Solution
Use the dots reporter instead