### PR TITLE
Minor UI title renames and other tweaks

### DIFF
--- a/web/app/js/components/DeploymentDetail.jsx
+++ b/web/app/js/components/DeploymentDetail.jsx
@@ -141,6 +141,7 @@ export default class DeploymentDetail extends React.Component {
       _.isEmpty(this.state.deployTs) ? null :
         <ResourceMetricsOverview
           key="stat-pane"
+          resourceType="deployment"
           lastUpdated={this.state.lastUpdated}
           timeseries={this.state.deployTs} />,
       this.renderMidsection(),

--- a/web/app/js/components/PodDetail.jsx
+++ b/web/app/js/components/PodDetail.jsx
@@ -109,6 +109,7 @@ export default class PodDetail extends React.Component {
       _.isEmpty(this.state.podTs) ? null :
         <ResourceMetricsOverview
           key="pod-stat-pane"
+          resourceType="pod"
           lastUpdated={this.state.lastUpdated}
           timeseries={this.state.podTs} />,
       <UpstreamDownstream

--- a/web/app/js/components/ResourceHealthOverview.jsx
+++ b/web/app/js/components/ResourceHealthOverview.jsx
@@ -65,7 +65,7 @@ export default class ResourceHealthOverview extends React.Component {
 
     return (
       <div key="entity-heath" className="entity-health">
-        <div className="subsection-header">{this.props.resourceType} Health</div>
+        <div className="subsection-header">Upstream/Downstream Traffic</div>
         <Row>
           <Col span={8}>
             { stats.inbound.numDeploys === 0 ? null :

--- a/web/app/js/components/ResourceHealthOverview.jsx
+++ b/web/app/js/components/ResourceHealthOverview.jsx
@@ -46,10 +46,12 @@ export default class ResourceHealthOverview extends React.Component {
     return {
       inbound: {
         requests: metricToFormatter["REQUEST_RATE"](this.getRequestRate(this.props.upstreamMetrics)),
+        numDeploys: _.size(this.props.upstreamMetrics),
         health: this.getHealthClassName(inboundSr)
       },
       outbound: {
         requests: metricToFormatter["REQUEST_RATE"](this.getRequestRate(this.props.downstreamMetrics)),
+        numDeploys: _.size(this.props.downstreamMetrics),
         health: this.getHealthClassName(outboundSr)
       },
       current: {
@@ -66,17 +68,21 @@ export default class ResourceHealthOverview extends React.Component {
         <div className="subsection-header">{this.props.resourceType} Health</div>
         <Row>
           <Col span={8}>
-            <Metric title="Inbound request rate" value={stats.inbound.requests} className="float-right" />
+            { stats.inbound.numDeploys === 0 ? null :
+              <Metric title="Inbound request rate" value={stats.inbound.requests} className="float-right" />
+            }
           </Col>
           <Col span={8} />
           <Col span={8}>
-            <Metric title="Outbound request rate" value={stats.outbound.requests} className="float-left" />
+            { stats.outbound.numDeploys === 0 ? null :
+              <Metric title="Outbound request rate" value={stats.outbound.requests} className="float-left" />
+            }
           </Col>
         </Row>
 
         <Row>
           <Col span={8}>
-            <div className="entity-count">&laquo; {_.size(this.props.upstreamMetrics)} {this.props.resourceType}s</div>
+            <div className="entity-count">&laquo; {stats.inbound.numDeploys} {this.props.resourceType}s</div>
             <div className={`adjacent-health ${stats.inbound.health}`}>
               <TrafficIndicator healthStat={stats.inbound.health} />
             </div>
@@ -86,7 +92,7 @@ export default class ResourceHealthOverview extends React.Component {
             <div className={`entity-title ${stats.current.health}`}>{this.props.resourceName}</div>
           </Col>
           <Col span={8}>
-            <div className="entity-count float-right">{_.size(this.props.downstreamMetrics)} {this.props.resourceType}s &raquo;</div>
+            <div className="entity-count float-right">{stats.outbound.numDeploys} {this.props.resourceType}s &raquo;</div>
             <div className={`adjacent-health ${stats.outbound.health}`}>
               <TrafficIndicator healthStat={stats.outbound.health} />
             </div>

--- a/web/app/js/components/ResourceMetricsOverview.jsx
+++ b/web/app/js/components/ResourceMetricsOverview.jsx
@@ -9,6 +9,7 @@ export default class ResourceMetricsOverview extends React.Component {
   render() {
     return (
       <div>
+        <div className="subsection-header">{this.props.resourceType} Health</div>
         <Row gutter={rowGutter}>
           <Col span={8}>
             <ResourceOverviewMetric

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -28,16 +28,15 @@ const serviceMeshDetailsColumns = [
 ];
 const componentNames = {
   "prometheus":   "Prometheus",
-  "destination":  "Controller destination",
-  "proxy-api":    "Controller proxy-api",
-  "public-api":   "Controller public-api",
-  "tap":          "Controller tap",
+  "destination":  "Controller Deestination",
+  "proxy-api":    "Controller Proxy API",
+  "public-api":   "Controller Public API",
+  "tap":          "Controller Tap",
   "telemetry":    "Controller Telemetry",
   "web":          "Web UI"
 };
 
 const componentGraphTitles = {
-  "destination":  "Service lookups",
   "telemetry": "Telemetry requests"
 };
 

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -32,9 +32,15 @@ const componentNames = {
   "proxy-api":    "Controller proxy-api",
   "public-api":   "Controller public-api",
   "tap":          "Controller tap",
-  "telemetry":    "Controller telemetry",
+  "telemetry":    "Controller Telemetry",
   "web":          "Web UI"
 };
+
+const componentGraphTitles = {
+  "destination":  "Service lookups",
+  "telemetry": "Telemetry requests"
+};
+
 const componentDeploys = {
   "prometheus":   "prometheus",
   "destination":  "controller",
@@ -44,7 +50,7 @@ const componentDeploys = {
   "telemetry":    "controller",
   "web":          "web"
 };
-const componentsToGraph = ["proxy-api", "telemetry", "destination"];
+const componentsToGraph = ["proxy-api", "telemetry", "public-api"];
 const noData = {
   timeseries: { requestRate: [], successRate: [] }
 };
@@ -196,7 +202,7 @@ export default class ServiceMesh extends React.Component {
             _.map(componentsToGraph, meshComponent => {
               let data = _.cloneDeep(_.find(this.state.metrics, ["name", meshComponent]) || noData);
               data.id = meshComponent;
-              data.name = componentNames[meshComponent];
+              data.name = componentGraphTitles[meshComponent] || componentNames[meshComponent];
               return (<Col span={8} key={`col-${data.id}`}>
                 <DeploymentSummary
                   key={data.id}

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -28,7 +28,7 @@ const serviceMeshDetailsColumns = [
 ];
 const componentNames = {
   "prometheus":   "Prometheus",
-  "destination":  "Controller Deestination",
+  "destination":  "Controller Destination",
   "proxy-api":    "Controller Proxy API",
   "public-api":   "Controller Public API",
   "tap":          "Controller Tap",


### PR DESCRIPTION
Tweaks to make the Section titles of various pages less confusing, removes destination svc graph on the ServiceMesh page that had sparse data points (#213).

- ResourceMetricOverview: retitle DeploymentDetail/PodDetail sections
- ResourceHealthOverview: Hide Inbound/Outbound request rate if there are 0 deployments
- ServiceMesh: plot public-api instead of destination, retitle destination and telemetry graphs

Section retitling:

![screen shot 2018-02-01 at 6 03 20 pm](https://user-images.githubusercontent.com/549258/35713068-437d14ec-077a-11e8-901c-451c38999a45.png)

Don't show num requests if that number is 0 and there are no neighboring deployments/pods:
![screen shot 2018-02-01 at 6 03 35 pm](https://user-images.githubusercontent.com/549258/35713069-4390fde0-077a-11e8-815b-09aeb8eac242.png)


Fixes #244