### PR TITLE
Require timestamp on all telemetry requests

### DIFF
--- a/controller/telemetry/server_test.go
+++ b/controller/telemetry/server_test.go
@@ -42,10 +42,19 @@ func TestServerResponses(t *testing.T) {
 	responses := []testResponse{
 
 		testResponse{
+			err:     errors.New("EndMs timestamp missing from request: query:\"fake query0\" "),
+			promRes: &model.Scalar{},
+			queryReq: &read.QueryRequest{
+				Query: "fake query0",
+			},
+			queryRes: nil,
+		},
+		testResponse{
 			err:     errors.New("Unexpected query result type (expected Vector): scalar"),
 			promRes: &model.Scalar{},
 			queryReq: &read.QueryRequest{
-				Query: "fake query",
+				Query: "fake query1",
+				EndMs: 1,
 			},
 			queryRes: nil,
 		},
@@ -53,7 +62,8 @@ func TestServerResponses(t *testing.T) {
 			err:     errors.New("Unexpected query result type (expected Vector): matrix"),
 			promRes: model.Matrix{},
 			queryReq: &read.QueryRequest{
-				Query: "fake query",
+				Query: "fake query2",
+				EndMs: 1,
 			},
 			queryRes: nil,
 		},
@@ -61,7 +71,7 @@ func TestServerResponses(t *testing.T) {
 			err:     errors.New("Unexpected query result type (expected Matrix): vector"),
 			promRes: model.Vector{},
 			queryReq: &read.QueryRequest{
-				Query:   "fake query",
+				Query:   "fake query3",
 				StartMs: 1,
 				EndMs:   2,
 				Step:    "10s",
@@ -83,7 +93,8 @@ func TestServerResponses(t *testing.T) {
 				},
 			},
 			queryReq: &read.QueryRequest{
-				Query: "fake query",
+				Query: "fake query4",
+				EndMs: 1,
 			},
 			queryRes: &read.QueryResponse{
 				Metrics: []*read.Sample{
@@ -117,7 +128,7 @@ func TestServerResponses(t *testing.T) {
 				},
 			},
 			queryReq: &read.QueryRequest{
-				Query:   "fake query",
+				Query:   "fake query5",
 				StartMs: 1,
 				EndMs:   2,
 				Step:    "10s",

--- a/proto/controller/telemetry/telemetry.proto
+++ b/proto/controller/telemetry/telemetry.proto
@@ -14,9 +14,17 @@ service Telemetry {
 }
 
 message QueryRequest {
+  // required
   string query = 1;
+
+  // required for timeseries queries
   int64 start_ms = 2;
+
+  // required for timeseries queries
+  // optional for single data point, but if unset, results will have non-deterministic timestamps
   int64 end_ms = 3;
+
+  // required for timeseries queries
   string step = 4;
 }
 


### PR DESCRIPTION
PR #298 moved summary (non-timeseries) requests to Prometheus' Query
endpoint, with no timestamp provided. This Query endpoint returns a
single data point with whatever timestamp was provided in the request.
In the absense of a timestamp, it uses current server time. This causes
the Public API to return discreet data points with slightly different
timestamps, which is unexpected behavior.

Modify the Public API -> Telemetry -> Prometheus request path to always
require a timestamp for single data point requests.

Fixes #340

Signed-off-by: Andrew Seigner <siggy@buoyant.io>