### PR TITLE
Use Prometheus to track added data plane pods.

### DIFF
--- a/controller/telemetry/server.go
+++ b/controller/telemetry/server.go
@@ -27,6 +27,10 @@ import (
 	k8sV1 "k8s.io/api/core/v1"
 )
 
+const (
+	requestsMetric = "reports_total"
+)
+
 var (
 	requestLabels = []string{"source_deployment", "target_deployment", "method"}
 	requestsTotal = prometheus.NewCounterVec(
@@ -66,7 +70,7 @@ var (
 	reportsLabels = []string{"pod"}
 	reportsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "reports_total",
+			Name: requestsMetric,
 			Help: "Total number of telemetry reports received",
 		},
 		reportsLabels,
@@ -214,11 +218,11 @@ func (s *server) ListPods(ctx context.Context, req *read.ListPodsRequest) (*publ
 		return nil, err
 	}
 
-	// Reports is map from instance name to the absolute time of the most recent
+	// Reports is a map from instance name to the absolute time of the most recent
 	// report from that instance.
 	reports := make(map[string]time.Time)
 	// Query Prometheus for reports in the last 30 seconds.
-	res, err := s.prometheusAPI.Query(ctx, "reports_total[30s]", time.Time{})
+	res, err := s.prometheusAPI.Query(ctx, requestsMetric + "[30s]", time.Time{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The instance cache that powers the ListPods API is stored in memory in the telemetry service. This means that when there are multiple replicas of the telemetry service, each replica will have a distinct, incomplete view of the added pods based on which pods report to that telemetry replica. This causes the data plane bubbles on the dashboard to not all be filled in, and to flicker with each data refresh.

We create a Prometheus counter called `reports_total` which has `pod` as a label.  Whenever a telemetry service instance receives a report from a pod, it increments `reports_total` for that pod.  This allows us to remove the in-memory instance cache and instead query Prometheus to see if each pod has had a report in the last 30 seconds.

Fixes #337 

Signed-off-by: Alex Leong <alex@buoyant.io>