### PR TITLE
Replace shelling out with kubernetes proxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "5a9e19d4e1e41a734154e44a2132b358afb49a03"
-  version = "v0.13.0"
+  revision = "767c40d6a2e058483c25fa193e963a22da17236d"
+  version = "v0.18.0"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
@@ -15,8 +15,8 @@
     "autorest/azure",
     "autorest/date"
   ]
-  revision = "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01"
-  version = "v9.7.0"
+  revision = "d4e6b95c12a08b4de2d48b45d5b4d594e5d32fab"
+  version = "v9.9.0"
 
 [[projects]]
   name = "github.com/PuerkitoBio/purell"
@@ -54,8 +54,8 @@
     ".",
     "log"
   ]
-  revision = "777bb3f19bcafe2575ffb2a3e46af92509ae9594"
-  version = "v1.2"
+  revision = "2dd44038f0b95ae693b266c5f87593b5d2fdd78d"
+  version = "v2.5.0"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -79,13 +79,13 @@
   branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "3faa0055dbbf2110abc1f3b4e3adbb22721e96e7"
+  revision = "f3499b5df53897321d6f5e9c22cf19309d41d3bc"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  revision = "f3f9494671f93fcff853e3c6e9e948b3eb71e590"
+  revision = "84f4bee7c0a6db40e3166044c7983c1c32125429"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
@@ -93,8 +93,8 @@
     "proto",
     "sortkeys"
   ]
-  revision = "100ba4e885062801d56799d78530b73b178a78f3"
-  version = "v0.4"
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
 
 [[projects]]
   branch = "master"
@@ -124,7 +124,7 @@
   branch = "master"
   name = "github.com/google/btree"
   packages = ["."]
-  revision = "316fb6d3f031ae8f4d457c6c5186b9e3ded70435"
+  revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
@@ -154,7 +154,7 @@
     "openstack/utils",
     "pagination"
   ]
-  revision = "b2bf8a613b41baa2a8b56a6a8483321a84520dfa"
+  revision = "bb5adf2838a3646f74c131df11c061c3a1fe0bd4"
 
 [[projects]]
   branch = "master"
@@ -178,7 +178,7 @@
     ".",
     "simplelru"
   ]
-  revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
+  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
@@ -189,8 +189,8 @@
 [[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "3e95a51e0639b4cf372f2ccf74c86749d747fbdc"
-  version = "0.2.2"
+  revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
+  version = "0.3.2"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -201,14 +201,14 @@
 [[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
-  version = "1.0.4"
+  revision = "28452fcdec4e44348d2af0d91d1e9e38da3a9e0a"
+  version = "1.0.5"
 
 [[projects]]
-  branch = "master"
   name = "github.com/juju/ratelimit"
   packages = ["."]
-  revision = "5b9ff866471762aa2ab2dced63c9fb6f53921342"
+  revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
+  version = "1.0.1"
 
 [[projects]]
   name = "github.com/julienschmidt/httprouter"
@@ -224,13 +224,19 @@
     "jlexer",
     "jwriter"
   ]
-  revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
+  revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mxk/go-flowrate"
+  packages = ["flowrate"]
+  revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
 
 [[projects]]
   branch = "master"
@@ -270,7 +276,7 @@
   branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
@@ -280,22 +286,24 @@
     "internal/bitbucket.org/ww/goautoneg",
     "model"
   ]
-  revision = "1bab55dd05dbff384524a6a1c99006d9eb5f139b"
+  revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
+    "internal/util",
+    "nfs",
     "xfs"
   ]
-  revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
+  revision = "cb4147076ac75738c9a7d279075a253c0cc5acbd"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/sergi/go-diff"
@@ -306,8 +314,8 @@
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
+  revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
+  version = "v1.0.4"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -323,14 +331,14 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "faadfbdc035307d901e69eea569f5dda451a3ee3"
+  revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
 
 [[projects]]
   branch = "master"
@@ -338,6 +346,8 @@
   packages = [
     "context",
     "context/ctxhttp",
+    "html",
+    "html/atom",
     "http2",
     "http2/hpack",
     "idna",
@@ -345,7 +355,7 @@
     "lex/httplex",
     "trace"
   ]
-  revision = "b129b8e0fbeb39c8358e51a07ab6c50ad415e72e"
+  revision = "b417086c80e91bfa321ef761574721644b8b9f61"
 
 [[projects]]
   branch = "master"
@@ -357,7 +367,7 @@
     "jws",
     "jwt"
   ]
