### PR TITLE
Optimize Prometheus queries

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,8 +15,8 @@
     "autorest/azure",
     "autorest/date"
   ]
-  revision = "d4e6b95c12a08b4de2d48b45d5b4d594e5d32fab"
-  version = "v9.9.0"
+  revision = "fc3b03a2d2d1f43fad3007038bd16f044f870722"
+  version = "v9.10.0"
 
 [[projects]]
   name = "github.com/PuerkitoBio/purell"
@@ -54,8 +54,8 @@
     ".",
     "log"
   ]
-  revision = "2dd44038f0b95ae693b266c5f87593b5d2fdd78d"
-  version = "v2.5.0"
+  revision = "26b41036311f2da8242db402557a0dbd09dc83da"
+  version = "v2.6.0"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -93,8 +93,8 @@
     "proto",
     "sortkeys"
   ]
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -154,7 +154,7 @@
     "openstack/utils",
     "pagination"
   ]
-  revision = "bb5adf2838a3646f74c131df11c061c3a1fe0bd4"
+  revision = "104e2578924bb3b211150c19414d0144b82165bb"
 
 [[projects]]
   branch = "master"
@@ -269,8 +269,7 @@
     "prometheus",
     "prometheus/promhttp"
   ]
-  revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
-  version = "v0.9.0-pre1"
+  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
 
 [[projects]]
   branch = "master"
@@ -338,7 +337,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
+  revision = "d9133f5469342136e669e85192a26056b587f503"
 
 [[projects]]
   branch = "master"
@@ -355,7 +354,7 @@
     "lex/httplex",
     "trace"
   ]
-  revision = "b417086c80e91bfa321ef761574721644b8b9f61"
+  revision = "2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1"
 
 [[projects]]
   branch = "master"
@@ -376,7 +375,7 @@
     "unix",
     "windows"
   ]
-  revision = "8f27ce8a604014414f8dfffc25cbcde83a3f2216"
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
   branch = "master"
