### PR TITLE
UI tweaks: sidebar collapse, latency formatting, table row spacing

### DIFF
--- a/web/app/js/components/DeploymentsList.jsx
+++ b/web/app/js/components/DeploymentsList.jsx
@@ -2,9 +2,9 @@ import _ from 'lodash';
 import CallToAction from './CallToAction.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
+import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
 import React from 'react';
-import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import { emptyMetric, getPodsByDeployment, processRollupMetrics } from './util/MetricUtils.js';
 import './../../css/deployments.css';
 import 'whatwg-fetch';
@@ -88,7 +88,7 @@ export default class DeploymentsList extends React.Component {
             { _.isEmpty(this.state.metrics) ?
               <CallToAction numDeployments={_.size(this.state.metrics)} /> :
               <div className="deployments-list">
-                <TabbedMetricsTable
+                <MetricsTable
                   resource="deployment"
                   metrics={this.state.metrics}
                   api={this.api} />

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -72,7 +72,7 @@ const columnDefinitions = (sortable = true, resource, ConduitLink) => {
 
 const numericSort = (a, b) => (_.isNil(a) ? -1 : a) - (_.isNil(b) ? -1 : b);
 
-export default class TabbedMetricsTable extends React.Component {
+export default class MetricsTable extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
@@ -100,6 +100,7 @@ export default class TabbedMetricsTable extends React.Component {
       columns={columns}
       pagination={false}
       className="conduit-table"
-      rowKey={r => r.name} />);
+      rowKey={r => r.name}
+      size="middle" />);
   }
 }

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -264,7 +264,8 @@ export default class ServiceMesh extends React.Component {
             className="conduit-table"
             dataSource={this.getServiceMeshDetails()}
             columns={serviceMeshDetailsColumns}
-            pagination={false} />
+            pagination={false}
+            size="middle" />
         </div>
       </div>
     );

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -60,6 +60,7 @@ export default class Sidebar extends React.Component {
   render() {
     let normalizedPath = this.props.location.pathname.replace(this.props.pathPrefix, "");
     let ConduitLink = this.api.ConduitLink;
+
     return (
       <div className="sidebar">
         <div className="list-container">
@@ -88,11 +89,16 @@ export default class Sidebar extends React.Component {
             </Menu.Item>
           </Menu>
 
-          <SocialLinks />
-
-          <Version
-            releaseVersion={this.props.releaseVersion}
-            uuid={this.props.uuid} />
+          {
+            !this.props.collapsed ? (
+              <React.Fragment>
+                <SocialLinks />
+                <Version
+                  releaseVersion={this.props.releaseVersion}
+                  uuid={this.props.uuid} />
+              </React.Fragment>
+            ) : null
+          }
         </div>
       </div>
     );

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -95,6 +95,7 @@ export default class StatusTable extends React.Component {
       columns={tableCols}
       pagination={false}
       className="conduit-table"
-      rowKey={r => r.name} />);
+      rowKey={r => r.name}
+      size="middle" />);
   }
 }

--- a/web/app/js/components/UpstreamDownstream.jsx
+++ b/web/app/js/components/UpstreamDownstream.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
+import MetricsTable from './MetricsTable.jsx';
 import React from 'react';
 import { rowGutter } from './util/Utils.js';
-import TabbedMetricsTable from './TabbedMetricsTable.jsx';
 import { Col, Row } from 'antd';
 
 export default class UpstreamDownstreamTables extends React.Component {
@@ -17,7 +17,7 @@ export default class UpstreamDownstreamTables extends React.Component {
                 <div className="border-container border-neutral subsection-header">
                   <div className="border-container-content subsection-header">Upstreams</div>
                 </div>
-                <TabbedMetricsTable
+                <MetricsTable
                   resource={`upstream_${this.props.resourceType}`}
                   resourceName={this.props.resourceName}
                   metrics={this.props.upstreamMetrics}
@@ -30,7 +30,7 @@ export default class UpstreamDownstreamTables extends React.Component {
                 <div className="border-container border-neutral subsection-header">
                   <div className="border-container-content subsection-header">Downstreams</div>
                 </div>
-                <TabbedMetricsTable
+                <MetricsTable
                   resource={`downstream_${this.props.resourceType}`}
                   resourceName={this.props.resourceName}
                   metrics={this.props.downstreamMetrics}

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -11,12 +11,23 @@ export const rowGutter = 3 * baseWidth;
 * Number formatters
 */
 const successRateFormatter = d3.format(".2%");
+const latencySecFormatter = d3.format(".3f");
 const latencyFormatter = d3.format(",");
+
+const formatLatency = m => {
+  if (_.isNil(m)) {
+    return "---";
+  } else if (m < 1000) {
+    return `${latencyFormatter(m)} ms`;
+  } else {
+    return `${latencySecFormatter(m / 1000)} s`;
+  }
+};
 
 export const metricToFormatter = {
   "REQUEST_RATE": m => _.isNil(m) ? "---" : styleNum(m, " RPS", true),
   "SUCCESS_RATE": m => _.isNil(m) ? "---" : successRateFormatter(m),
-  "LATENCY": m => `${_.isNil(m) ? "---" : latencyFormatter(m)} ms`
+  "LATENCY": formatLatency
 };
 
 /*

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -21,11 +21,23 @@ if (proxyPathMatch) {
 
 let api = ApiHelpers(pathPrefix);
 
-ReactDOM.render((
+let applicationHtml = hideSidebar => (
   <BrowserRouter>
     <Layout>
-      <Layout.Sider width="310">
-        <Route render={routeProps => <Sidebar {...routeProps} goVersion={appData.goVersion} releaseVersion={appData.releaseVersion} api={api} pathPrefix={pathPrefix} uuid={appData.uuid} />} />
+      <Layout.Sider
+        width="310"
+        breakpoint="lg"
+        collapsedWidth={0}
+        onCollapse={onSidebarCollapse}>
+        <Route
+          render={routeProps => (<Sidebar
+            {...routeProps}
+            goVersion={appData.goVersion}
+            releaseVersion={appData.releaseVersion}
+            api={api}
+            collapsed={hideSidebar}
+            pathPrefix={pathPrefix}
+            uuid={appData.uuid} />)} />
       </Layout.Sider>
       <Layout>
         <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
@@ -42,4 +54,10 @@ ReactDOM.render((
       </Layout>
     </Layout>
   </BrowserRouter>
-), appMain);
+);
+
+const onSidebarCollapse = isHidden => {
+  ReactDOM.render(applicationHtml(isHidden), appMain);
+};
+
+ReactDOM.render(applicationHtml(false), appMain);

--- a/web/app/test/DeploymentsListTest.jsx
+++ b/web/app/test/DeploymentsListTest.jsx
@@ -65,7 +65,7 @@ describe('DeploymentsList', () => {
       expect(component.find("DeploymentsList").length).to.equal(1);
       expect(component.find("ConduitSpinner").length).to.equal(0);
       expect(component.find("CallToAction").length).to.equal(0);
-      expect(component.find("TabbedMetricsTable").length).to.equal(1);
+      expect(component.find("MetricsTable").length).to.equal(1);
     });
   });
 });

--- a/web/app/test/UtilsTest.js
+++ b/web/app/test/UtilsTest.js
@@ -56,7 +56,7 @@ describe('Utils', () => {
       let undefinedMetric;
       expect(metricToFormatter["REQUEST_RATE"](undefinedMetric)).to.equal('---');
       expect(metricToFormatter["SUCCESS_RATE"](undefinedMetric)).to.equal('---');
-      expect(metricToFormatter["LATENCY"](undefinedMetric)).to.equal('--- ms');
+      expect(metricToFormatter["LATENCY"](undefinedMetric)).to.equal('---');
     });
 
     it('formats requests with rounding and unit', () => {
@@ -68,12 +68,15 @@ describe('Utils', () => {
       expect(metricToFormatter["REQUEST_RATE"](99999)).to.equal('100k RPS');
     });
 
-    it('formats latency', () => {
+    it('formats subsecond latency as ms', () => {
       expect(metricToFormatter["LATENCY"](99)).to.equal('99 ms');
       expect(metricToFormatter["LATENCY"](999)).to.equal('999 ms');
-      expect(metricToFormatter["LATENCY"](1000)).to.equal('1,000 ms');
-      expect(metricToFormatter["LATENCY"](9999)).to.equal('9,999 ms');
-      expect(metricToFormatter["LATENCY"](99999)).to.equal('99,999 ms');
+    });
+
+    it('formats latency greater than 1s as s', () => {
+      expect(metricToFormatter["LATENCY"](1000)).to.equal('1.000 s');
+      expect(metricToFormatter["LATENCY"](9999)).to.equal('9.999 s');
+      expect(metricToFormatter["LATENCY"](99999)).to.equal('99.999 s');
     });
 
     it('formats success rate', () => {


### PR DESCRIPTION
- reduce row spacing on tables to make them more compact
- Rename TabbedMetricsTable to MetricsTable since it's not tabbed any more
- Format latencies greater than 1000ms as seconds
- Make sidebar collapsible for smaller screen widths

![screen shot 2018-02-14 at 3 09 40 pm](https://user-images.githubusercontent.com/549258/36234684-451f0162-11a1-11e8-8986-a4b91c6d9139.png)


![screen shot 2018-02-14 at 4 05 33 pm](https://user-images.githubusercontent.com/549258/36234679-387ef444-11a1-11e8-9d9a-6be47d11b0c3.png)
