### PR TITLE
add check and friendly error if conduit dashboard is not installed

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -39,7 +39,8 @@ var dashboardCmd = &cobra.Command{
 
 		client, err := newPublicAPIClient()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to initialize API Client: %+v\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to initialize Conduit API client: %+v\n", err)
+			os.Exit(1)
 		}
 
 		dashboardAvailable, err := isDashboardAvailable(client)
@@ -48,7 +49,7 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		if !dashboardAvailable {
-			fmt.Fprint(os.Stderr, "Conduit dashboard might not be installed in your cluster\n")
+			fmt.Fprint(os.Stderr, "Conduit web deployment is not installed in your cluster\n")
 			os.Exit(1)
 		}
 

--- a/cli/cmd/dashboard_test.go
+++ b/cli/cmd/dashboard_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type MockHttpClient struct{}
+
+func TestDashboardAvailability(t *testing.T) {
+	t.Run("Returns true if dashboard HTTP request status code is 200", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "Hello, client")
+		}))
+		defer ts.Close()
+
+		dashboardAvailable, err := isDashboardAvailable(ts.Client(), ts.URL)
+		if err != nil {
+			t.Fatalf("Expected to not receive an error but got: %+v\n", err)
+		}
+
+		if !dashboardAvailable {
+			t.Fatalf("Expected dashboard available to be true but got: %t", dashboardAvailable)
+		}
+	})
+
+	t.Run("Returns true if dashboard HTTP request status code is 300", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusPermanentRedirect)
+		}))
+		defer ts.Close()
+
+		dashboardAvailable, err := isDashboardAvailable(ts.Client(), ts.URL)
+		if err != nil {
+			t.Fatalf("Expected to not receive an error but got: %+v\n", err)
+		}
+
+		if !dashboardAvailable {
+			t.Fatalf("Expected dashboard available to be true but got: %t", dashboardAvailable)
+		}
+	})
+	t.Run("dashboardAvailable is false if dashboard HTTP request status code is 500", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		dashboardAvailable, err := isDashboardAvailable(ts.Client(), ts.URL)
+		if err != nil {
+			t.Fatalf("Expected to not receive an error but got: %+v\n", err)
+		}
+
+		if dashboardAvailable {
+			t.Fatalf("Expected dashboard available to be true but got: %t", dashboardAvailable)
+		}
+	})
+}


### PR DESCRIPTION
This is a new PR that is a resurrection from #197. Given that the `dashboard.go` code underwent a refactor, I created a new branch an PR that works off of the refactor.

When the conduit dashboard CLI command is run with and conduitnot installed in a cluster. The CLI will optimistically run kubectl proxy -p 8001 and attempt to open a browser pointing to the conduit dashboard URL.

This causes it to display an error message from K8S as outlined in this #190. This PR adds functionality to check if the conduit dashboard URL is reachable and only attempt to open up the URL. If the dashboard is unreachable, the command displays an error.

Unit tests have been added and tested the change locally in minikube.

fixes #190
Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>