### PR TITLE
Don't manually install Docker in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,12 +77,6 @@ jobs:
           - "$HOME/google-cloud-sdk/"
 
       before_install:
-        - |
-          # Install docker.
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-          sudo apt-get update
-          sudo apt-get -y install docker-ce
         - docker version
 
         - |


### PR DESCRIPTION
Travis CI now installs Docker 17.09 or later, which is good enough for
us, so avoid installing Docker manually.

Signed-off-by: Brian Smith <brian@briansmith.org>