### PR TITLE
Fix bug where table data wasn't being updated

### DIFF
--- a/web/app/js/components/TabbedMetricsTable.jsx
+++ b/web/app/js/components/TabbedMetricsTable.jsx
@@ -79,14 +79,6 @@ export default class TabbedMetricsTable extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
-
-    this.state = {
-      timeseries: {},
-      rollup: this.preprocessMetrics(),
-      error: '',
-      pollingInterval: 10000,
-      pendingRequests: false
-    };
   }
 
   preprocessMetrics() {
@@ -103,10 +95,11 @@ export default class TabbedMetricsTable extends React.Component {
 
   render() {
     let resource = resourceInfo[this.props.resource];
+    let tableData = this.preprocessMetrics();
     let columns = _.compact(columnDefinitions(this.props.sortable, resource, this.api.ConduitLink));
 
     return (<Table
-      dataSource={this.state.rollup}
+      dataSource={tableData}
       columns={columns}
       pagination={false}
       className="conduit-table"


### PR DESCRIPTION
Also remove unused state initializations.

*Problem*
The state of TabbedMetricsTable wasn't being updated when the metrics were updated.

*Cause*
State doesn't update with props update in the constructor
(https://reactjs.org/docs/react-component.html#constructor)

*Solution*
Don't use the state set in the constructor.

Fixes #236