### PR TITLE
Do not require DCO signoff for project members

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
We only need the DCO bot to validate external submissions.