### PR TITLE
Rename --version flag in conduit install to --conduit-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ jobs:
         - bin/docker-push-deps
         - bin/docker-push $CONDUIT_TAG
         - bin/docker-retag-all $CONDUIT_TAG master && bin/docker-push master
-        - target/cli/linux/conduit install --version=$CONDUIT_TAG |tee conduit.yml
+        - target/cli/linux/conduit install --conduit-version=$CONDUIT_TAG |tee conduit.yml
         - kubectl -n conduit apply -f conduit.yml --prune --selector='conduit.io/plane=control'
 
 notifications:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -349,6 +349,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e413f61a54604e322648bbbb879e7548ef7ce2e6581532a6c7fcc2ac93d50750"
+  inputs-digest = "b9949249a1b88b851ea33a371af8a547536aacc14c0f642f7741a8cd6fac66ea"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -349,6 +349,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b9949249a1b88b851ea33a371af8a547536aacc14c0f642f7741a8cd6fac66ea"
+  inputs-digest = "e413f61a54604e322648bbbb879e7548ef7ce2e6581532a6c7fcc2ac93d50750"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -376,7 +376,7 @@ type enhancedDaemonSet struct {
 
 func init() {
 	RootCmd.AddCommand(injectCmd)
-	injectCmd.PersistentFlags().StringVarP(&conduitVersion, "conduit-version", "v", version.Version, "tag to be used for conduit images")
+	injectCmd.PersistentFlags().StringVarP(&conduitVersion, "conduit-version", "v", version.Version, "tag to be used for Conduit images")
 	injectCmd.PersistentFlags().StringVar(&initImage, "init-image", "gcr.io/runconduit/proxy-init", "Conduit init container image name")
 	injectCmd.PersistentFlags().StringVar(&proxyImage, "proxy-image", "gcr.io/runconduit/proxy", "Conduit proxy container image name")
 	injectCmd.PersistentFlags().StringVar(&imagePullPolicy, "image-pull-policy", "IfNotPresent", "Docker image pull policy")

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -472,7 +472,7 @@ func validate() error {
 
 func init() {
 	RootCmd.AddCommand(installCmd)
-	installCmd.PersistentFlags().StringVarP(&conduitVersion, "version", "v", version.Version, "Conduit version to install")
+	installCmd.PersistentFlags().StringVarP(&conduitVersion, "conduit-version", "v", version.Version, "tag to be used for Conduit images")
 	installCmd.PersistentFlags().StringVarP(&dockerRegistry, "registry", "r", "gcr.io/runconduit", "Docker registry to pull images from")
 	installCmd.PersistentFlags().UintVar(&controllerReplicas, "controller-replicas", 1, "replicas of the controller to deploy")
 	installCmd.PersistentFlags().UintVar(&webReplicas, "web-replicas", 1, "replicas of the web server to deploy")


### PR DESCRIPTION
This makes the `conduit install` flag match the `conduit inject` flag.