### PR TITLE
Strip `conduit` CLI executables in `docker build`.

### DIFF
--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -6,9 +6,10 @@ COPY cli cli
 COPY controller controller
 COPY pkg pkg
 RUN mkdir -p /out
-RUN CGO_ENABLED=0 GOOS=darwin  go build -installsuffix cgo -o /out/conduit-darwin  -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
-RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux   -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
-RUN CGO_ENABLED=0 GOOS=windows go build -installsuffix cgo -o /out/conduit-windows -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
+ENV GO_LDFLAGS="-s -w -X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}"
+RUN CGO_ENABLED=0 GOOS=darwin  go build -installsuffix cgo -o /out/conduit-darwin  -ldflags "${GO_LDFLAGS}" ./cli
+RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux   -ldflags "${GO_LDFLAGS}" ./cli
+RUN CGO_ENABLED=0 GOOS=windows go build -installsuffix cgo -o /out/conduit-windows -ldflags "${GO_LDFLAGS}" ./cli
 
 ## export without sources & dependencies
 FROM gcr.io/runconduit/base:2017-10-30.01


### PR DESCRIPTION
File sizes (in bytes) before and after this change:

```
        conduit-darwin conduit-linux conduit-windows
Before:     27,056,288    27,282,364      27,359,744
After:      20,023,456    18,080,576      18,262,528
----------------------------------------------------
Diff         7,032,832     9,201,788       9,097,216
```

Fixes #352.

Signed-off-by: Brian Smith <brian@briansmith.org>