### PR TITLE
Skip pods with hostNetwork=true in `conduit inject`

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -172,9 +172,13 @@ func injectDaemonSet(bytes []byte) (interface{}, error) {
 }
 
 /* Given a PodTemplateSpec, return a new PodTemplateSpec with the sidecar
- * and init-container injected.
+ * and init-container injected. If the pod is unsuitable for having them
+ * injected, return null.
  */
 func injectPodTemplateSpec(t *v1.PodTemplateSpec) *enhancedPodTemplateSpec {
+	// Pods with `hostNetwork=true` share a network namespace with the host. The
+	// init-container would destroy the iptables configuration on the host, so
+	// skip the injection in this case.
 	if t.Spec.HostNetwork {
 		return nil
 	}

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -15,6 +15,8 @@ func TestInjectYAML(t *testing.T) {
 		goldenFileName string
 	}{
 		{"inject_emojivoto_deployment.input.yml", "inject_emojivoto_deployment.golden.yml"},
+		{"inject_emojivoto_deployment_hostNetwork_false.input.yml", "inject_emojivoto_deployment_hostNetwork_false.golden.yml"},
+		{"inject_emojivoto_deployment_hostNetwork_true.input.yml", "inject_emojivoto_deployment_hostNetwork_true.golden.yml"},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -3,34 +3,44 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestInjectYAML(t *testing.T) {
-	t.Run("Run successful conduit inject on valid k8s yaml", func(t *testing.T) {
-		file, err := os.Open("testdata/inject_emojivoto_deployment.input.yml")
-		if err != nil {
-			t.Errorf("error opening test file: %v\n", err)
-		}
+	testCases := []struct {
+		inputFileName  string
+		goldenFileName string
+	}{
+		{"inject_emojivoto_deployment.input.yml", "inject_emojivoto_deployment.golden.yml"},
+	}
 
-		read := bufio.NewReader(file)
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d: %s", i, tc.inputFileName), func(t *testing.T) {
+			file, err := os.Open("testdata/" + tc.inputFileName)
+			if err != nil {
+				t.Errorf("error opening test input file: %v\n", err)
+			}
 
-		output := new(bytes.Buffer)
+			read := bufio.NewReader(file)
 
-		err = InjectYAML(read, output)
-		if err != nil {
-			t.Errorf("Unexpected error injecting YAML: %v\n", err)
-		}
+			output := new(bytes.Buffer)
 
-		actualOutput := output.String()
+			err = InjectYAML(read, output)
+			if err != nil {
+				t.Errorf("Unexpected error injecting YAML: %v\n", err)
+			}
 
-		goldenFileBytes, err := ioutil.ReadFile("testdata/inject_emojivoto_deployment.golden.yml")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		expectedOutput := string(goldenFileBytes)
-		diffCompare(t, actualOutput, expectedOutput)
-	})
+			actualOutput := output.String()
+
+			goldenFileBytes, err := ioutil.ReadFile("testdata/" + tc.goldenFileName)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			expectedOutput := string(goldenFileBytes)
+			diffCompare(t, actualOutput, expectedOutput)
+		})
+	}
 }

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        conduit.io/created-by: conduit/cli latest
+        conduit.io/proxy-version: latest
+      creationTimestamp: null
+      labels:
+        app: web-svc
+        conduit.io/control-plane-ns: conduit
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: http
+        resources: {}
+      - env:
+        - name: CONDUIT_PROXY_LOG
+          value: warn,conduit_proxy=info
+        - name: CONDUIT_PROXY_CONTROL_URL
+          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+        - name: CONDUIT_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: CONDUIT_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: CONDUIT_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: CONDUIT_PROXY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CONDUIT_PROXY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CONDUIT_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
+          value: Kubernetes
+        image: gcr.io/runconduit/proxy:latest
+        imagePullPolicy: IfNotPresent
+        name: conduit-proxy
+        ports:
+        - containerPort: 4143
+          name: conduit-proxy
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - "4190"
+        image: gcr.io/runconduit/proxy-init:latest
+        imagePullPolicy: IfNotPresent
+        name: conduit-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.input.yml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: http
+        resources: {}
+      hostNetwork: false
+status: {}

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.golden.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: http
+        resources: {}
+      hostNetwork: true
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.input.yml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: http
+        resources: {}
+      hostNetwork: true
+status: {}


### PR DESCRIPTION
The init container injected by `conduit inject` rewrites the iptables configuration for its network namespace. This causes havoc when the network namespace isn't restricted to the pod, i.e. when `hostNetwork=true`.

Skip pods with `hostNetwork=true` to avoid this problem.

Fixes #366.