### PR TITLE
Add ability to cancel promises via a wrapper

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -41,7 +41,7 @@ export default class Sidebar extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    this.api.fetchPods().then(r => {
+    this.api.fetchPods().promise.then(r => {
       let deploys =  _.map(getPodsByDeployment(r.pods), 'name');
 
       this.setState({

--- a/web/app/js/components/Version.jsx
+++ b/web/app/js/components/Version.jsx
@@ -30,8 +30,8 @@ export default class Version extends React.Component {
     let versionUrl = `https://versioncheck.conduit.io/version.json?version=${this.props.releaseVersion}?uuid=${this.props.uuid}`;
     let versionFetch = ApiHelpers("").fetch(versionUrl);
     // expose serverPromise for testing
-    this.serverPromise = Promise.all([versionFetch])
-      .then(([resp]) => {
+    this.serverPromise = versionFetch.promise
+      .then(resp => {
         this.setState({
           latest: resp.version,
           loaded: true,

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -121,6 +121,20 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
     }
   };
 
+  // maintain a list of a component's requests,
+  // convenient for providing a cancel() functionality
+  let currentRequests = [];
+  const setCurrentRequests = cancelablePromises => {
+    currentRequests = cancelablePromises;
+  };
+  const getCurrentPromises = () => {
+    return _.map(currentRequests, 'promise');
+  };
+  const cancelCurrentRequests = () => {
+    _.each(currentRequests, promise => {
+      promise.cancel();
+    });
+  };
 
   // prefix all links in the app with `pathPrefix`
   const ConduitLink = props => {
@@ -143,6 +157,9 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '10m') => {
     getMetricsWindowDisplayText,
     urlsForResource: urlsForResource,
     ConduitLink,
+    setCurrentRequests,
+    getCurrentPromises,
+    cancelCurrentRequests,
     // DO NOT USE makeCancelable, use fetch, this is only exposed for testing
     makeCancelable
   };


### PR DESCRIPTION
Fixes react setSate warnings when we navigate between components.
Follows advice of https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html

Problem: if a component has initiated a fetch that has not yet completed, and you navigate to another component in the meantime, when the fetch completes, the previous component will try to call a `setState`. However, that component has already been unmounted, which causes a `Warning: Can only update a mounted or mounting component` error.

Solution: wrap the promise, adding a `cancel()` method that will reject the promise

Fixes #242
Fixes #157