### PR TITLE
Remove redundant `app` labels in control plane.

### DIFF
--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -83,14 +83,13 @@ metadata:
   name: api
   namespace: Namespace
   labels:
-    app: controller
     ControllerComponentLabel: controller
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    app: controller
+    ControllerComponentLabel: controller
   ports:
   - name: http
     port: 8085
@@ -103,14 +102,13 @@ metadata:
   name: proxy-api
   namespace: Namespace
   labels:
-    app: controller
     ControllerComponentLabel: controller
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    app: controller
+    ControllerComponentLabel: controller
   ports:
   - name: grpc
     port: 8086
@@ -125,7 +123,6 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: controller
-    app: controller
   name: controller
   namespace: Namespace
 spec:
@@ -140,7 +137,6 @@ spec:
       creationTimestamp: null
       labels:
         ControllerComponentLabel: controller
-        app: controller
         conduit.io/control-plane-ns: Namespace
     spec:
       containers:
@@ -282,14 +278,13 @@ metadata:
   name: web
   namespace: Namespace
   labels:
-    app: web
     ControllerComponentLabel: web
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    app: web
+    ControllerComponentLabel: web
   ports:
   - name: http
     port: 8084
@@ -307,7 +302,6 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: web
-    app: web
   name: web
   namespace: Namespace
 spec:
@@ -322,7 +316,6 @@ spec:
       creationTimestamp: null
       labels:
         ControllerComponentLabel: web
-        app: web
         conduit.io/control-plane-ns: Namespace
     spec:
       containers:
@@ -405,14 +398,13 @@ metadata:
   name: prometheus
   namespace: Namespace
   labels:
-    app: prometheus
     ControllerComponentLabel: prometheus
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    app: prometheus
+    ControllerComponentLabel: prometheus
   ports:
   - name: http
     port: 9090
@@ -427,7 +419,6 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: prometheus
-    app: prometheus
   name: prometheus
   namespace: Namespace
 spec:
@@ -442,7 +433,6 @@ spec:
       creationTimestamp: null
       labels:
         ControllerComponentLabel: prometheus
-        app: prometheus
         conduit.io/control-plane-ns: Namespace
     spec:
       containers:
@@ -533,7 +523,6 @@ metadata:
   name: prometheus-config
   namespace: Namespace
   labels:
-    app: prometheus
     ControllerComponentLabel: prometheus
   annotations:
     CreatedByAnnotation: CliVersion

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -86,14 +86,13 @@ metadata:
   name: api
   namespace: {{.Namespace}}
   labels:
-    app: controller
     {{.ControllerComponentLabel}}: controller
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    app: controller
+    {{.ControllerComponentLabel}}: controller
   ports:
   - name: http
     port: 8085
@@ -106,14 +105,13 @@ metadata:
   name: proxy-api
   namespace: {{.Namespace}}
   labels:
-    app: controller
     {{.ControllerComponentLabel}}: controller
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    app: controller
+    {{.ControllerComponentLabel}}: controller
   ports:
   - name: grpc
     port: 8086
@@ -126,7 +124,6 @@ metadata:
   name: controller
   namespace: {{.Namespace}}
   labels:
-    app: controller
     {{.ControllerComponentLabel}}: controller
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
@@ -135,7 +132,6 @@ spec:
   template:
     metadata:
       labels:
-        app: controller
         {{.ControllerComponentLabel}}: controller
       annotations:
         {{.CreatedByAnnotation}}: {{.CliVersion}}
@@ -222,14 +218,13 @@ metadata:
   name: web
   namespace: {{.Namespace}}
   labels:
-    app: web
     {{.ControllerComponentLabel}}: web
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    app: web
+    {{.ControllerComponentLabel}}: web
   ports:
   - name: http
     port: 8084
@@ -245,7 +240,6 @@ metadata:
   name: web
   namespace: {{.Namespace}}
   labels:
-    app: web
     {{.ControllerComponentLabel}}: web
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
@@ -254,7 +248,6 @@ spec:
   template:
     metadata:
       labels:
-        app: web
         {{.ControllerComponentLabel}}: web
       annotations:
         {{.CreatedByAnnotation}}: {{.CliVersion}}
@@ -286,14 +279,13 @@ metadata:
   name: prometheus
   namespace: {{.Namespace}}
   labels:
-    app: prometheus
     {{.ControllerComponentLabel}}: prometheus
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    app: prometheus
+    {{.ControllerComponentLabel}}: prometheus
   ports:
   - name: http
     port: 9090
@@ -306,7 +298,6 @@ metadata:
   name: prometheus
   namespace: {{.Namespace}}
   labels:
-    app: prometheus
     {{.ControllerComponentLabel}}: prometheus
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
@@ -315,7 +306,6 @@ spec:
   template:
     metadata:
       labels:
-        app: prometheus
         {{.ControllerComponentLabel}}: prometheus
       annotations:
         {{.CreatedByAnnotation}}: {{.CliVersion}}
@@ -352,7 +342,6 @@ metadata:
   name: prometheus-config
   namespace: {{.Namespace}}
   labels:
-    app: prometheus
     {{.ControllerComponentLabel}}: prometheus
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}


### PR DESCRIPTION
The `app` label should be reserved for end-user applications and we
shouldn't use it ourselves. We already have a Conduit-specific label
we can use instead, so just use that one.

Signed-off-by: Brian Smith <brian@briansmith.org>