### PR TITLE
Add some space between the sidebar collapse button and headings

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -58,7 +58,7 @@ h2, h3, h4, h5, h6 {
 .main-content {
   max-width: 970px;
   width: 100%;
-  padding: 32px;
+  padding: 40px;
   float: left;
 }
 


### PR DESCRIPTION
On the Deployment Detail pages, the collapse button is a little too close to the Deployment name, and overlaps. Fix that.

Before
![screen shot 2018-02-19 at 5 32 58 pm](https://user-images.githubusercontent.com/549258/36403697-7db59722-159b-11e8-87d0-9de2eca4399b.png)

After
![screen shot 2018-02-19 at 5 35 19 pm](https://user-images.githubusercontent.com/549258/36403698-7f7cf654-159b-11e8-9d02-6c40a98e18b4.png)


