### PR TITLE
Remove unused web routes and helper

### DIFF
--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -89,19 +89,6 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
           rollup: downstreamRollupUrl
         };
       }
-    },
-    "path": {
-      // all paths (default), or all paths of a given deploy if specified
-      groupBy: "path",
-      url: (deploy = null) => {
-        let pathRollupUrl = `${metricsUrl}&aggregation=path${ !deploy ? "" : `&target_deploy=${deploy}`}`;
-        let pathTsUrl = `${pathRollupUrl}&timeseries=true`;
-
-        return {
-          ts: pathTsUrl,
-          rollup: pathRollupUrl
-        };
-      }
     }
   };
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -80,12 +80,9 @@ func NewServer(addr, templateDir, staticDir, uuid, webpackDevServer string, relo
 
 	// webapp routes
 	server.router.GET("/", handler.handleIndex)
-	server.router.GET("/pod", handler.handleIndex)
 	server.router.GET("/deployment", handler.handleIndex)
 	server.router.GET("/deployments", handler.handleIndex)
-	server.router.GET("/paths", handler.handleIndex)
 	server.router.GET("/servicemesh", handler.handleIndex)
-	server.router.GET("/routes", handler.handleIndex)
 	server.router.ServeFiles(
 		"/dist/*filepath", // add catch-all parameter to match all files in dir
 		filesonly.FileSystem(server.staticDir))


### PR DESCRIPTION
This is a very minor follow-up to #304, #315, and #319 -- am just removing some additional code that's no longer in use now that pods, paths and routes have been removed from the web ui.