### PR TITLE
controller: resolve external services with public DNS

### DIFF
--- a/controller/destination/egress.go
+++ b/controller/destination/egress.go
@@ -1,0 +1,186 @@
+package destination
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	common "github.com/runconduit/conduit/controller/gen/common"
+	log "github.com/sirupsen/logrus"
+	"github.com/runconduit/conduit/controller/util"
+)
+
+type DnsListener interface {
+	Update(add []common.TcpAddress, remove []common.TcpAddress)
+}
+
+type DnsWatcher struct {
+	hosts map[string]*informer
+	mutex sync.Mutex
+}
+
+func NewDnsWatcher() *DnsWatcher {
+	return &DnsWatcher{
+		hosts: make(map[string]*informer),
+	}
+}
+
+func (w *DnsWatcher) Subscribe(host string, listener DnsListener) error {
+	log.Printf("Establishing dns watch on host %s", host)
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	informer, ok := w.hosts[host]
+	if !ok {
+		informer = newInformer(host)
+		go informer.run()
+		w.hosts[host] = informer
+	}
+
+	informer.add(listener)
+
+	return nil
+}
+
+func (w *DnsWatcher) Unsubscribe(host string, listener DnsListener) error {
+	log.Printf("Stopping dns watch on host %s", host)
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	informer, ok := w.hosts[host]
+	if !ok {
+		return fmt.Errorf("Cannot unsubscribe from %s: not subscribed", host)
+	}
+
+	informer.mutex.Lock()
+	defer informer.mutex.Unlock()
+
+	for i, v := range informer.listeners {
+		if v == listener {
+			num := len(informer.listeners)
+			if num == 1 {
+				// last subscription being removed, close me up!
+				informer.stopCh <- struct{}{}
+				delete(w.hosts, host)
+				return nil
+			} else if num == i + 1 {
+				informer.listeners = informer.listeners[:i]
+			} else {
+				informer.listeners = append(informer.listeners[:i], informer.listeners[i+1:]...)
+			}
+		}
+	}
+
+	return nil
+}
+
+type informer struct {
+	addrs     map[string]struct {}
+	host      string
+	listeners []DnsListener
+	mutex     sync.Mutex
+	stopCh    chan struct{}
+}
+
+func newInformer(host string) *informer {
+	i := &informer{
+		addrs: make(map[string]struct {}),
+		host: host,
+		listeners: make([]DnsListener, 0),
+		stopCh: make(chan struct{}),
+	}
+
+	return i
+}
+
+func (i *informer) run() {
+	ticker := time.NewTicker(10 * time.Second)
+	for {
+		addrs, err := net.LookupHost(i.host)
+
+		if err == nil {
+			i.update(addrs)
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-i.stopCh:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (i* informer) update(addrs []string) {
+	// diff with current set, send any updates
+
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	oldSet := i.addrs
+	newSet := make(map[string]struct {})
+	additions := make([]common.TcpAddress, 0)
+	removals := make([]common.TcpAddress, 0)
+
+	for _, addr := range addrs {
+		if _, ok := oldSet[addr]; !ok {
+			ip, err := util.ParseIPV4(addr)
+			if err != nil {
+				log.Printf("%s is not a valid IP address", ip)
+				continue
+			}
+			additions = append(additions, common.TcpAddress{
+				Ip: ip,
+				Port: 80, //magical
+			})
+		} else {
+			delete(oldSet, addr)
+		}
+		newSet[addr] = struct{}{}
+	}
+
+	for addr := range oldSet {
+		// anything still active was remove from oldSet above
+		// so anything left behind is a removal
+		ip, err := util.ParseIPV4(addr)
+		if err != nil {
+			log.Printf("%s is not a valid IP address", ip)
+			continue
+		}
+		removals = append(removals, common.TcpAddress{
+			Ip: ip,
+			Port: 80, //magical
+		})
+	}
+
+	i.addrs = newSet
+
+	for _, listener := range i.listeners {
+		listener.Update(additions, removals)
+	}
+}
+
+func (i *informer) add(listener DnsListener) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	add := make([]common.TcpAddress, len(i.addrs))
+	for addr := range i.addrs {
+		ip, err := util.ParseIPV4(addr)
+		if err != nil {
+			log.Printf("%s is not a valid IP address", addr)
+			continue
+		}
+		add = append(add, common.TcpAddress{
+			Ip: ip,
+			Port: 80, //magical
+		})
+	}
+	listener.Update(add, nil)
+
+	i.listeners = append(i.listeners, listener)
+}

--- a/controller/destination/egress_test.go
+++ b/controller/destination/egress_test.go
@@ -3,17 +3,71 @@ package destination
 import (
 	"testing"
 
+	common "github.com/runconduit/conduit/controller/gen/common"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/runconduit/conduit/controller/util"
 )
+
+type testListener struct {
+	t       *testing.T
+	added   []string
+	removed []string
+}
+
+func (me testListener) Update(add []common.TcpAddress, remove []common.TcpAddress) {
+	assert.Equal(me.t, len(me.added), len(add))
+	assert.Equal(me.t, len(me.removed), len(remove))
+
+	for i, addr := range add {
+		assert.Equal(me.t, me.added[i], util.AddressToString(&addr))
+	}
+
+	for i, addr := range remove {
+		assert.Equal(me.t, me.removed[i], util.AddressToString(&addr))
+	}
+}
 
 func TestInformerUpdate(t *testing.T) {
 	informer := newInformer("example.com")
+	listener := &testListener{
+		t: t,
+		added: nil,
+		removed: nil,
+	}
 
-	informer.update([]string {"10.0.0.1", "10.0.0.2"})
+	informer.add(listener)
 
-	assert.Equal(t, 2, len(informer.addrs))
+	updates := []struct {
+		update  []string
+		added   []string
+		removed []string
+	}{
+		{
+			update: []string{"10.0.0.1", "10.0.0.2"},
+			added: []string{"10.0.0.1:80", "10.0.0.2:80"},
+			removed: nil,
+		},
+		{
+			update: []string{"10.0.0.1", "10.0.0.2"},
+			added: nil,
+			removed: nil,
+		},
+		{
+			update: []string{"10.0.0.2", "10.0.0.3"},
+			added: []string{"10.0.0.3:80"},
+			removed: []string{"10.0.0.1:80"},
+		},
+		{
+			update: nil,
+			added: nil,
+			removed: []string{"10.0.0.2:80", "10.0.0.3:80"},
+		},
+	}
 
-	informer.update([]string {"10.0.0.1", "10.0.0.2", "10.0.0.3"})
-
-	assert.Equal(t, 3, len(informer.addrs))
+	for _, tc := range updates {
+		listener.added = tc.added
+		listener.removed = tc.removed
+		informer.update(tc.update)
+	}
 }

--- a/controller/destination/egress_test.go
+++ b/controller/destination/egress_test.go
@@ -1,0 +1,19 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInformerUpdate(t *testing.T) {
+	informer := newInformer("example.com")
+
+	informer.update([]string {"10.0.0.1", "10.0.0.2"})
+
+	assert.Equal(t, 2, len(informer.addrs))
+
+	informer.update([]string {"10.0.0.1", "10.0.0.2", "10.0.0.3"})
+
+	assert.Equal(t, 3, len(informer.addrs))
+}


### PR DESCRIPTION
This is a pretty basic stab at providing DNS support for external services (see #155). Notably:

- This doesn't use any DNS library at the moment, just `net.LookupHost`. This means it was much easier to implement, but that it doesn't observe TTLs, and so the interval it checks for updates is rather arbitrary.
- I tried to follow what I saw in the `Endpoints` stuff to keep only 1 querying thing per host, even if multiple proxies are all asking for it.
- Hopefully the `informer.run()` part is sufficiently separate that we could later add in usage of `dns` or `coredns` or something.


Closes #155 