### PR TITLE
Ensure latency quantile queries match timestamps

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -361,7 +361,12 @@ func (s *grpcServer) queryCount(ctx context.Context, req *pb.MetricRequest, rawQ
 		return queryResult{res: telemPb.QueryResponse{}, err: err}
 	}
 
-	return s.query(ctx, req, query)
+	queryReq, err := reqToQueryReq(req, query)
+	if err != nil {
+		return queryResult{res: telemPb.QueryResponse{}, err: err}
+	}
+
+	return s.query(ctx, queryReq)
 }
 
 func (s *grpcServer) queryLatency(ctx context.Context, req *pb.MetricRequest) (map[pb.HistogramLabel]telemPb.QueryResponse, error) {
@@ -372,15 +377,24 @@ func (s *grpcServer) queryLatency(ctx context.Context, req *pb.MetricRequest) (m
 		return nil, err
 	}
 
+	// omit query string, we'll fill it in later
+	queryReq, err := reqToQueryReq(req, "")
+	if err != nil {
+		return nil, err
+	}
+
 	results := make(chan queryResultWithLabel)
 
 	// kick off requests
 	for quantile, label := range quantileMap {
 		go func(quantile string, label pb.HistogramLabel) {
-			q := fmt.Sprintf(quantileQuery, quantile, query)
+			// copy queryReq, gets us StartMS, EndMS, and Step
+			qr := queryReq
+			// insert our quantile-specific query
+			qr.Query = fmt.Sprintf(quantileQuery, quantile, query)
 
 			results <- queryResultWithLabel{
-				queryResult: s.query(ctx, req, q),
+				queryResult: s.query(ctx, qr),
 				label:       label,
 			}
 		}(quantile, label)
@@ -401,29 +415,33 @@ func (s *grpcServer) queryLatency(ctx context.Context, req *pb.MetricRequest) (m
 	return queryRsps, err
 }
 
-func (s *grpcServer) query(ctx context.Context, req *pb.MetricRequest, query string) queryResult {
-	queryReq := &telemPb.QueryRequest{
-		Query: query,
-	}
-
-	start, end, step, err := queryParams(req)
-	if err != nil {
-		return queryResult{res: telemPb.QueryResponse{}, err: err}
-	}
-
-	// EndMs always required to ensure deterministic timestamps
-	queryReq.EndMs = end
-	if !req.Summarize {
-		queryReq.StartMs = start
-		queryReq.Step = step
-	}
-
-	queryRsp, err := s.telemetryClient.Query(ctx, queryReq)
+func (s *grpcServer) query(ctx context.Context, queryReq telemPb.QueryRequest) queryResult {
+	queryRsp, err := s.telemetryClient.Query(ctx, &queryReq)
 	if err != nil {
 		return queryResult{res: telemPb.QueryResponse{}, err: err}
 	}
 
 	return queryResult{res: *queryRsp, err: nil}
+}
+
+func reqToQueryReq(req *pb.MetricRequest, query string) (telemPb.QueryRequest, error) {
+	start, end, step, err := queryParams(req)
+	if err != nil {
+		return telemPb.QueryRequest{}, err
+	}
+
+	// EndMs always required to ensure deterministic timestamps
+	queryReq := telemPb.QueryRequest{
+		Query: query,
+		EndMs: end,
+	}
+
+	if !req.Summarize {
+		queryReq.StartMs = start
+		queryReq.Step = step
+	}
+
+	return queryReq, nil
 }
 
 func formatQuery(query string, req *pb.MetricRequest, sumBy string) (string, error) {


### PR DESCRIPTION
In PR #298 we moved time window parsing (10s => (time.now - 10s,
time.now) down the stack to immediately before the query. This had the
unintended effect of creating parallel latency quantile requests with
slightly different timestamps.

This change parses the time window prior to latency quantile fan out,
ensuring all requests have the same timestamp.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>