### PR TITLE
Remove uses of upstream/downstream from web UI

### DIFF
--- a/web/app/js/components/ResourceHealthOverview.jsx
+++ b/web/app/js/components/ResourceHealthOverview.jsx
@@ -65,7 +65,6 @@ export default class ResourceHealthOverview extends React.Component {
 
     return (
       <div key="entity-heath" className="entity-health">
-        <div className="subsection-header">Upstream/Downstream Traffic</div>
         <Row>
           <Col span={8}>
             { stats.inbound.numDeploys === 0 ? null :

--- a/web/app/js/components/UpstreamDownstream.jsx
+++ b/web/app/js/components/UpstreamDownstream.jsx
@@ -15,7 +15,7 @@ export default class UpstreamDownstreamTables extends React.Component {
             numUpstreams === 0 ? null :
               <div className="upstream-downstream-list">
                 <div className="border-container border-neutral subsection-header">
-                  <div className="border-container-content subsection-header">Upstreams</div>
+                  <div className="border-container-content subsection-header">Inbound</div>
                 </div>
                 <MetricsTable
                   resource={`upstream_${this.props.resourceType}`}
@@ -28,7 +28,7 @@ export default class UpstreamDownstreamTables extends React.Component {
             numDownstreams === 0 ? null :
               <div className="upstream-downstream-list">
                 <div className="border-container border-neutral subsection-header">
-                  <div className="border-container-content subsection-header">Downstreams</div>
+                  <div className="border-container-content subsection-header">Outbound</div>
                 </div>
                 <MetricsTable
                   resource={`downstream_${this.props.resourceType}`}


### PR DESCRIPTION
To prevent confusion, I'm removing the last few places where we use upstream/downstream in the web UI, and switching to inbound/outbound throughout. It looks like this:

![screen shot 2018-02-20 at 4 36 28 pm](https://user-images.githubusercontent.com/9226/36456967-89c9cbfc-165c-11e8-8054-e82ec061d79c.png)

Note that I'm not renaming any of the non-visible components or css classes as part of this change, even though the use upstream and downstream heavily. If we're really sold on the new labels we can go back and rename everything to match in a follow-up commit.