### PR TITLE
Add --url option to conduit dashboard

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -10,40 +10,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	proxyPort = -1
-)
+var dashboardProxyPort int
+var dashboardSkipBrowser bool
 
 var dashboardCmd = &cobra.Command{
 	Use:   "dashboard [flags]",
 	Short: "Open the Conduit dashboard in a web browser",
-	Long:  "Open the Conduit dashboard in a web browser.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if proxyPort < 0 {
-			return fmt.Errorf("port must be greater than or equal to zero, was %d", proxyPort)
+		if dashboardProxyPort < 0 {
+			return fmt.Errorf("port must be greater than or equal to zero, was %d", dashboardProxyPort)
 		}
 
-		kp, err := k8s.InitK8sProxy(shell.NewUnixShell().HomeDir(), kubeconfigPath, proxyPort)
+		kubernetesProxy, err := k8s.InitK8sProxy(shell.NewUnixShell().HomeDir(), kubeconfigPath, dashboardProxyPort)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to initialize proxy: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to initialize proxy: %s\n", err)
 			os.Exit(1)
 		}
 
-		url, err := kp.URLFor(controlPlaneNamespace, "/services/web:http/proxy/")
+		url, err := kubernetesProxy.URLFor(controlPlaneNamespace, "/services/web:http/proxy/")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to generate URL for dashboard: %s", err)
+			fmt.Fprintf(os.Stderr, "Failed to generate URL for dashboard: %s\n", err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("Opening [%s] in the default browser\n", url)
-		err = browser.OpenURL(url.String())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to open URL %s in the default browser: %s", url, err)
-			os.Exit(1)
+		fmt.Printf("Conduit dashboard available at:\n%s\n", url.String())
+
+		if !dashboardSkipBrowser {
+			fmt.Println("Opening the default browser")
+			err = browser.OpenURL(url.String())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to open URL %s in the default browser: %s", url, err)
+				os.Exit(1)
+			}
 		}
 
 		// blocks until killed
-		err = kp.Run()
+		err = kubernetesProxy.Run()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error running proxy: %s", err)
 			os.Exit(1)
@@ -60,5 +62,6 @@ func init() {
 
 	// This is identical to what `kubectl proxy --help` reports, `--port 0`
 	// indicates a random port.
-	dashboardCmd.PersistentFlags().IntVarP(&proxyPort, "port", "p", 8001, "The port on which to run the proxy. Set to 0 to pick a random port.")
+	dashboardCmd.PersistentFlags().IntVarP(&dashboardProxyPort, "port", "p", 8001, "The port on which to run the proxy. Set to 0 to pick a random port.")
+	dashboardCmd.PersistentFlags().BoolVar(&dashboardSkipBrowser, "url", false, "Display the Conduit dashboard URL in the CLI instead of opening it in the default browser")
 }


### PR DESCRIPTION
```shell
Usage:
  conduit dashboard [flags]

Flags:
      --api-addr string     Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)
  -h, --help                help for dashboard
      --kubeconfig string   Path to the kubeconfig file to use for CLI requests
      --url                           Display the Conduit dashboard URL in the CLI instead of opening it in the default browser
  -p, --port int            The port on which to run the proxy. Set to 0 to pick a random port. (default 8001)

Global Flags:
  -n, --conduit-namespace string   namespace in which Conduit is installed (default "conduit")
      --verbose                    turn on debug logging
```

Browser opening is a UX nicety, but it shouldn't be mandatory.