### PR TITLE
Remove kubectl dependency, validate k8s server version via api

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -26,13 +26,6 @@ problems were found.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		kubectl, err := k8s.NewKubectl(shell.NewUnixShell())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error with kubectl: %s\n", err.Error())
-			statusCheckResultWasError(os.Stdout)
-			os.Exit(2)
-		}
-
 		kubeApi, err := k8s.NewK8sAPI(shell.NewUnixShell().HomeDir(), kubeconfigPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error with Kubernetes API: %s\n", err.Error())
@@ -52,7 +45,7 @@ problems were found.`,
 			os.Exit(2)
 		}
 
-		err = checkStatus(os.Stdout, kubectl, kubeApi, healthcheck.NewGrpcStatusChecker(public.ConduitApiSubsystemName, conduitApi))
+		err = checkStatus(os.Stdout, kubeApi, healthcheck.NewGrpcStatusChecker(public.ConduitApiSubsystemName, conduitApi))
 		if err != nil {
 			os.Exit(2)
 		}

--- a/cli/cmd/check_test.go
+++ b/cli/cmd/check_test.go
@@ -11,28 +11,6 @@ import (
 
 func TestCheckStatus(t *testing.T) {
 	t.Run("Prints expected output", func(t *testing.T) {
-		kubectl := &k8s.MockKubectl{}
-		kubectl.SelfCheckResultsToReturn = []*healthcheckPb.CheckResult{
-			{
-				SubsystemName:         k8s.KubectlSubsystemName,
-				CheckDescription:      k8s.KubectlConnectivityCheckDescription,
-				Status:                healthcheckPb.CheckStatus_OK,
-				FriendlyMessageToUser: "This shouldnt be printed",
-			},
-			{
-				SubsystemName:         k8s.KubectlSubsystemName,
-				CheckDescription:      k8s.KubectlIsInstalledCheckDescription,
-				Status:                healthcheckPb.CheckStatus_FAIL,
-				FriendlyMessageToUser: "This should contain instructions for fail",
-			},
-			{
-				SubsystemName:         k8s.KubectlSubsystemName,
-				CheckDescription:      k8s.KubectlVersionCheckDescription,
-				Status:                healthcheckPb.CheckStatus_ERROR,
-				FriendlyMessageToUser: "This should contain instructions for err",
-			},
-		}
-
 		kubeApi := &k8s.MockKubeApi{}
 		kubeApi.SelfCheckResultsToReturn = []*healthcheckPb.CheckResult{
 			{
@@ -45,12 +23,18 @@ func TestCheckStatus(t *testing.T) {
 				SubsystemName:         k8s.KubeapiSubsystemName,
 				CheckDescription:      k8s.KubeapiAccessCheckDescription,
 				Status:                healthcheckPb.CheckStatus_OK,
-				FriendlyMessageToUser: "This shouldnt be printed",
+				FriendlyMessageToUser: "This shouldn't be printed",
+			},
+			{
+				SubsystemName:         k8s.KubeapiSubsystemName,
+				CheckDescription:      k8s.KubeapiVersionCheckDescription,
+				Status:                healthcheckPb.CheckStatus_ERROR,
+				FriendlyMessageToUser: "This should contain instructions for err",
 			},
 		}
 
 		output := bytes.NewBufferString("")
-		checkStatus(output, kubectl, kubeApi)
+		checkStatus(output, kubeApi)
 
 		goldenFileBytes, err := ioutil.ReadFile("testdata/status_busy_output.golden")
 		if err != nil {

--- a/cli/cmd/testdata/status_busy_output.golden
+++ b/cli/cmd/testdata/status_busy_output.golden
@@ -1,7 +1,5 @@
-kubectl: can talk to Kubernetes cluster.........................................[ok]
-kubectl: is in $PATH............................................................[FAIL]  -- This should contain instructions for fail
-kubectl: has compatible version.................................................[ERROR] -- This should contain instructions for err
 kubernetes-api: can initialize the client.......................................[FAIL]  -- This should contain instructions for fail
 kubernetes-api: can query the Kubernetes API....................................[ok]
+kubernetes-api: is running the minimum Kubernetes API version...................[ERROR] -- This should contain instructions for err
 
 Status check results are [ERROR]

--- a/pkg/healthcheck/grpc.go
+++ b/pkg/healthcheck/grpc.go
@@ -21,7 +21,7 @@ func (proxy *statusCheckerProxy) SelfCheck() []*healthcheckPb.CheckResult {
 	canConnectViaGrpcCheck := &healthcheckPb.CheckResult{
 		Status:           healthcheckPb.CheckStatus_OK,
 		SubsystemName:    proxy.prefix,
-		CheckDescription: "can retrieve status via gRPC",
+		CheckDescription: "can query the Conduit API",
 	}
 
 	selfCheckResponse, err := proxy.delegate.SelfCheck(context.Background(), &healthcheckPb.SelfCheckRequest{})

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	kubernetesConfigFilePathEnvVariable = "KUBECONFIG"
+	KubernetesDeployments               = "deployments"
+	KubernetesPods                      = "pods"
 )
 
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
@@ -63,4 +65,17 @@ func buildK8sConfig(homedir string, k8sConfigFilesystemPathOverride string) (*re
 	kubeconfigEnvVar := os.Getenv(kubernetesConfigFilePathEnvVariable)
 
 	return parseK8SConfig(findK8sConfigFile(k8sConfigFilesystemPathOverride, kubeconfigEnvVar, homedir))
+}
+
+//CanonicalKubernetesNameFromFriendlyName returns a canonical name from common shorthands used in command line tools.
+// This works based on https://github.com/kubernetes/kubernetes/blob/63ffb1995b292be0a1e9ebde6216b83fc79dd988/pkg/kubectl/kubectl.go#L39
+func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error) {
+	switch friendlyName {
+	case "deploy", "deployment", "deployments":
+		return KubernetesDeployments, nil
+	case "po", "pod", "pods":
+		return KubernetesPods, nil
+	}
+
+	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)
 }

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -110,3 +110,38 @@ func TestFindK8sConfigFile(t *testing.T) {
 		}
 	})
 }
+
+func TestCanonicalKubernetesNameFromFriendlyName(t *testing.T) {
+	t.Run("Returns canonical name for all known variants", func(t *testing.T) {
+		expectations := map[string]string{
+			"po":          KubernetesPods,
+			"pod":         KubernetesPods,
+			"deployment":  KubernetesDeployments,
+			"deployments": KubernetesDeployments,
+		}
+
+		for input, expectedName := range expectations {
+			actualName, err := CanonicalKubernetesNameFromFriendlyName(input)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if actualName != expectedName {
+				t.Fatalf("Expected friendly name [%s] to resolve to [%s], but got [%s]", input, expectedName, actualName)
+			}
+		}
+	})
+
+	t.Run("Returns error if input isn't a supported name", func(t *testing.T) {
+		unsupportedNames := []string{
+			"pdo", "dop", "paths", "path", "", "mesh",
+		}
+
+		for _, n := range unsupportedNames {
+			out, err := CanonicalKubernetesNameFromFriendlyName(n)
+			if err == nil {
+				t.Fatalf("Expecting error when resolving [%s], but it did resolve to [%s]", n, out)
+			}
+		}
+	})
+}

--- a/pkg/k8s/kubectl.go
+++ b/pkg/k8s/kubectl.go
@@ -2,55 +2,27 @@ package k8s
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
-
-	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
-	"github.com/runconduit/conduit/pkg/healthcheck"
-	"github.com/runconduit/conduit/pkg/shell"
 )
 
-type Kubectl interface {
-	Version() ([3]int, error)
-	healthcheck.StatusChecker
-}
+var revisionSeparator = regexp.MustCompile("[^0-9.]")
 
-type kubectl struct {
-	sh shell.Shell
-}
-
-const (
-	KubernetesDeployments               = "deployments"
-	KubernetesPods                      = "pods"
-	KubectlSubsystemName                = "kubectl"
-	KubectlIsInstalledCheckDescription  = "is in $PATH"
-	KubectlVersionCheckDescription      = "has compatible version"
-	KubectlConnectivityCheckDescription = "can talk to Kubernetes cluster"
-	//As per https://github.com/kubernetes/kubernetes/commit/0daee3ad2238de7bb356d1b4368b0733a3497a3a#diff-595bfea7ed0dd0171e1f339a1f8bfcb6R155
-)
-
-var minimumKubectlVersionExpected = [3]int{1, 8, 0}
-
-func (kctl *kubectl) Version() ([3]int, error) {
+func getK8sVersion(versionString string) ([3]int, error) {
 	var version [3]int
-	bytes, err := kctl.sh.CombinedOutput("kubectl", "version", "--client", "--short")
-	versionString := string(bytes)
-	if err != nil {
-		return version, fmt.Errorf("error running kubectl Version. Output: %s Error: %v", versionString, err)
-	}
-
-	justTheVersionString := strings.TrimPrefix(versionString, "Client Version: v")
-	justTheMajorMinorRevisionNumbers := strings.Split(justTheVersionString, "-")[0]
+	justTheVersionString := strings.TrimPrefix(versionString, "v")
+	justTheMajorMinorRevisionNumbers := revisionSeparator.Split(justTheVersionString, -1)[0]
 	split := strings.Split(justTheMajorMinorRevisionNumbers, ".")
 
 	if len(split) < 3 {
-		return version, fmt.Errorf("unknown Version string format from Kubectl: [%s] not enough segments: %s", versionString, split)
+		return version, fmt.Errorf("unknown version string format [%s]", versionString)
 	}
 
 	for i, segment := range split {
 		v, err := strconv.Atoi(strings.TrimSpace(segment))
 		if err != nil {
-			return version, fmt.Errorf("unknown Version string format from Kubectl: [%s], not an integer: [%s]", versionString, segment)
+			return version, fmt.Errorf("unknown version string format [%s]", versionString)
 		}
 		version[i] = v
 	}
@@ -58,80 +30,12 @@ func (kctl *kubectl) Version() ([3]int, error) {
 	return version, nil
 }
 
-func (kctl *kubectl) SelfCheck() []*healthcheckPb.CheckResult {
-	return []*healthcheckPb.CheckResult{
-		kctl.checkKubectlOnPath(),
-		kctl.checkKubectlVersion(),
-		kctl.checkKubectlApiAccess(),
-	}
-}
-
-func (kctl *kubectl) checkKubectlOnPath() *healthcheckPb.CheckResult {
-	checkResult := &healthcheckPb.CheckResult{
-		Status:           healthcheckPb.CheckStatus_OK,
-		SubsystemName:    KubectlSubsystemName,
-		CheckDescription: KubectlIsInstalledCheckDescription,
-	}
-
-	_, err := kctl.sh.CombinedOutput("kubectl", "config")
-	if err != nil {
-		checkResult.Status = healthcheckPb.CheckStatus_ERROR
-		checkResult.FriendlyMessageToUser = fmt.Sprintf("Could not run the command `kubectl`. The error message is: [%s] and the current $PATH is: %s", err.Error(), kctl.sh.Path())
-		return checkResult
-	}
-
-	return checkResult
-}
-
-func (kctl *kubectl) checkKubectlVersion() *healthcheckPb.CheckResult {
-	checkResult := &healthcheckPb.CheckResult{
-		Status:           healthcheckPb.CheckStatus_OK,
-		SubsystemName:    KubectlSubsystemName,
-		CheckDescription: KubectlVersionCheckDescription,
-	}
-
-	actualVersion, err := kctl.Version()
-	if err != nil {
-		checkResult.Status = healthcheckPb.CheckStatus_ERROR
-		checkResult.FriendlyMessageToUser = fmt.Sprintf("Error getting version from kubectl. The error message is: [%s].", err.Error())
-		return checkResult
-	}
-
-	if !isCompatibleVersion(minimumKubectlVersionExpected, actualVersion) {
-		checkResult.Status = healthcheckPb.CheckStatus_FAIL
-		checkResult.FriendlyMessageToUser = fmt.Sprintf("Kubectl is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required.",
-			actualVersion[0], actualVersion[1], actualVersion[2],
-			minimumKubectlVersionExpected[0], minimumKubectlVersionExpected[1], minimumKubectlVersionExpected[2])
-		return checkResult
-	}
-
-	return checkResult
-}
-
-func (kctl *kubectl) checkKubectlApiAccess() *healthcheckPb.CheckResult {
-	kubectlApiAccessCheck := &healthcheckPb.CheckResult{
-		Status:           healthcheckPb.CheckStatus_OK,
-		SubsystemName:    KubectlSubsystemName,
-		CheckDescription: KubectlConnectivityCheckDescription,
-	}
-
-	output, err := kctl.sh.CombinedOutput("kubectl", "get", "pods")
-	if err != nil {
-		kubectlApiAccessCheck.Status = healthcheckPb.CheckStatus_FAIL
-		kubectlApiAccessCheck.FriendlyMessageToUser = output
-		return kubectlApiAccessCheck
-	}
-
-	kubectlApiAccessCheck.Status = healthcheckPb.CheckStatus_OK
-	return kubectlApiAccessCheck
-}
-
 func isCompatibleVersion(minimalRequirementVersion [3]int, actualVersion [3]int) bool {
 	if minimalRequirementVersion[0] < actualVersion[0] {
 		return true
 	}
 
-	if (minimalRequirementVersion[0] == actualVersion[0]) && minimalRequirementVersion[1] <= actualVersion[1] {
+	if (minimalRequirementVersion[0] == actualVersion[0]) && minimalRequirementVersion[1] < actualVersion[1] {
 		return true
 	}
 
@@ -140,40 +44,4 @@ func isCompatibleVersion(minimalRequirementVersion [3]int, actualVersion [3]int)
 	}
 
 	return false
-}
-
-//CanonicalKubernetesNameFromFriendlyName returns a canonical name from common shorthands used in command line tools.
-// This works based on https://github.com/kubernetes/kubernetes/blob/63ffb1995b292be0a1e9ebde6216b83fc79dd988/pkg/kubectl/kubectl.go#L39
-func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error) {
-	switch friendlyName {
-	case "deploy", "deployment", "deployments":
-		return KubernetesDeployments, nil
-	case "po", "pod", "pods":
-		return KubernetesPods, nil
-	}
-
-	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)
-}
-
-func NewKubectl(shell shell.Shell) (Kubectl, error) {
-
-	kubectl := &kubectl{
-		sh: shell,
-	}
-
-	actualVersion, err := kubectl.Version()
-
-	if err != nil {
-		return nil, err
-	}
-
-	if !isCompatibleVersion(minimumKubectlVersionExpected, actualVersion) {
-		return nil, fmt.Errorf(
-			"kubectl is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required",
-			actualVersion[0], actualVersion[1], actualVersion[2],
-			minimumKubectlVersionExpected[0], minimumKubectlVersionExpected[1], minimumKubectlVersionExpected[2])
-	}
-
-	return kubectl, nil
-
 }

--- a/pkg/k8s/kubectl_test.go
+++ b/pkg/k8s/kubectl_test.go
@@ -1,33 +1,21 @@
 package k8s
 
 import (
-	"io/ioutil"
 	"testing"
-
-	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
-	"github.com/runconduit/conduit/pkg/healthcheck"
-	"github.com/runconduit/conduit/pkg/shell"
 )
 
-func TestKubectlVersion(t *testing.T) {
+func TestGetK8sVersion(t *testing.T) {
 	t.Run("Correctly parses a Version string", func(t *testing.T) {
 		versions := map[string][3]int{
-			"Client Version: v1.8.4":        {1, 8, 4},
-			"Client Version: v2.7.1":        {2, 7, 1},
-			"Client Version: v2.0.1":        {2, 0, 1},
-			"Client Version: v1.9.0-beta.2": {1, 9, 0},
+			"v1.8.4":               {1, 8, 4},
+			"v2.7.1":               {2, 7, 1},
+			"v2.0.1":               {2, 0, 1},
+			"v1.9.0-beta.2":        {1, 9, 0},
+			"v1.7.9+7f63532e4ff4f": {1, 7, 9},
 		}
 
-		shell := &shell.MockShell{}
 		for k, expectedVersion := range versions {
-			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			kctl, err := NewKubectl(shell)
-			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			actualVersion, err := kctl.Version()
-
+			actualVersion, err := getK8sVersion(k)
 			if err != nil {
 				t.Fatalf("Error parsing string: %v", err)
 			}
@@ -41,19 +29,19 @@ func TestKubectlVersion(t *testing.T) {
 	t.Run("Returns error if Version string looks broken", func(t *testing.T) {
 		versions := []string{
 			"",
-			"Client Version: 1.8.4",
-			"Client Version: 1.8.",
-			"Client Version",
-			"Client Version: Version.Info{Major:\"1\", Minor:\"8\", GitVersion:\"v1.8.4\", GitCommit:\"9befc2b8928a9426501d3bf62f72849d5cbcd5a3\", GitTreeState:\"clean\", BuildDate:\"2017-11-20T05:28:34Z\", GoVersion:\"go1.8.3\", Compiler:\"gc\", Platform:\"darwin/amd64\"}",
+			"1",
+			"1.8.",
+			"1.9-beta.2",
+			"v1.7+7f63532e4ff4f",
+			"Client Version: v1.8.4",
+			"Version.Info{Major:\"1\", Minor:\"8\", GitVersion:\"v1.8.4\", GitCommit:\"9befc2b8928a9426501d3bf62f72849d5cbcd5a3\", GitTreeState:\"clean\", BuildDate:\"2017-11-20T05:28:34Z\", GoVersion:\"go1.8.3\", Compiler:\"gc\", Platform:\"darwin/amd64\"}",
 		}
 
-		shell := &shell.MockShell{}
-		for _, expectedVersion := range versions {
-			shell.OutputToReturn = append(shell.OutputToReturn, expectedVersion)
-			_, err := NewKubectl(shell)
+		for _, invalidVersion := range versions {
+			_, err := getK8sVersion(invalidVersion)
 
 			if err == nil {
-				t.Fatalf("Expected error parsing string: %s", expectedVersion)
+				t.Fatalf("Expected error parsing string: %s", invalidVersion)
 			}
 		}
 	})
@@ -63,6 +51,7 @@ func TestIsCompatibleVersion(t *testing.T) {
 	t.Run("Success when compatible versions", func(t *testing.T) {
 		compatibleVersions := map[[3]int][3]int{
 			{1, 8, 4}: {1, 8, 4},
+			{1, 9, 0}: {1, 9, 2},
 			{1, 1, 1}: {1, 1, 1},
 			{1, 1, 1}: {2, 1, 2},
 			{1, 1, 1}: {1, 2, 1},
@@ -80,6 +69,7 @@ func TestIsCompatibleVersion(t *testing.T) {
 	t.Run("Fail when incompatible versions", func(t *testing.T) {
 		inCompatibleVersions := map[[3]int][3]int{
 			{1, 8, 4}:    {1, 7, 1},
+			{1, 9, 2}:    {1, 9, 0},
 			{10, 10, 10}: {9, 10, 10},
 			{10, 10, 10}: {10, 9, 10},
 			{10, 10, 10}: {10, 10, 9},
@@ -91,148 +81,4 @@ func TestIsCompatibleVersion(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestKubectlSelfCheck(t *testing.T) {
-	t.Run("Returns success when no problems found", func(t *testing.T) {
-		shell := &shell.MockShell{}
-		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		var kubectlAsStatusChecker healthcheck.StatusChecker
-		kubectlAsStatusChecker, _ = NewKubectl(shell)
-
-		output, err := ioutil.ReadFile("testdata/kubectl_config.output")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		shell.OutputToReturn = append(shell.OutputToReturn, string(output))
-
-		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-
-		output, err = ioutil.ReadFile("testdata/kubectl_cluster-info.output")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		shell.OutputToReturn = append(shell.OutputToReturn, string(output))
-
-		results := kubectlAsStatusChecker.SelfCheck()
-
-		expectedNumChecks := 3
-		actualNumChecks := len(results)
-		if actualNumChecks != expectedNumChecks {
-			t.Fatalf("Expecting [%d] checks, got [%d]", expectedNumChecks, actualNumChecks)
-		}
-
-		checkResult(t, results[0], KubectlIsInstalledCheckDescription, healthcheckPb.CheckStatus_OK)
-		checkResult(t, results[1], KubectlVersionCheckDescription, healthcheckPb.CheckStatus_OK)
-		checkResult(t, results[2], KubectlConnectivityCheckDescription, healthcheckPb.CheckStatus_OK)
-	})
-
-	t.Run("Returns failures when problems were found", func(t *testing.T) {
-		shell := &shell.MockShell{}
-		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v1.8.4")
-		var kubectlAsStatusChecker healthcheck.StatusChecker
-		kubectlAsStatusChecker, _ = NewKubectl(shell)
-
-		output, err := ioutil.ReadFile("testdata/kubectl_config.output")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		shell.OutputToReturn = append(shell.OutputToReturn, string(output))
-
-		shell.OutputToReturn = append(shell.OutputToReturn, "Client Version: v0.0.0")
-
-		output, err = ioutil.ReadFile("testdata/kubectl_cluster-info.output")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		shell.OutputToReturn = append(shell.OutputToReturn, string(output))
-
-		results := kubectlAsStatusChecker.SelfCheck()
-
-		expectedNumChecks := 3
-		actualNumChecks := len(results)
-		if actualNumChecks != expectedNumChecks {
-			t.Fatalf("Expecting [%d] checks, got [%d]", expectedNumChecks, actualNumChecks)
-		}
-		checkResult(t, results[0], KubectlIsInstalledCheckDescription, healthcheckPb.CheckStatus_OK)
-		checkResult(t, results[1], KubectlVersionCheckDescription, healthcheckPb.CheckStatus_FAIL)
-		checkResult(t, results[2], KubectlConnectivityCheckDescription, healthcheckPb.CheckStatus_OK)
-	})
-}
-
-func TestNewKubectl(t *testing.T) {
-	t.Run("Starts when kubectl is at compatible version", func(t *testing.T) {
-		versions := map[string][3]int{
-			"Client Version: v1.8.4":        {1, 8, 4},
-			"Client Version: v1.9.0-beta.2": {1, 9, 0},
-		}
-
-		shell := &shell.MockShell{}
-		for k, v := range versions {
-			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			_, err := NewKubectl(shell)
-
-			if err != nil {
-				t.Fatalf("Unexpected error when kubectl is at version [%v]: %v", v, err)
-			}
-		}
-	})
-
-	t.Run("Doesnt start when kubectl is at incompatible version", func(t *testing.T) {
-		versions := map[string][3]int{
-			"Client Version: v1.7.1": {1, 7, 1},
-			"Client Version: v0.0.1": {0, 0, 1},
-		}
-
-		shell := &shell.MockShell{}
-		for k, v := range versions {
-			shell.OutputToReturn = append(shell.OutputToReturn, k)
-			_, err := NewKubectl(shell)
-
-			if err == nil {
-				t.Fatalf("Expecting error when starting with incompatible version [%v] but got nothing", v)
-			}
-		}
-	})
-}
-
-func TestCanonicalKubernetesNameFromFriendlyName(t *testing.T) {
-	t.Run("Returns canonical name for all known variants", func(t *testing.T) {
-		expectations := map[string]string{
-			"po":          KubernetesPods,
-			"pod":         KubernetesPods,
-			"deployment":  KubernetesDeployments,
-			"deployments": KubernetesDeployments,
-		}
-
-		for input, expectedName := range expectations {
-			actualName, err := CanonicalKubernetesNameFromFriendlyName(input)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if actualName != expectedName {
-				t.Fatalf("Expected friendly name [%s] to resolve to [%s], but got [%s]", input, expectedName, actualName)
-			}
-		}
-	})
-
-	t.Run("Returns error if inout isn't a supported name", func(t *testing.T) {
-		unsupportedNames := []string{
-			"pdo", "dop", "paths", "path", "", "mesh",
-		}
-
-		for _, n := range unsupportedNames {
-			out, err := CanonicalKubernetesNameFromFriendlyName(n)
-			if err == nil {
-				t.Fatalf("Expecting error when resolving [%s], but it did resolkve to [%s]", n, out)
-			}
-		}
-	})
-}
-
-func checkResult(t *testing.T, actualResult *healthcheckPb.CheckResult, expectedDescription string, expectedStatus healthcheckPb.CheckStatus) {
-	if actualResult.SubsystemName != KubectlSubsystemName || actualResult.CheckDescription != expectedDescription || actualResult.Status != expectedStatus {
-		t.Fatalf("Expecting results to have subsytem [%s], description [%s] and status [%s], but got: %v", KubectlSubsystemName, expectedDescription, expectedStatus, actualResult)
-	}
 }


### PR DESCRIPTION
In this branch I'm removing the `k8s.Kubectl` interface, which was only used to check the `kubectl` client version. I've instead added a Kubernetes server version check as part of `k8s.KubernetesApi` interface.

As part of this changed I've also fixed two issues regarding version checking:

* "v1.7.9+7f63532e4ff4f" is now considered to be a valid version (#346)
* The bugfix version number is now used to determine compatibility when the major and minor version numbers are identical.
  * Previously, given a minimum version of "1.9.2", the code considered "1.9.0" to be compatible.

Before this merges I am going to:

```
git mv pkg/k8s/kubectl.go pkg/k8s/version_test.go
git mv pkg/k8s/kubectl_test.go pkg/k8s/version_test.go
```

But that creates a really noisy diff, so I wanted to submit for review without renaming first.

Fixes #286. Fixes #346.