### PR TITLE
Improve get/stat/tap help text by way of examples

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -11,12 +11,13 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:   "get [flags] RESOURCE",
+	Use:   "get [flags] pods",
 	Short: "Display one or many mesh resources",
 	Long: `Display one or many mesh resources.
 
-Valid resource types include:
- * pods (aka pod, po)`,
+Only pod resources (aka pods, po) are supported.`,
+	Example: `  # get all pods
+  conduit get pods`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please specify a resource type")

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -21,14 +21,18 @@ var target string
 var timeWindow string
 
 var statCmd = &cobra.Command{
-	Use:   "stat [flags] RESOURCE [TARGET]",
+	Use:   "stat [flags] deployment [TARGET]",
 	Short: "Display runtime statistics about mesh resources",
 	Long: `Display runtime statistics about mesh resources.
 
-Valid resource types include:
- * deployments (aka deployment, deploy)
+Only deployment resources (aka deployments, deploy) are supported.
 
-The optional [TARGET] option can be a name for a deployment.`,
+The optional [TARGET] argument can be used to target a specific deployment.`,
+	Example: `  # get stats for all deployments
+  conduit stat deployments
+
+  # get stats for the web deployment in the default namespace
+  conduit stat deploy default/web`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var friendlyNameForResourceType string
 
@@ -39,7 +43,7 @@ The optional [TARGET] option can be a name for a deployment.`,
 			friendlyNameForResourceType = args[0]
 			target = args[1]
 		default:
-			return errors.New("please specify a resource type: deployments")
+			return errors.New("please specify a resource type")
 		}
 
 		validatedResourceType, err := k8s.CanonicalKubernetesNameFromFriendlyName(friendlyNameForResourceType)

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -35,9 +35,15 @@ var tapCmd = &cobra.Command{
 	Short: "Listen to a traffic stream",
 	Long: `Listen to a traffic stream.
 
-Valid targets include:
- * Pods (default/hello-world-h4fb2)
- * Deployments (default/hello-world)`,
+Only deployment resources (aka deployments, deploy) and pod resources
+(aka pods, po) are supported.
+
+The TARGET argument is used to specify the pod or deployment to tap.`,
+	Example: `  # tap the web deployment in the default namespace
+  conduit tap deploy default/web
+
+  # tap the web-dlbvj pod in the default namespace
+  conduit tap pod default/web-dlbvj`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
 			return errors.New("please specify a resource type and target")


### PR DESCRIPTION
The CLI get/stat/tap commands require command line arguments, but the help text for how specify those arguments varies. In this branch I'm standardizing, and adding examples of proper usage.

The get command on master outputs:

```
$ conduit get
Error: please specify a resource type
Usage:
  conduit get [flags] RESOURCE

Flags:
```

Whereas with this branch:

```
$ conduit get
Error: please specify a resource type
Usage:
  conduit get [flags] pods

Examples:
  # get all pods
  conduit get pods

Flags:
```

---

The stat command on master outputs:

```
$ conduit stat
Error: please specify a resource type: deployments
Usage:
  conduit stat [flags] RESOURCE [TARGET]

Flags:
```

Whereas with this branch:

```
$ conduit stat
Error: please specify a resource type
Usage:
  conduit stat [flags] deployment [TARGET]

Examples:
  # get stats for all deployments
  conduit stat deployments

  # get stats for the web deployment in the default namespace
  conduit stat deploy default/web

Flags:
```

---

The tap command on master outputs:

```
$ conduit tap
Error: please specify a resource type and target
Usage:
  conduit tap [flags] (deployment|pod) TARGET

Flags:
```

Whereas with this branch:

```
$ conduit tap
Error: please specify a resource type and target
Usage:
  conduit tap [flags] (deployment|pod) TARGET

Examples:
  # tap the web deployment in the default namespace
  conduit tap deploy default/web

  # tap the web-dlbvj pod in the default namespace
  conduit tap pod default/web-dlbvj

Flags:
```