### PR TITLE
Improve the caching behavior of Dockerfile-go-deps.

### DIFF
--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,16 +5,14 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-# Fetch `dep` and ensure that all Go dependencies are vendored.
-FROM golang:1.9.1 as build
-WORKDIR /go/src/github.com/runconduit/conduit
-COPY . .
-RUN bin/dep ensure
-
-# Preserve dependency sources and build artifacts without maintaining conduit
-# sources/artifacts.
 FROM golang:1.9.1
 WORKDIR /go/src/github.com/runconduit/conduit
-COPY --from=build /go/src/github.com/runconduit/conduit/vendor     vendor
-COPY --from=build /go/src/github.com/runconduit/conduit/Gopkg.toml Gopkg.toml
-COPY --from=build /go/src/github.com/runconduit/conduit/Gopkg.lock Gopkg.lock
+
+# Download `dep` without being sensitive to changes to Gopkg.{toml,lock}.
+COPY bin/dep bin/dep
+RUN bin/dep version
+
+# Vendor the Go dependencies.
+COPY Gopkg.toml Gopkg.lock ./
+RUN bin/dep ensure -vendor-only -v
+

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
+FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
+FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
+FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:fd9e1b30 as golang
+FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Previously Dockerfile-go-deps would run `dep ensure` whenever anything in the
source tree changed. Also, because it was a multi-stage Dockerfile it did not
work well with Docker's `--cache-from` feature.

Change Dockerfile-go-deps to only re-run `dep ensure` when Gopkg.{toml,lock}
and/or bin/dep change. Simplify it to a single stage so that it works better
with Docker's `--cache-from` feature.

Signed-off-by: Brian Smith <brian@briansmith.org>
