### PR TITLE
Test the proxy in release mode in Docker in CI on the master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,9 +115,9 @@ jobs:
         - export BUILD_DEBUG=1 DOCKER_TRACE=1
 
       script:
-        # Proxy tests are run in the `test` stage, re-running them here would be
-        # redundant/slow. #280
-        - PROXY_SKIP_TESTS=1 bin/docker-build
+        # We re-run the tests here in *release* (--release) mode since the
+        # `test` stage only runs them in *debug* node.
+        - bin/docker-build
 
       after_success:
         - bin/docker-push-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
 
       script:
         # We re-run the tests here in *release* (--release) mode since the
-        # `test` stage only runs them in *debug* node.
+        # `test` stage only runs them in *debug* mode.
         - bin/docker-build
 
       after_success:


### PR DESCRIPTION
Previously we were not running the proxy tests in the release configuration.

Run the proxy tests in the release configuration through Docker.

Docker builds with tests in release mode are too slow to run on every
pull request so release mode tests will only be run on the master
branch.

Signed-off-by: Brian Smith <brian@briansmith.org>