### PR TITLE
Upgrade to Prometheus 2.1.0

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -349,9 +349,8 @@ spec:
         image: {{.PrometheusImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
-        - "-storage.local.retention=6h"
-        - "-storage.local.memory-chunks=500000"
-        - "-config.file=/etc/prometheus/prometheus.yml"
+        - "--storage.tsdb.retention=6h"
+        - "--config.file=/etc/prometheus/prometheus.yml"
 
       # TODO remove/replace?
       - name: kubectl
@@ -432,7 +431,7 @@ var installCmd = &cobra.Command{
 			Namespace:                controlPlaneNamespace,
 			ControllerImage:          fmt.Sprintf("%s/controller:%s", dockerRegistry, conduitVersion),
 			WebImage:                 fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
-			PrometheusImage:          "prom/prometheus:v1.8.1",
+			PrometheusImage:          "prom/prometheus:v2.1.0",
 			ControllerReplicas:       controllerReplicas,
 			WebReplicas:              webReplicas,
 			PrometheusReplicas:       prometheusReplicas,

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -333,9 +333,8 @@ spec:
         image: PrometheusImage
         imagePullPolicy: ImagePullPolicy
         args:
-        - "-storage.local.retention=6h"
-        - "-storage.local.memory-chunks=500000"
-        - "-config.file=/etc/prometheus/prometheus.yml"
+        - "--storage.tsdb.retention=6h"
+        - "--config.file=/etc/prometheus/prometheus.yml"
 
       # TODO remove/replace?
       - name: kubectl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,12 +102,11 @@ services:
     - -template-dir=/templates
 
   prometheus:
-    image: prom/prometheus:v1.8.1
+    image: prom/prometheus:v2.1.0
     ports:
     - 9090:9090
     volumes:
     - .prometheus.dev.yml:/etc/prometheus/prometheus.yml:ro
     command:
-    - -config.file=/etc/prometheus/prometheus.yml
-    - -storage.local.memory-chunks=500000
-    - -storage.local.retention=6h
+    - --config.file=/etc/prometheus/prometheus.yml
+    - --storage.tsdb.retention=6h


### PR DESCRIPTION
Conduit has been on Prometheus 1.8.1. Prometheus 2.x promises better
performance.

Upgrade Conduit to Prometheus 2.1.0

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

More details at:
https://prometheus.io/docs/prometheus/2.0/migration/

Preliminary testing shows performance is comparable, and system is operating correctly.

## 1.8.1

![prom18](https://user-images.githubusercontent.com/236915/36170941-bdfd3302-10b5-11e8-9b76-0f6b67024a06.png)

## 2.1.0

![prom2](https://user-images.githubusercontent.com/236915/36170944-c04d83a0-10b5-11e8-9b92-3d1bf1e80d3e.png)

