### PR TITLE
Update go-run to set version equal to root-tag

### DIFF
--- a/bin/go-run
+++ b/bin/go-run
@@ -7,6 +7,7 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 
-go build -v -i -race -o .gorun ./"$1"
+ldflags="-X github.com/runconduit/conduit/pkg/version.Version=$(bin/root-tag)"
+go build -v -i -race -o .gorun -ldflags "$ldflags" "./$1"
 shift
 exec ./.gorun "$@"

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestInjectYAML(t *testing.T) {
-	conduitVersion = "latest" // override "undefined"
+	testInjectVersion := "testinjectversion"
 	testCases := []struct {
 		inputFileName  string
 		goldenFileName string
@@ -31,7 +31,7 @@ func TestInjectYAML(t *testing.T) {
 
 			output := new(bytes.Buffer)
 
-			err = InjectYAML(read, output)
+			err = InjectYAML(read, output, testInjectVersion)
 			if err != nil {
 				t.Errorf("Unexpected error injecting YAML: %v\n", err)
 			}
@@ -49,6 +49,7 @@ func TestInjectYAML(t *testing.T) {
 }
 
 func TestRunInjectCmd(t *testing.T) {
+	testInjectVersion := "testinjectversion"
 	testCases := []struct {
 		inputFileName        string
 		stdErrGoldenFileName string
@@ -77,7 +78,7 @@ func TestRunInjectCmd(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			exitCode := runInjectCmd(in, errBuffer, outBuffer)
+			exitCode := runInjectCmd(in, errBuffer, outBuffer, testInjectVersion)
 			if exitCode != tc.exitCode {
 				t.Fatalf("Expected exit code to be %d but got: %d", tc.exitCode, exitCode)
 			}

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestInjectYAML(t *testing.T) {
+	conduitVersion = "latest" // override "undefined"
 	testCases := []struct {
 		inputFileName  string
 		goldenFileName string

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -14,7 +14,7 @@ spec:
     metadata:
       annotations:
         conduit.io/created-by: conduit/cli undefined
-        conduit.io/proxy-version: latest
+        conduit.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
         app: web-svc
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
-        image: gcr.io/runconduit/proxy:latest
+        image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
         ports:
@@ -80,7 +80,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - "4190"
-        image: gcr.io/runconduit/proxy-init:latest
+        image: gcr.io/runconduit/proxy-init:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-init
         resources: {}

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        conduit.io/created-by: conduit/cli latest
+        conduit.io/created-by: conduit/cli undefined
         conduit.io/proxy-version: latest
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        conduit.io/created-by: conduit/cli latest
+        conduit.io/created-by: conduit/cli undefined
         conduit.io/proxy-version: latest
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -14,7 +14,7 @@ spec:
     metadata:
       annotations:
         conduit.io/created-by: conduit/cli undefined
-        conduit.io/proxy-version: latest
+        conduit.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
         app: web-svc
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
-        image: gcr.io/runconduit/proxy:latest
+        image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
         ports:
@@ -81,7 +81,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - "4190"
-        image: gcr.io/runconduit/proxy-init:latest
+        image: gcr.io/runconduit/proxy-init:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-init
         resources: {}

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -8,8 +8,8 @@ spec:
   template:
     metadata:
       annotations:
-        conduit.io/created-by: conduit/cli latest
-        conduit.io/proxy-version: latest
+        conduit.io/created-by: conduit/cli undefined
+        conduit.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
         app: get-test
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
-        image: gcr.io/runconduit/proxy:latest
+        image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
         ports:
@@ -82,7 +82,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - "4190"
-        image: gcr.io/runconduit/proxy-init:latest
+        image: gcr.io/runconduit/proxy-init:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-init
         resources: {}
@@ -103,8 +103,8 @@ spec:
   template:
     metadata:
       annotations:
-        conduit.io/created-by: conduit/cli latest
-        conduit.io/proxy-version: latest
+        conduit.io/created-by: conduit/cli undefined
+        conduit.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
         app: get-test
@@ -158,7 +158,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
-        image: gcr.io/runconduit/proxy:latest
+        image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
         ports:
@@ -177,7 +177,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - "4190"
-        image: gcr.io/runconduit/proxy-init:latest
+        image: gcr.io/runconduit/proxy-init:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-init
         resources: {}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,7 @@ import (
 
 // DO NOT EDIT
 // This var is updated automatically as part of the build process
-var Version = "latest"
+var Version = "undefined"
 
 func VersionFlag() *bool {
 	return flag.Bool("version", false, "print version and exit")


### PR DESCRIPTION
This is a follow up to #208 and #284. Per @pcalcado's suggestion, we're going to return "undefined" for the version number when it's not set via ldflags. As part of this change I'm also updating the `bin/go-run` script to start using ldflags, to set the version based on the output of `bin/root-tag`. It looks like this:

```
$ bin/go-run cli version 2> /dev/null 
Client version: git-9fae374b
Server version: unavailable
```

Fixes #223.