-  revision = "13449ad91cb26cb47661c1b080790392170385fd"
+  revision = "a032972e28060ca4f5644acffae3dfc268cc09db"
 
 [[projects]]
   branch = "master"
@@ -366,15 +376,20 @@
     "unix",
     "windows"
   ]
-  revision = "062cd7e4e68206d8bab9b18396626e855c992658"
+  revision = "8f27ce8a604014414f8dfffc25cbcde83a3f2216"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
     "internal/gen",
+    "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "language",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -383,7 +398,7 @@
     "unicode/rangetable",
     "width"
   ]
-  revision = "acd49d43e9b95df46670431bf5c7ae59586daad8"
+  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -406,16 +421,19 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "595979c8a7bf586b2d293fb42246bf91a0b893d9"
+  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
 
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
     "codes",
     "connectivity",
     "credentials",
+    "encoding",
     "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
@@ -424,13 +442,15 @@
     "naming",
     "peer",
     "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
     "stats",
     "status",
     "tap",
     "transport"
   ]
-  revision = "61d37c5d657a47e4404fd6823bd598341a2595de"
-  version = "v1.7.1"
+  revision = "6b51017f791ae1cfbec89c52efdf444b13b550ef"
+  version = "v1.9.2"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -442,10 +462,9 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [[projects]]
-  branch = "release-1.9"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -478,9 +497,9 @@
     "storage/v1beta1"
   ]
   revision = "006a217681ae70cbacdd66a5e2fca1a61a8ff28e"
+  version = "kubernetes-1.9.1"
 
 [[projects]]
-  branch = "release-1.9"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -509,9 +528,11 @@
     "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
+    "pkg/util/httpstream",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/net",
+    "pkg/util/proxy",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/validation",
@@ -520,9 +541,11 @@
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect"
   ]
   revision = "68f9c3a1feb3140df59c67ced62d3a5df8e6c9c2"
+  version = "kubernetes-1.9.1"
 
 [[projects]]
   name = "k8s.io/client-go"
@@ -591,11 +614,20 @@
   branch = "master"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/common"]
-  revision = "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+  revision = "275e2ce91dec4c05a4094a7b1daee5560b555ac9"
+
+[[projects]]
+  name = "k8s.io/kubernetes"
+  packages = [
+    "pkg/kubectl/proxy",
+    "pkg/kubectl/util"
+  ]
+  revision = "5fa2db2bd46ac79e5e00a4e6ed24191080aa463b"
+  version = "v1.9.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "902019db7e0b8a324ccaaa9dd06470f8639063a41a7b80eaafa56088c92ac7d5"
+  inputs-digest = "6fc47f2323bfee45f95f7aa0d49abafc3dfa9b57a20c8bcc3a4e3ef6e8abfdb4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,6 +25,10 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
   version = "kubernetes-1.9.1"
 
 [[constraint]]