@@ -421,7 +420,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+  revision = "2b5a72b8730b0b16380010cfe5286c42108d88e7"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -628,6 +627,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6fc47f2323bfee45f95f7aa0d49abafc3dfa9b57a20c8bcc3a4e3ef6e8abfdb4"
+  inputs-digest = "7c38374623dc6cc1376aa9407e23f4e47825d4c035bff1a8daae23dab5fe5a3c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,6 +40,10 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
   name = "github.com/golang/protobuf"
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845" # protobuf has no release tags at time of writing
 
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
+
 #
 # k8s.io/kubernetes dependency fixes
 # taken from https://github.com/kubernetes/kubernetes/blob/master/Godeps/Godeps.json

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:f24620b6 as golang
+FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:f24620b6 as golang
+FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -1,0 +1,92 @@
+package public
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	tap "github.com/runconduit/conduit/controller/gen/controller/tap"
+	telemetry "github.com/runconduit/conduit/controller/gen/controller/telemetry"
+	conduit_public "github.com/runconduit/conduit/controller/gen/public"
+	pb "github.com/runconduit/conduit/controller/gen/public"
+	"google.golang.org/grpc"
+)
+
+type mockTelemetry struct {
+	client telemetry.TelemetryClient
+	res    *telemetry.QueryResponse
+}
+
+// satisfies telemetry.TelemetryClient
+func (m *mockTelemetry) Query(ctx context.Context, in *telemetry.QueryRequest, opts ...grpc.CallOption) (*telemetry.QueryResponse, error) {
+	return m.res, nil
+}
+func (m *mockTelemetry) ListPods(ctx context.Context, in *telemetry.ListPodsRequest, opts ...grpc.CallOption) (*conduit_public.ListPodsResponse, error) {
+	return nil, nil
+}
+
+type testResponse struct {
+	tRes *telemetry.QueryResponse
+	mReq *pb.MetricRequest
+	mRes *pb.MetricResponse
+}
+
+func TestStat(t *testing.T) {
+	t.Run("Stat returns the expected responses", func(t *testing.T) {
+
+		responses := []testResponse{
+			testResponse{
+				tRes: &telemetry.QueryResponse{
+					Metrics: []*telemetry.Sample{
+						&telemetry.Sample{
+							Values: []*telemetry.SampleValue{
+								&telemetry.SampleValue{Value: 1, TimestampMs: 2},
+							},
+							Labels: map[string]string{
+								pathLabel:         "pathLabel",
+								sourceDeployLabel: "sourceDeployLabel",
+								targetDeployLabel: "targetDeployLabel",
+							},
+						},
+					},
+				},
+				mReq: &pb.MetricRequest{
+					Metrics: []pb.MetricName{
+						pb.MetricName_REQUEST_RATE,
+					},
+				},
+				mRes: &pb.MetricResponse{
+					Metrics: []*pb.MetricSeries{
+						&pb.MetricSeries{
+							Name: pb.MetricName_REQUEST_RATE,
+							Metadata: &pb.MetricMetadata{
+								Path:         "pathLabel",
+								SourceDeploy: "sourceDeployLabel",
+								TargetDeploy: "targetDeployLabel",
+							},
+							Datapoints: []*pb.MetricDatapoint{
+								&pb.MetricDatapoint{
+									Value:       &pb.MetricValue{Value: &pb.MetricValue_Gauge{Gauge: 1}},
+									TimestampMs: 2,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, tr := range responses {
+			s := newGrpcServer(&mockTelemetry{res: tr.tRes}, tap.NewTapClient(nil))
+
+			res, err := s.Stat(context.Background(), tr.mReq)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tr.mRes) {
+				t.Fatalf("Unexpected response:\n%+v\n!=\n%+v", res, tr.mRes)
+			}
+		}
+	})
+}

--- a/controller/telemetry/server_test.go
+++ b/controller/telemetry/server_test.go
@@ -1,0 +1,165 @@
+package telemetry
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	read "github.com/runconduit/conduit/controller/gen/controller/telemetry"
+	"golang.org/x/net/context"
+)
+
+type mockProm struct {
+	api v1.API
+	res model.Value
+}
+
+// satisfies v1.API
+func (m *mockProm) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	return m.res, nil
+}
+func (m *mockProm) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
+	return m.res, nil
+}
+func (m *mockProm) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
+	return nil, nil
+}
+func (m *mockProm) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	return nil, nil
+}
+
+type testResponse struct {
+	err      error
+	promRes  model.Value
+	queryReq *read.QueryRequest
+	queryRes *read.QueryResponse
+}
+
+func TestServerResponses(t *testing.T) {
+	responses := []testResponse{
+
+		testResponse{
+			err:     errors.New("Unexpected query result type (expected Vector): scalar"),
+			promRes: &model.Scalar{},
+			queryReq: &read.QueryRequest{
+				Query: "fake query",
+			},
+			queryRes: nil,
+		},
+		testResponse{
+			err:     errors.New("Unexpected query result type (expected Vector): matrix"),
+			promRes: model.Matrix{},
+			queryReq: &read.QueryRequest{
+				Query: "fake query",
+			},
+			queryRes: nil,
+		},
+		testResponse{
+			err:     errors.New("Unexpected query result type (expected Matrix): vector"),
+			promRes: model.Vector{},
+			queryReq: &read.QueryRequest{
+				Query:   "fake query",
+				StartMs: 1,
+				EndMs:   2,
+				Step:    "10s",
+			},
+			queryRes: nil,
+		},
+		testResponse{
+			err: nil,
+			promRes: model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"fake label": "fake value"},
+					Value:     123,
+					Timestamp: 456,
+				},
+				&model.Sample{
+					Metric:    model.Metric{"fake label2": "fake value2"},
+					Value:     321,
+					Timestamp: 654,
+				},
+			},
+			queryReq: &read.QueryRequest{
+				Query: "fake query",
+			},
+			queryRes: &read.QueryResponse{
+				Metrics: []*read.Sample{
+					&read.Sample{
+						Values: []*read.SampleValue{{Value: 123, TimestampMs: 456}},
+						Labels: map[string]string{"fake label": "fake value"},
+					},
+					&read.Sample{
+						Values: []*read.SampleValue{{Value: 321, TimestampMs: 654}},
+						Labels: map[string]string{"fake label2": "fake value2"},
+					},
+				},
+			},
+		},
+		testResponse{
+			err: nil,
+			promRes: model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"fake label": "fake value"},
+					Values: []model.SamplePair{
+						{Timestamp: 1, Value: 2},
+						{Timestamp: 3, Value: 4},
+					},
+				},
+				&model.SampleStream{
+					Metric: model.Metric{"fake label2": "fake value2"},
+					Values: []model.SamplePair{
+						{Timestamp: 5, Value: 6},
+						{Timestamp: 7, Value: 8},
+					},
+				},
+			},
+			queryReq: &read.QueryRequest{
+				Query:   "fake query",
+				StartMs: 1,
+				EndMs:   2,
+				Step:    "10s",
+			},
+			queryRes: &read.QueryResponse{
+				Metrics: []*read.Sample{
+					&read.Sample{
+						Values: []*read.SampleValue{
+							{Value: 2, TimestampMs: 1},
+							{Value: 4, TimestampMs: 3},
+						},
+						Labels: map[string]string{"fake label": "fake value"},
+					},
+					&read.Sample{
+						Values: []*read.SampleValue{
+							{Value: 6, TimestampMs: 5},
+							{Value: 8, TimestampMs: 7},
+						},
+						Labels: map[string]string{"fake label2": "fake value2"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Queries return the expected responses", func(t *testing.T) {
+		for _, tr := range responses {
+			s := server{
+				prometheusAPI: &mockProm{res: tr.promRes},
+			}
+			res, err := s.Query(context.Background(), tr.queryReq)
+			if err != nil || tr.err != nil {
+				if (err == nil && tr.err != nil) ||
+					(err != nil && tr.err == nil) ||
+					(err.Error() != tr.err.Error()) {
+					t.Fatalf("Unexpected error (Expected: %s, Got: %s)", tr.err, err)
+				}
+			}
+
+			if !reflect.DeepEqual(res, tr.queryRes) {
+				t.Fatalf("Unexpected response:\n%+v\n!=\n%+v", res, tr.queryRes)
+			}
+		}
+	})
+}

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:f24620b6 as golang
+FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:f24620b6 as golang
+FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Prometheus queries from the Telemetry service were taking seconds or 10s
of seconds.

Optimize these queries:
- Move all summary queries requiring a single data point off of Prometheus'
  QueryRange() endpoint, onto Query()
- Set `defaultVectorRange` to 30s, and also use it regardless of time
  window
Also add tests for grpc_server and telemetry server

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Fixes #260

# Results

Previously we had 12 variants of Prometheus query with p50's ranging from 4s to 8s. After these changes, all queries are < 3s, and all but 9 are < 300ms. p95 and p99 are also cut in half.

All results were generated using https://github.com/runconduit/conduit/tree/siggy/viz

## Average latency across all Prometheus queries

### Before

![sum_avg_baseline](https://user-images.githubusercontent.com/236915/35950577-111ff256-0c2c-11e8-9c42-560c54737ac0.png)

### After

![screen shot 2018-02-07 at 10 15 26 am](https://user-images.githubusercontent.com/236915/35950578-156c5a84-0c2c-11e8-9397-4cfd45d7dafb.png)

## Latency per Prometheus query

### Before

![avg_baseline_step](https://user-images.githubusercontent.com/236915/35950449-7cfeecee-0c2b-11e8-9c73-c7637a0ba6fd.png)

### After

![avg_query_step](https://user-images.githubusercontent.com/236915/35950451-80280edc-0c2b-11e8-9779-befaeac28d97.png)
