### PR TITLE
Clean up DeploymentList page

### DIFF
--- a/web/app/js/components/DeploymentsList.jsx
+++ b/web/app/js/components/DeploymentsList.jsx
@@ -1,27 +1,13 @@
 import _ from 'lodash';
 import CallToAction from './CallToAction.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
-import DeploymentSummary from './DeploymentSummary.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import PageHeader from './PageHeader.jsx';
 import React from 'react';
-import ScatterPlot from './ScatterPlot.jsx';
 import TabbedMetricsTable from './TabbedMetricsTable.jsx';
-import { Col, Row } from 'antd';
-import { emptyMetric, getPodsByDeployment, processRollupMetrics, processTimeseriesMetrics } from './util/MetricUtils.js';
-import { metricToFormatter, rowGutter } from './util/Utils.js';
+import { emptyMetric, getPodsByDeployment, processRollupMetrics } from './util/MetricUtils.js';
 import './../../css/deployments.css';
 import 'whatwg-fetch';
-
-const maxTsToFetch = 15; // Beyond this, stop showing sparklines in table
-let nodeStats = (description, node) => (
-  <div>
-    <div className="title">{description}:</div>
-    <div>
-      {node.name} ({metricToFormatter["LATENCY"](_.get(node, ["latency", "P99"]))})
-    </div>
-  </div>
-);
 
 export default class DeploymentsList extends React.Component {
   constructor(props) {
@@ -29,14 +15,10 @@ export default class DeploymentsList extends React.Component {
     this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
-    this.loadTimeseriesFromServer = this.loadTimeseriesFromServer.bind(this);
 
     this.state = {
       pollingInterval: 10000, // TODO: poll based on metricsWindow size
       metrics: [],
-      timeseriesByDeploy: {},
-      lastUpdated: 0,
-      limitSparklineData: false,
       pendingRequests: false,
       loaded: false,
       error: ''
@@ -79,40 +61,14 @@ export default class DeploymentsList extends React.Component {
         let meshDeploys = processRollupMetrics(rollup.metrics, "targetDeploy");
         let combinedMetrics = this.addDeploysWithNoMetrics(poByDeploy, meshDeploys);
 
-        this.loadTimeseriesFromServer(meshDeploys, combinedMetrics);
-      })
-      .catch(this.handleApiError);
-  }
-
-  loadTimeseriesFromServer(meshDeployMetrics, combinedMetrics) {
-    // fetch only the timeseries for the 3 deployments we display at the top of the page
-    let limitSparklineData = _.size(meshDeployMetrics) > maxTsToFetch;
-
-    let resourceInfo = this.api.urlsForResource["deployment"];
-    let mostActiveDeployments = this.getMostActiveDeployments(meshDeployMetrics);
-
-    let tsPromises = _.map(mostActiveDeployments, dep => {
-      let tsPathForDeploy = resourceInfo.url(dep.name).ts;
-      return this.api.fetchMetrics(tsPathForDeploy);
-    });
-
-    Promise.all(tsPromises)
-      .then(tsMetrics => {
-        let mostActiveTs = _.reduce(tsMetrics, (mem, ea) => {
-          mem = mem.concat(ea.metrics);
-          return mem;
-        }, []);
-        let tsByDeploy = processTimeseriesMetrics(mostActiveTs, resourceInfo.groupBy);
         this.setState({
-          timeseriesByDeploy: tsByDeploy,
-          lastUpdated: Date.now(),
           metrics: combinedMetrics,
-          limitSparklineData: limitSparklineData,
           loaded: true,
           pendingRequests: false,
           error: ''
         });
-      }).catch(this.handleApiError);
+      })
+      .catch(this.handleApiError);
   }
 
   handleApiError(e) {
@@ -120,87 +76,6 @@ export default class DeploymentsList extends React.Component {
       pendingRequests: false,
       error: `Error getting data from server: ${e.message}`
     });
-  }
-
-  getMostActiveDeployments(deployMetrics, limit = 3) {
-    return _(deployMetrics)
-      .filter('added')
-      .orderBy('requestRate', 'desc')
-      .take(limit)
-      .value();
-  }
-
-  renderPageContents() {
-    let mostActiveDeployments = this.getMostActiveDeployments(this.state.metrics);
-
-    return (
-      <div className="clearfix">
-        {_.isEmpty(mostActiveDeployments) ? null :
-          <div className="subsection-header">Most active deployments</div>}
-        <Row gutter={rowGutter}>
-          {
-            _.map(mostActiveDeployments, deployment => {
-              return (<Col span={8} key={`col-${deployment.name}`}>
-                <DeploymentSummary
-                  key={deployment.name}
-                  lastUpdated={this.state.lastUpdated}
-                  data={deployment}
-                  api = {this.api}
-                  requestTs={_.get(this.state.timeseriesByDeploy,
-                    [deployment.name, "REQUEST_RATE"], [])} />
-              </Col>);
-            })
-          }
-        </Row>
-        {/* <Row gutter={rowGutter}>
-          { this.renderScatterplot() }
-        </Row> */}
-        <div className="deployments-list">
-          <TabbedMetricsTable
-            resource="deployment"
-            metrics={this.state.metrics}
-            api={this.api} />
-        </div>
-      </div>
-    );
-  }
-
-  renderScatterplot() {
-    let scatterplotData = _.reduce(this.state.metrics, (mem, datum) => {
-      if (!_.isNil(datum.successRate) && !_.isNil(datum.latency)) {
-        mem.push(datum);
-      }
-      return mem;
-    }, []);
-
-    let slowestNode = _.maxBy(scatterplotData, 'latency.P99');
-    let fastestNode = _.minBy(scatterplotData, 'latency.P99');
-
-    if (_.isEmpty(scatterplotData)) {
-      return null;
-    }
-
-    return (<div className="deployments-scatterplot">
-      <div className="scatterplot-info">
-        <div className="subsection-header">Success rate vs p99 latency</div>
-      </div>
-      <Row gutter={rowGutter}>
-        <Col span={8}>
-          <div className="scatterplot-display">
-            <div className="extremal-latencies">
-              { !fastestNode ? null : nodeStats("Least latency", fastestNode) }
-              { !slowestNode ? null : nodeStats("Most latency", slowestNode) }
-            </div>
-          </div>
-        </Col>
-        <Col span={16}><div className="scatterplot-chart">
-          <ScatterPlot
-            data={scatterplotData}
-            lastUpdated={this.state.lastUpdated}
-            containerClassName="scatterplot-chart" />
-        </div></Col>
-      </Row>
-    </div>);
   }
 
   render() {
@@ -212,7 +87,12 @@ export default class DeploymentsList extends React.Component {
             <PageHeader header="Deployments" api={this.api} />
             { _.isEmpty(this.state.metrics) ?
               <CallToAction numDeployments={_.size(this.state.metrics)} /> :
-              this.renderPageContents()
+              <div className="deployments-list">
+                <TabbedMetricsTable
+                  resource="deployment"
+                  metrics={this.state.metrics}
+                  api={this.api} />
+              </div>
             }
           </div>
         }


### PR DESCRIPTION
- remove "Most active deployments" graphs from the Deployments List page
- remove the scatterplot sections of the page as I don't think we'll be using them for a while

![screen shot 2018-02-09 at 2 16 48 pm](https://user-images.githubusercontent.com/549258/36052809-0baabf4e-0da4-11e8-9b5c-bacc0c5a2fd1.png)
