### PR TITLE
Add -log-level flag for install and inject commands

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -39,7 +38,7 @@ var completionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		out, err := getCompletion(args[0])
 		if err != nil {
-			log.Fatal(err.Error())
+			logFatalf(err.Error())
 		} else {
 			fmt.Printf(out)
 		}

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -28,6 +28,7 @@ var (
 	ignoreOutboundPorts           []uint
 	proxyControlPort              uint
 	proxyAPIPort                  uint
+	proxyLogLevel                 string
 	conduitCreatedByAnnotation    = "conduit.io/created-by"
 	conduitProxyVersionAnnotation = "conduit.io/proxy-version"
 	conduitControlLabel           = "conduit.io/controller"
@@ -259,7 +260,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec) enhancedPodTemplateSpec {
 			},
 		},
 		Env: []v1.EnvVar{
-			v1.EnvVar{Name: "CONDUIT_PROXY_LOG", Value: "warn,conduit_proxy=info"},
+			v1.EnvVar{Name: "CONDUIT_PROXY_LOG", Value: proxyLogLevel},
 			v1.EnvVar{
 				Name:  "CONDUIT_PROXY_CONTROL_URL",
 				Value: fmt.Sprintf("tcp://proxy-api.%s.svc.cluster.local:%d", controlPlaneNamespace, proxyAPIPort),
@@ -386,4 +387,5 @@ func init() {
 	injectCmd.PersistentFlags().UintSliceVar(&ignoreOutboundPorts, "skip-outbound-ports", nil, "outbound ports that should skip the proxy")
 	injectCmd.PersistentFlags().UintVar(&proxyControlPort, "control-port", 4190, "proxy port to use for control")
 	injectCmd.PersistentFlags().UintVar(&proxyAPIPort, "api-port", 8086, "port where the Conduit controller is running")
+	injectCmd.PersistentFlags().StringVar(&proxyLogLevel, "log-level", "warn,conduit_proxy=info", "log level for the proxy")
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/runconduit/conduit/controller/api/public"
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
@@ -13,25 +16,23 @@ var cfgFile string
 var controlPlaneNamespace string
 var apiAddr string // An empty value means "use the Kubernetes configuration"
 var kubeconfigPath string
-var logLevel string
+var verbose bool
 
 var RootCmd = &cobra.Command{
 	Use:   "conduit",
 	Short: "conduit manages the Conduit service mesh",
 	Long:  `conduit manages the Conduit service mesh.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// set global log level
-		level, err := log.ParseLevel(logLevel)
-		if err != nil {
-			log.Fatalf("invalid log-level: %s", logLevel)
+		// turn on debug logging
+		if verbose {
+			log.SetLevel(log.DebugLevel)
 		}
-		log.SetLevel(level)
 	},
 }
 
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&controlPlaneNamespace, "conduit-namespace", "n", "conduit", "namespace in which Conduit is installed")
-	RootCmd.PersistentFlags().StringVar(&logLevel, "log-level", log.FatalLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
+	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "turn on debug logging")
 }
 
 // TODO: decide if we want to use viper
@@ -52,4 +53,12 @@ func newPublicAPIClient() (pb.ApiClient, error) {
 		return nil, err
 	}
 	return public.NewExternalClient(controlPlaneNamespace, kubeApi)
+}
+
+// This is equivalent to calling log.Fatalf, but unlike go's logger interface,
+// it does not support any formatting of the output prior to printing, which is
+// preferable for printing errors from the CLI
+func logFatalf(format string, v ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", v...)
+	os.Exit(1)
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/version"
@@ -22,8 +21,7 @@ var versionCmd = &cobra.Command{
 
 		client, err := newPublicAPIClient()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error connecting to server: %s\n", err)
-			return
+			logFatalf("Error connecting to server: %s", err)
 		}
 
 		fmt.Printf("Server version: %s\n", getServerVersion(client))


### PR DESCRIPTION
This branch updates the install and inject commands to add a `--log-level` flag, which can be used to set the log level of the control and data plane components.

Note that the CLI previously supported a global `--log-level` flag, but I've renamed that to `--verbose`, which can be used to turn on debug logging, as there shouldn't be any other use case for adjusting the log level of the CLI.

I'm also fixing an issue where, in certain places, we were calling `log.Fatal`, and that was causing the logged messages to be rendered with additional formatting, which seemed unintended. For instance, on master:

```
$ conduit completion asdf
2018/01/30 18:05:54 unsupported shell type (must be bash or zsh): asdf
```

Whereas with this change:

```
$ conduit completion asdf
unsupported shell type (must be bash or zsh): asdf
```

Fixes #230.