### PR TITLE
Upgrade to Rust 1.24.0

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -310,6 +310,8 @@ yarn karma start --single-run
 These commands assume a working [Rust](https://www.rust-lang.org)
 environment.
 
+Note that we _only_ support the most recent `stable` version of Rust.
+
 To build and run the Rust proxy:
 
 ```bash

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,7 +7,7 @@
 # When PROXY_SKIP_TESTS is set and not empty, tests are not run. Otherwise, tests are run
 # against either unoptimized or optimized proxy code, according to PROXY_UNOPTIMIZED.
 
-ARG RUST_IMAGE=rust:1.23.0
+ARG RUST_IMAGE=rust:1.24.0
 ARG RUNTIME_IMAGE=gcr.io/runconduit/base:2017-10-30.01
 
 ## Builds the proxy as incrementally as possible.


### PR DESCRIPTION
Rust 1.24.0, the newest stable version of the rust compiler, was released
today.

This changes the default version used for docker builds.

Additionally, I have added a sentence to the rust section of BUILD.md
noting that we only support the most recent stable version of Rust.

Fixes #120 
Fixes #362