### PR TITLE
Change default version string from "unknown" to "latest"

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,7 @@ import (
 
 // DO NOT EDIT
 // This var is updated automatically as part of the build process
-var Version = "unknown"
+var Version = "latest"
 
 func VersionFlag() *bool {
 	return flag.Bool("version", false, "print version and exit")


### PR DESCRIPTION
This is a follow-up to #208. We no longer hardcode the conduit version in go source files. Instead, we default it to the string "unknown". When building in docker, we override the default to match the docker image tag. When running the code outside of docker, the default of "unknown" is still used. It was suggested that this default is confusing, however, so I'm changing it to "latest", which hopefully makes more sense. Fixes #223.