### PR TITLE
Always use the 64-bit version of dep.

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -9,15 +9,10 @@ if [ "$(uname -s)" = "Darwin" ]; then
 else
   os=linux
 fi
-if [ "$(uname -m)" = "x86_64" ]; then
-  arch=386
-else 
-  arch=amd64
-fi
 
 depbin=.dep
 depversion=0.4.1 # Need to keep this in sync with Dockerfile-go-deps
-depurl="https://github.com/golang/dep/releases/download/v${depversion}/dep-${os}-${arch}"
+depurl="https://github.com/golang/dep/releases/download/v${depversion}/dep-${os}-amd64"
 
 if [ ! -f "$depbin" ]; then
   tmp=$(mktemp -d -t dep.XXX)


### PR DESCRIPTION
The logic for choosing the 32-bit vs. 64-bit version of dep was
inverted.

Fix this by simply always using the 64-bit version.

Signed-off-by: Brian Smith <brian@briansmith.org>