+  name = "k8s.io/kubernetes"
+  version = "v1.9.1"
+
+[[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "v1.0.3"
 
@@ -35,3 +39,20 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
 [[constraint]]
   name = "github.com/golang/protobuf"
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845" # protobuf has no release tags at time of writing
+
+#
+# k8s.io/kubernetes dependency fixes
+# taken from https://github.com/kubernetes/kubernetes/blob/master/Godeps/Godeps.json
+#
+
+[[override]]
+  name = "github.com/docker/distribution"
+  revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
+
+[[override]]
+  name = "github.com/docker/docker"
+  revision = "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+
+[[override]]
+	name = "github.com/russross/blackfriday"
+	revision = "300106c228d52c8941d4b3de6054a6062a86dda3"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:8c385762 as golang
+FROM gcr.io/runconduit/go-deps:f24620b6 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -33,7 +33,7 @@ problems were found.`,
 			os.Exit(2)
 		}
 
-		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath)
+		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell().HomeDir(), kubeconfigPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error with Kubernetes API: %s\n", err.Error())
 			statusCheckResultWasError(os.Stdout)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -47,9 +47,9 @@ func newPublicAPIClient() (pb.ApiClient, error) {
 	if apiAddr != "" {
 		return public.NewInternalClient(apiAddr)
 	}
-	kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell(), kubeconfigPath)
+	kubeAPI, err := k8s.NewK8sAPI(shell.NewUnixShell().HomeDir(), kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
-	return public.NewExternalClient(controlPlaneNamespace, kubeApi)
+	return public.NewExternalClient(controlPlaneNamespace, kubeAPI)
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -4,8 +4,6 @@ import (
 	"os"
 
 	"github.com/runconduit/conduit/cli/cmd"
-	// Load all the auth plugins for the cloud providers.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func main() {

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:8c385762 as golang
+FROM gcr.io/runconduit/go-deps:f24620b6 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -14,16 +14,16 @@ func TestKubernetesApiUrlFor(t *testing.T) {
 	t.Run("Returns base config containing k8s endpoint listed in config.test", func(t *testing.T) {
 		expected := fmt.Sprintf("https://55.197.171.239/api/v1/namespaces/%s%s", namespace, extraPath)
 		shell := &shell.MockShell{}
-		api, err := NewK8sAPI(shell, "testdata/config.test")
+		api, err := NewK8sAPI(shell.HomeDir(), "testdata/config.test")
 		if err != nil {
-			t.Fatalf("Unexpected error starting proxy: %v", err)
+			t.Fatalf("Unexpected error creating Kubernetes API: %+v", err)
 		}
-		actualUrl, err := api.UrlFor(namespace, extraPath)
+		actualURL, err := api.UrlFor(namespace, extraPath)
 		if err != nil {
-			t.Fatalf("Unexpected error starting proxy: %v", err)
+			t.Fatalf("Unexpected error generating URL: %+v", err)
 		}
-		if actualUrl.String() != expected {
-			t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualUrl.String())
+		if actualURL.String() != expected {
+			t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, actualURL.String())
 		}
 	})
 }

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -3,10 +3,15 @@ package k8s
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	kubernetesConfigFilePathEnvVariable = "KUBECONFIG"
 )
 
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
@@ -52,4 +57,10 @@ func findK8sConfigFile(override string, contentsOfKubecongigEnvVar string, homeD
 
 func parseK8SConfig(pathToConfigFile string) (*rest.Config, error) {
 	return clientcmd.BuildConfigFromFlags("", pathToConfigFile)
+}
+
+func buildK8sConfig(homedir string, k8sConfigFilesystemPathOverride string) (*rest.Config, error) {
+	kubeconfigEnvVar := os.Getenv(kubernetesConfigFilePathEnvVariable)
+
+	return parseK8SConfig(findK8sConfigFile(k8sConfigFilesystemPathOverride, kubeconfigEnvVar, homedir))
 }

--- a/pkg/k8s/proxy.go
+++ b/pkg/k8s/proxy.go
@@ -1,0 +1,95 @@
+package k8s
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/kubectl/proxy"
+	// Load all the auth plugins for the cloud providers.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+type KubernetesProxy struct {
+	listener net.Listener
+	server   *proxy.Server
+}
+
+// InitK8sProxy initalizes a KubernetesProxy object and starts listening on a
+// network address.
+func InitK8sProxy(homedir string, k8sConfigFilesystemPathOverride string, proxyPort int) (*KubernetesProxy, error) {
+	config, err := buildK8sConfig(homedir, k8sConfigFilesystemPathOverride)
+	if err != nil {
+		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
+	}
+
+	server, err := proxyCreate(config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create proxy: %+v", err)
+	}
+
+	listener, err := proxyListen(server, proxyPort)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to listen with proxy: %+v", err)
+	}
+
+	return &KubernetesProxy{
+		listener: listener,
+		server:   server,
+	}, nil
+}
+
+// Run starts proxying a connection to Kubernetes, and blocks until the process
+// exits.
+func (kp *KubernetesProxy) Run() error {
+	// blocks until process is killed
+	err := proxyServe(kp.server, kp.listener)
+	if err != nil {
+		return fmt.Errorf("Failed to serve with proxy: %+v", err)
+	}
+
+	return nil
+}
+
+// URLFor generates a URL based on the configured KubernetesProxy.
+func (kp *KubernetesProxy) URLFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
+	schemeHostAndPort := fmt.Sprintf("http://127.0.0.1:%d", kp.listener.Addr().(*net.TCPAddr).Port)
+	return generateKubernetesApiBaseUrlFor(schemeHostAndPort, namespace, extraPathStartingWithSlash)
+}
+
+func proxyCreate(config *rest.Config) (*proxy.Server, error) {
+	filter := &proxy.FilterServer{
+		AcceptPaths:   proxy.MakeRegexpArrayOrDie(proxy.DefaultPathAcceptRE),
+		RejectPaths:   proxy.MakeRegexpArrayOrDie(proxy.DefaultPathRejectRE),
+		AcceptHosts:   proxy.MakeRegexpArrayOrDie(proxy.DefaultHostAcceptRE),
+		RejectMethods: proxy.MakeRegexpArrayOrDie(proxy.DefaultMethodRejectRE),
+	}
+	server, err := proxy.NewServer("", "/", "/static/", filter, config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create proxy server: %+v", err)
+	}
+
+	return server, nil
+}
+
+func proxyListen(server *proxy.Server, proxyPort int) (net.Listener, error) {
+	listener, err := server.Listen("127.0.0.1", proxyPort)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to listen via proxy server: %+v", err)
+	}
+
+	return listener, nil
+}
+
+func proxyServe(server *proxy.Server, listener net.Listener) error {
+	fmt.Printf("Starting to serve on %s\n", listener.Addr().String())
+
+	// blocks until process is killed
+	err := server.ServeOnListener(listener)
+	if err != nil {
+		return fmt.Errorf("Failed to serve via proxy server: %+v", err)
+	}
+
+	return nil
+}

--- a/pkg/k8s/proxy_test.go
+++ b/pkg/k8s/proxy_test.go
@@ -1,0 +1,44 @@
+package k8s
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestInitK8sProxy(t *testing.T) {
+	t.Run("Returns an initialized Kubernetes Proxy object", func(t *testing.T) {
+		kp, err := InitK8sProxy("./homedir", "testdata/config.test", 0)
+		if err != nil {
+			t.Fatalf("Unexpected error creating Kubernetes API: %+v", err)
+		}
+
+		if kp.listener.Addr().Network() != "tcp" {
+			t.Fatalf("Unexpected listener network: %+v", kp.listener.Addr().Network())
+		}
+	})
+}
+
+func TestKubernetesProxyUrlFor(t *testing.T) {
+	const namespace = "some-namespace"
+	const extraPath = "/some/extra/path"
+
+	t.Run("Returns proxy URL based on the initialized KubernetesProxy", func(t *testing.T) {
+		kp, err := InitK8sProxy("./homedir", "testdata/config.test", 0)
+		if err != nil {
+			t.Fatalf("Unexpected error creating Kubernetes API: %+v", err)
+		}
+		actualURL, err := kp.URLFor(namespace, extraPath)
+		if err != nil {
+			t.Fatalf("Unexpected error generating URL: %+v", err)
+		}
+
+		url := actualURL.String()
+		expected := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s%s", kp.listener.Addr().(*net.TCPAddr).Port, namespace, extraPath)
+		if url != expected {
+			t.Fatalf("Expected generated URL to be [%s], but got [%s]", expected, url)
+		}
+	})
+}
+
+// TODO: test kb.Run()

--- a/pkg/k8s/test_helper.go
+++ b/pkg/k8s/test_helper.go
@@ -36,16 +36,6 @@ type MockKubectl struct {
 
 func (m *MockKubectl) Version() ([3]int, error) { return [3]int{}, nil }
 
-func (m *MockKubectl) StartProxy(potentialErrorWhenStartingProxy chan error, port int) error {
-	return nil
-}
-
-func (m *MockKubectl) UrlFor(namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
-	return nil, nil
-}
-
-func (m *MockKubectl) ProxyPort() int { return -666 }
-
 func (m *MockKubectl) SelfCheck() []*healthcheckPb.CheckResult {
 	return m.SelfCheckResultsToReturn
 }

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -1,20 +1,13 @@
 package shell
 
 import (
-	"bufio"
-	"fmt"
-	"io"
-
 	"os"
 	"os/exec"
 	"runtime"
-	"time"
 )
 
 type Shell interface {
 	CombinedOutput(name string, arg ...string) (string, error)
-	AsyncStdout(potentialErrorFromAsyncProcess chan error, name string, arg ...string) (*bufio.Reader, error)
-	WaitForCharacter(charToWaitFor byte, output *bufio.Reader, timeout time.Duration) (string, error)
 	HomeDir() string
 	Path() string
 }
@@ -29,48 +22,6 @@ func (sh *unixShell) CombinedOutput(name string, arg ...string) (string, error) 
 	}
 
 	return string(bytes), nil
-}
-
-func (sh *unixShell) AsyncStdout(potentialErrorFromAsyncProcess chan error, name string, arg ...string) (*bufio.Reader, error) {
-	command := exec.Command(name, arg...)
-	stdout, err := command.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("error executing command in an async way: %v", err)
-	}
-
-	reader := bufio.NewReader(stdout)
-
-	go func(e chan error) { e <- command.Run() }(potentialErrorFromAsyncProcess)
-
-	return reader, nil
-}
-
-func (sh *unixShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Reader, timeout time.Duration) (string, error) {
-	output := make(chan string, 1)
-	potentialError := make(chan error, 1)
-
-	go func(output chan string, e chan error) {
-		outputString, err := outputReader.ReadString(charToWaitFor)
-		if err != nil {
-			if err == io.EOF {
-				e <- fmt.Errorf("reached end of stream while waiting for character [%c] in output [%s] of command: %v", charToWaitFor, outputString, err)
-			} else {
-				e <- fmt.Errorf("error while reading output from command: %v", err)
-			}
-		}
-
-		output <- outputString
-	}(output, potentialError)
-
-	select {
-	case <-time.After(timeout):
-		return "", fmt.Errorf("timed-out expoecting token [%c] in reader", charToWaitFor)
-	case e := <-potentialError:
-		return "", e
-	case o := <-output:
-		return o, nil
-	}
-
 }
 
 func (sh *unixShell) HomeDir() string {

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -1,12 +1,10 @@
 package shell
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestCombinedOutput(t *testing.T) {
@@ -29,104 +27,6 @@ func TestCombinedOutput(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expecting error, got nothing")
 		}
-	})
-}
-
-func TestAsyncStdout(t *testing.T) {
-	t.Run("Executes command and returns result without error if return code 0", func(t *testing.T) {
-		expectedOutput := "expected"
-		asyncError := make(chan error, 1)
-		output, err := NewUnixShell().AsyncStdout(asyncError, "echo", expectedOutput)
-		if err != nil {
-			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
-		}
-
-		outputBytes, err := ioutil.ReadAll(output)
-		if err != nil {
-			//TODO: fix flakiness
-			t.Skip("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
-		}
-
-		actualOutput := strings.TrimSpace(string(outputBytes))
-		if actualOutput != expectedOutput {
-			//TODO: fix flakiness
-			t.Skip("Expecting command output to be [%s], got [%s]", expectedOutput, actualOutput)
-		}
-
-		select {
-		case e := <-asyncError:
-			if e != nil {
-				//TODO: fix flakiness
-				t.Skip("Unexpected error from the async process: %v", err)
-			}
-		}
-		close(asyncError)
-	})
-
-	t.Run("Executes command and returns result and error if did not find expected character", func(t *testing.T) {
-		asyncError := make(chan error, 1)
-		out, err := NewUnixShell().AsyncStdout(asyncError, "command-that-doesnt", "--exist")
-		if err != nil {
-			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
-		}
-
-		select {
-		case err := <-asyncError:
-			if err == nil {
-				outputBytes, _ := ioutil.ReadAll(out)
-				//TODO: fix flakiness
-				t.Skip("Expecting error, got nothing. Output: [%s]", string(outputBytes))
-			}
-		}
-		close(asyncError)
-	})
-}
-
-func TestWaitForCharacter(t *testing.T) {
-	t.Run("Executes command and returns result without error if return code 0", func(t *testing.T) {
-		shell := NewUnixShell()
-		asyncError := make(chan error, 1)
-		expectedOutput := "expected>"
-
-		output, err := shell.AsyncStdout(asyncError, "echo", expectedOutput)
-		if err != nil {
-			t.Fatalf("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
-		}
-
-		outputString, err := shell.WaitForCharacter('>', output, 10*time.Second)
-		if err != nil {
-			//TODO: fix flakiness
-			t.Skip("Unexpected error [%v], asyncError is [%v]", err, <-asyncError)
-		}
-
-		if strings.TrimSpace(outputString) != expectedOutput {
-			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, strings.TrimSpace(outputString))
-		}
-
-		select {
-		case e := <-asyncError:
-			if e != nil {
-				//TODO: fix flakiness
-				t.Skip("Unexpected error from the async process: %v", err)
-			}
-		}
-		close(asyncError)
-	})
-
-	t.Run("Executes command and returns timeout error if expected character never shows up in output", func(t *testing.T) {
-		shell := NewUnixShell()
-		asyncError := make(chan error, 1)
-		output, err := shell.AsyncStdout(asyncError, "sleep", "1")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		outputString, err := shell.WaitForCharacter('!', output, 100*time.Millisecond)
-		if err == nil {
-			//TODO: fix flakiness
-			t.Skip("Expecting error, got nothing. output was [%s]", outputString)
-		}
-		close(asyncError)
 	})
 }
 

--- a/pkg/shell/test_helper.go
+++ b/pkg/shell/test_helper.go
@@ -1,10 +1,8 @@
 package shell
 
 import (
-	"bufio"
 	"fmt"
 	"strings"
-	"time"
 )
 
 type MockShell struct {
@@ -32,18 +30,6 @@ func (sh *MockShell) CombinedOutput(name string, arg ...string) (string, error) 
 	sh.LastArgsCalled = arg
 
 	return sh.pop()
-}
-
-func (sh *MockShell) AsyncStdout(asyncError chan error, name string, arg ...string) (*bufio.Reader, error) {
-	sh.LastNameCalled = name
-	sh.LastArgsCalled = arg
-
-	outputToReturn, errToReturn := sh.pop()
-	return bufio.NewReader(strings.NewReader(outputToReturn)), errToReturn
-}
-
-func (sh *MockShell) WaitForCharacter(charToWaitFor byte, outputReader *bufio.Reader, timeout time.Duration) (string, error) {
-	return outputReader.ReadString(charToWaitFor)
 }
 
 func (sh *MockShell) HomeDir() string {

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:8c385762 as golang
+FROM gcr.io/runconduit/go-deps:f24620b6 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:8c385762 as golang
+FROM gcr.io/runconduit/go-deps:f24620b6 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
The conduit dashboard command asychronously shells out and runs "kubectl
proxy".

This change replaces the shelling out with calls to kubernetes proxy
APIs. It also allows us to enable race detection in our go tests, as the
shell out code tests did not pass race detection.

Fixes #173

Signed-off-by: Andrew Seigner <siggy@buoyant.io>