### PR TITLE
Remove temporary files generated by dep in go-deps image.

### DIFF
--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -7,26 +7,32 @@
 
 FROM golang:1.9.4
 ENV TEMP_GOPATH=/temp-gopath
-ENV GOPATH=${TEMP_GOPATH}
-WORKDIR $GOPATH/src/github.com/runconduit/conduit
+WORKDIR ${TEMP_GOPATH}/src/github.com/runconduit/conduit
 
 # Download `dep` without being sensitive to changes to Gopkg.{toml,lock}.
 COPY bin/dep bin/dep
-RUN bin/dep version
+RUN GOPATH=${TEMP_GOPATH} bin/dep version
 
-# Vendor the Go dependencies.
+# Vendor the Go dependencies. `dep ensure` caches the entire Git repo for
+# every dependency in `${TEMP_GOPATH}/pkg/dep` so it is important to remove it.
+# `go install` below cannot find the packages under vendor/ so move them to
+# /go/pkg. This is all done in a single RUN to avoid creating a giant
+# intermediate layer.
 COPY Gopkg.toml Gopkg.lock ./
-RUN bin/dep ensure -vendor-only -v
+RUN \
+  GOPATH=${TEMP_GOPATH} bin/dep ensure -vendor-only -v && \
+  mv vendor/* /go/src/ && \
+  rm -rf ${TEMP_GOPATH}
 
-# Move the dependencies to where `go install` can see them.
-ENV GOPATH=/go
-RUN mv vendor/* $GOPATH/src/
+# The previous WORKDIR was deleted. Reset it to avoid any potential for
+# strangeness later.
+WORKDIR /
 
 # Precompile key slow-to-build dependencies. This list doesn't need to be
 # complete for the build to work correctly; the completeness of this list
 # only affects the speed of incremental rebuilds of Dependent Dockerfiles.
 #
-# This list was derived from the output of `find $GOPATH/pkg -type f`
+# This list was derived from the output of `find /go/pkg -type f`
 # after building the controller.
 RUN CGO_ENABLED=0 GOOS=linux go install -installsuffix cgo \
     github.com/golang/protobuf/jsonpb \
@@ -92,5 +98,3 @@ RUN CGO_ENABLED=0 GOOS=linux go install -installsuffix cgo \
     k8s.io/client-go/util/jsonpath \
     k8s.io/kubernetes/pkg/kubectl/proxy \
     k8s.io/kubernetes/pkg/kubectl/util
-
-RUN mv ${TEMP_GOPATH}/src/github.com/runconduit $GOPATH/src/github.com/runconduit

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:1fc8d578 as golang
+FROM gcr.io/runconduit/go-deps:41834c3f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:1fc8d578 as golang
+FROM gcr.io/runconduit/go-deps:41834c3f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:1fc8d578 as golang
+FROM gcr.io/runconduit/go-deps:41834c3f as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:1fc8d578 as golang
+FROM gcr.io/runconduit/go-deps:41834c3f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Previously Dockerfile-go-deps was converted from a multi-stage Dockefile
to a single-stage Dockerfile in anticipation of enabling efficient use
of `--cache-from` in CI. However, that resulted in the image ballooning
in size because it contained the Git repo for every package downloaded
by `dep ensure`.

Bring the image back down to the proper size by removing the temporary
files created.

Signed-off-by: Brian Smith <brian@briansmith.org>