### PR TITLE
Stop running "cargo check" in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ jobs:
     - stage: test
       language: rust
       rust: stable
-      cache:
-        cargo: true
+      cache: cargo
+      before_install:
+        # TEMPORARY: clear cargo caches
+        - rm -rf $HOME/.cargo/checkouts
+        - rm -rf $HOME/.cargo/db
+        - rm -rf $TRAVIS_BUILD_DIR/target
       install:
         - cargo fetch --locked
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jobs:
       install:
         - cargo fetch --locked
       script:
-        - cargo check --frozen
         - cargo test --frozen
 
     - language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,6 @@ jobs:
       language: rust
       rust: stable
       cache: cargo
-      before_install:
-        # TEMPORARY: clear cargo caches
-        - rm -rf $HOME/.cargo/checkouts
-        - rm -rf $HOME/.cargo/db
-        - rm -rf $TRAVIS_BUILD_DIR/target
       install:
         - cargo fetch --locked
       script:

--- a/BUILD.md
+++ b/BUILD.md
@@ -346,9 +346,17 @@ It supports two environment variables:
 
 ### Testing
 
+To build the Rust code and run tests, run:
+
+```bash
+cargo test
+```
+
+To analyze the Rust code and report errors, without building object files or
+running tests, run:
+
 ```bash
 cargo check
-cargo test
 ```
 
 # Dependencies


### PR DESCRIPTION
Running both `cargo check` and `cargo test` in CI is slowing down our Rust CI builds. In this branch I'm removing the `cargo check` command, and clarifying when to use check or test in BUILD.md. Fixes #149.