### PR TITLE
Check SHA-256 sum of dep binary before running it.

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -1,6 +1,16 @@
-#!/bin/sh
+#!/bin/bash
+# bash is required since indirect variable substitution is used.
 
 set -eu
+
+# Keep this in sync with Dockerfile-go-deps. The digests will be different for each
+# version and each platform; they can be found in the *.sha256 files alongside the
+# executables at ${dep_base_url}.
+depversion=0.4.1
+dep_base_url="https://github.com/golang/dep/releases/download/v${depversion}/"
+dep_digest_linux=31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315
+dep_digest_darwin=f170008e2bf8b196779c361a4eaece1b03450d23bbf32d1a0beaa9b00b6a5ab4
+dep_digest_windows=f6e6a872c54d5ae7536ac71fd5bcac9f4e7b8a1dafa1ef7c23866e2f3069fe4e
 
 cd "$(pwd -P)"
 
@@ -14,14 +24,18 @@ elif [ "$(uname -o)" = "Msys" ]; then
 fi
 
 depbin=.dep${exe}
-depversion=0.4.1 # Need to keep this in sync with Dockerfile-go-deps
-depurl="https://github.com/golang/dep/releases/download/v${depversion}/dep-${os}-amd64${exe}"
+depurl="${dep_base_url}dep-${os}-amd64${exe}"
 
 if [ ! -f "$depbin" ]; then
   tmp=$(mktemp -d -t dep.XXX)
   (
     cd "$tmp"
     curl -L --silent --fail -o "$depbin" "$depurl"
+    ddv="dep_digest_${os}"
+    (echo "${!ddv} *$depbin" | shasum -c -a 256 -p -s -) || {
+      echo Actual digest of $depbin does not match expected digest.
+      exit 1
+    }
     chmod +x "$depbin"
   )
   mv "$tmp/$depbin" "$depbin"


### PR DESCRIPTION
Check SHA-256 sum of dep binary before running it.

Previously we didn't verify that the downloaded dep binary is the right
binary.

Verify that the downloaded binary is correct.