### PR TITLE
Use bin/dep in Dockerfile-go-deps.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 .travis.yml
+.dep
+.dep.exe
 .git
 **/.idea
 **/cmake-*
 **/CMakeLists.txt
 *.iml
 bin
+!bin/dep
 **/Dockerfile*
 Dockerfile*
 **/target

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -7,10 +7,9 @@
 
 # Fetch `dep` and ensure that all Go dependencies are vendored.
 FROM golang:1.9.1 as build
-RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 && chmod +x /usr/local/bin/dep
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY . .
-RUN dep ensure
+RUN bin/dep ensure
 
 # Preserve dependency sources and build artifacts without maintaining conduit
 # sources/artifacts.

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
+FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
+FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
+FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:cfb2e0a7 as golang
+FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
bin/dep verifies the digest of the `dep` downloaded `dep` executable,
whereas previously Dockerfile-go-deps wasn't.

Signed-off-by: Brian Smith <brian@briansmith.org>