### PR TITLE
Refactor `conduit inject` code to eliminate duplicate logic

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -60,36 +60,6 @@ with 'conduit inject'. e.g. curl http://url.to/yml | conduit inject -
 	},
 }
 
-func unmarshalDeployment(bytes []byte) (interface{}, *v1.PodTemplateSpec, error) {
-	var deployment v1beta1.Deployment
-	err := yaml.Unmarshal(bytes, &deployment)
-	return &deployment, &deployment.Spec.Template, err
-}
-
-func unmarshalReplicationController(bytes []byte) (interface{}, *v1.PodTemplateSpec, error) {
-	var rc v1.ReplicationController
-	err := yaml.Unmarshal(bytes, &rc)
-	return &rc, rc.Spec.Template, err
-}
-
-func unmarshalReplicaSet(bytes []byte) (interface{}, *v1.PodTemplateSpec, error) {
-	var rs v1beta1.ReplicaSet
-	err := yaml.Unmarshal(bytes, &rs)
-	return &rs, &rs.Spec.Template, err
-}
-
-func unmarshalJob(bytes []byte) (interface{}, *v1.PodTemplateSpec, error) {
-	var job batchV1.Job
-	err := yaml.Unmarshal(bytes, &job)
-	return &job, &job.Spec.Template, err
-}
-
-func unmarshalDaemonSet(bytes []byte) (interface{}, *v1.PodTemplateSpec, error) {
-	var ds v1beta1.DaemonSet
-	err := yaml.Unmarshal(bytes, &ds)
-	return &ds, &ds.Spec.Template, err
-}
-
 /* Given a PodTemplateSpec, return a new PodTemplateSpec with the sidecar
  * and init-container injected. If the pod is unsuitable for having them
  * injected, return null.
@@ -234,16 +204,32 @@ func InjectYAML(in io.Reader, out io.Writer) error {
 
 		switch meta.Kind {
 		case "Deployment":
-			obj, podTemplateSpec, err = unmarshalDeployment(bytes)
+			var deployment v1beta1.Deployment
+			err = yaml.Unmarshal(bytes, &deployment)
+			obj = &deployment
+			podTemplateSpec = &deployment.Spec.Template
 		case "ReplicationController":
-			obj, podTemplateSpec, err = unmarshalReplicationController(bytes)
+			var rc v1.ReplicationController
+			err = yaml.Unmarshal(bytes, &rc)
+			obj = &rc
+			podTemplateSpec = rc.Spec.Template
 		case "ReplicaSet":
-			obj, podTemplateSpec, err = unmarshalReplicaSet(bytes)
+			var rs v1beta1.ReplicaSet
+			err = yaml.Unmarshal(bytes, &rs)
+			obj = &rs
+			podTemplateSpec = &rs.Spec.Template
 		case "Job":
-			obj, podTemplateSpec, err = unmarshalJob(bytes)
+			var job batchV1.Job
+			err = yaml.Unmarshal(bytes, &job)
+			obj = &job
+			podTemplateSpec = &job.Spec.Template
 		case "DaemonSet":
-			obj, podTemplateSpec, err = unmarshalDaemonSet(bytes)
+			var ds v1beta1.DaemonSet
+			err = yaml.Unmarshal(bytes, &ds)
+			obj = &ds
+			podTemplateSpec = &ds.Spec.Template
 		}
+
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -206,32 +206,43 @@ func InjectYAML(in io.Reader, out io.Writer) error {
 		case "Deployment":
 			var deployment v1beta1.Deployment
 			err = yaml.Unmarshal(bytes, &deployment)
+			if err != nil {
+				return err
+			}
 			obj = &deployment
 			podTemplateSpec = &deployment.Spec.Template
 		case "ReplicationController":
 			var rc v1.ReplicationController
 			err = yaml.Unmarshal(bytes, &rc)
+			if err != nil {
+				return err
+			}
 			obj = &rc
 			podTemplateSpec = rc.Spec.Template
 		case "ReplicaSet":
 			var rs v1beta1.ReplicaSet
 			err = yaml.Unmarshal(bytes, &rs)
+			if err != nil {
+				return err
+			}
 			obj = &rs
 			podTemplateSpec = &rs.Spec.Template
 		case "Job":
 			var job batchV1.Job
 			err = yaml.Unmarshal(bytes, &job)
+			if err != nil {
+				return err
+			}
 			obj = &job
 			podTemplateSpec = &job.Spec.Template
 		case "DaemonSet":
 			var ds v1beta1.DaemonSet
 			err = yaml.Unmarshal(bytes, &ds)
+			if err != nil {
+				return err
+			}
 			obj = &ds
 			podTemplateSpec = &ds.Spec.Template
-		}
-
-		if err != nil {
-			return err
 		}
 
 		// If we don't inject anything into the pod template then output the

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -199,8 +199,8 @@ func InjectYAML(in io.Reader, out io.Writer) error {
 
 		// obj and podTemplateSpec will reference zero or one the following
 		// objects, depending on the type.
-		var obj interface{} = nil
-		var podTemplateSpec *v1.PodTemplateSpec = nil
+		var obj interface{}
+		var podTemplateSpec *v1.PodTemplateSpec
 
 		switch meta.Kind {
 		case "Deployment":


### PR DESCRIPTION
Previously there was a lot of code repeated once for each type of
object that has a pod spec.

Refactor the code to reduce the amount of duplication there, to make future
changes easier.

Signed-off-by: Brian Smith <brian@briansmith.org>