### PR TITLE
Upgrade to Go 1.9.4.

### DIFF
--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,7 +5,7 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.9.1
+FROM golang:1.9.4
 WORKDIR /go/src/github.com/runconduit/conduit
 
 # Download `dep` without being sensitive to changes to Gopkg.{toml,lock}.

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
+FROM gcr.io/runconduit/go-deps:749453c2 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
+FROM gcr.io/runconduit/go-deps:749453c2 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller controller

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
+FROM gcr.io/runconduit/go-deps:749453c2 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -a -installsuffix cgo ./proxy-init/

--- a/proxy-init/integration_test/iptables/Dockerfile-tester
+++ b/proxy-init/integration_test/iptables/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM golang:1.9.1
+FROM golang:1.9.4
 
 ADD iptables/ /go
 # Kubernetes Jobs will be retried until they return status 0,

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:f9fff6b3 as golang
+FROM gcr.io/runconduit/go-deps:749453c2 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Go 1.9.4 is a security release

Signed-off-by: Brian Smith <brian@briansmith.org>
