### PR TITLE
Base control plane Docker images on scratch instead of base.

### DIFF
--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -11,6 +11,8 @@ RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux
 RUN CGO_ENABLED=0 GOOS=windows go build -installsuffix cgo -o /out/conduit-windows -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./cli
 
 ## export without sources & dependencies
-FROM gcr.io/runconduit/base:2017-10-30.01
+FROM scratch
 COPY --from=golang /out /out
-WORKDIR /out
+# `ENTRYPOINT` prevents `docker build` from otherwise failing with "Error
+# response from daemon: No command specified."
+ENTRYPOINT ["/out/conduit-linux"]

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -10,7 +10,6 @@ COPY controller controller
 RUN CGO_ENABLED=0 GOOS=linux go install -installsuffix cgo -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}" ./controller/cmd/...
 
 ## package runtime
-FROM gcr.io/runconduit/base:2017-10-30.01
-RUN mkdir /go
+FROM scratch
 ENV PATH=$PATH:/go/bin
 COPY --from=golang /go/bin /go/bin


### PR DESCRIPTION
The control plane is proxied through the Conduit proxy. The Conduit
proxy is based on the base image, and the control plane containers
and the proxy share a networking namespace. This means we don't
need the extra base utilities in the controller images since we can
use the utilties in the proxy image.

This is a step towards building the initial no-networking Conduit CA
pod. Since the Conduit CA will not do any networking of its own, we
networking debugging utilties are not helpful for it. They are
actually an unnecessary risk because they could facilitate the
exfiltration of the private key of the CA. (The Conduit CA pod won't
have the Conduit Proxy injected into it either.)

This also simplifies & slightly speeds up the building of the
controller images. This is a stepping stone towards being able to
build the controller images without `docker build` to improve build
times.

Signed-off-by: Brian Smith <brian@briansmith.org>