### PR TITLE
Run conduit dashboard on ephemeral port by default

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
 	"github.com/runconduit/conduit/pkg/shell"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +45,10 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		dashboardAvailable, err := isDashboardAvailable(client)
+		if err != nil {
+			log.Debugf("Error checking dashboard availability: %s", err)
+		}
+
 		if err != nil || !dashboardAvailable {
 			fmt.Fprintf(os.Stderr, "Conduit is not running in the \"%s\" namespace\n", controlPlaneNamespace)
 			fmt.Fprintf(os.Stderr, "Install with: conduit install -n %s | kubectl apply -f -\n", controlPlaneNamespace)

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -94,6 +94,6 @@ func init() {
 
 	// This is identical to what `kubectl proxy --help` reports, `--port 0`
 	// indicates a random port.
-	dashboardCmd.PersistentFlags().IntVarP(&dashboardProxyPort, "port", "p", 0, "The port on which to run the proxy. Set to 0 to pick a random port.")
+	dashboardCmd.PersistentFlags().IntVarP(&dashboardProxyPort, "port", "p", 0, "The port on which to run the proxy. When set to 0, a random port will be used.")
 	dashboardCmd.PersistentFlags().BoolVar(&dashboardSkipBrowser, "url", false, "Display the Conduit dashboard URL in the CLI instead of opening it in the default browser")
 }

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -44,12 +44,9 @@ var dashboardCmd = &cobra.Command{
 		}
 
 		dashboardAvailable, err := isDashboardAvailable(client)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed while checking availability of dashboard: %+v\n", err)
-		}
-
-		if !dashboardAvailable {
-			fmt.Fprint(os.Stderr, "Conduit web deployment is not installed in your cluster\n")
+		if err != nil || !dashboardAvailable {
+			fmt.Fprintf(os.Stderr, "Conduit is not running in the \"%s\" namespace\n", controlPlaneNamespace)
+			fmt.Fprintf(os.Stderr, "Install with: conduit install -n %s | kubectl apply -f -\n", controlPlaneNamespace)
 			os.Exit(1)
 		}
 
@@ -97,6 +94,6 @@ func init() {
 
 	// This is identical to what `kubectl proxy --help` reports, `--port 0`
 	// indicates a random port.
-	dashboardCmd.PersistentFlags().IntVarP(&dashboardProxyPort, "port", "p", 8001, "The port on which to run the proxy. Set to 0 to pick a random port.")
+	dashboardCmd.PersistentFlags().IntVarP(&dashboardProxyPort, "port", "p", 0, "The port on which to run the proxy. Set to 0 to pick a random port.")
 	dashboardCmd.PersistentFlags().BoolVar(&dashboardSkipBrowser, "url", false, "Display the Conduit dashboard URL in the CLI instead of opening it in the default browser")
 }


### PR DESCRIPTION
This branch changes the `conduit dashboard`'s default `--port` value to 0, which means that it will start the dashboard on a random ephemeral port.

As part of this change I'm also cleaning up the error message that's printed when conduit is not installed (relates to #289). Previously it would print:

```
$ conduit dashboard -n foo
Failed while checking availability of dashboard: POST to Conduit API endpoint [https://192.168.99.103:8443/api/v1/namespaces/foo/services/http:api:http/proxy/api/v1/SelfCheck] returned HTTP status [404 Not Found]
Conduit web deployment is not installed in your cluster
```

Now it prints:

```
$ conduit dashboard -n foo
Conduit is not running in the "foo" namespace
Install with: conduit install -n foo | kubectl apply -f -
```

Fixes #291.