### PR TITLE
Make build scripts location-agnostic

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -189,13 +189,13 @@ build/run/debug loop faster.
 In general, replace commands like this:
 
 ```bash
-go run web/main.go
+go run cli/main.go
 ```
 
 with this:
 
 ```bash
-bin/go-run web
+bin/go-run cli
 ```
 
 You may also leverage `go-run` to execute our `conduit` cli command. While in a
@@ -234,8 +234,8 @@ yarn
 ```bash
 cd web/app
 yarn && yarn webpack
-cd ../..
-bin/go-run web
+cd ..
+../bin/go-run .
 ```
 
 The web server will be running on `localhost:8084`.
@@ -256,7 +256,8 @@ address of the public API server that's running in your docker environment:
 
 ```bash
 docker-compose stop web
-bin/go-run web --api-addr=$DOCKER_IP:8085
+cd web
+../bin/go-run . --api-addr=$DOCKER_IP:8085
 ```
 
 #### 3. Connect to `public-api` in Kubernetes
@@ -272,7 +273,8 @@ kubectl -n conduit port-forward $POD_NAME 8085:8085
 Then connect the local web process to the forwarded port:
 
 ```bash
-bin/go-run web --api-addr=localhost:8085
+cd web
+../bin/go-run . --api-addr=localhost:8085
 ```
 
 ### Webpack dev server
@@ -287,7 +289,8 @@ yarn webpack-dev-server
 And then set the `--webpack-dev-server` flag when running the web server:
 
 ```bash
-bin/go-run web --webpack-dev-server=http://localhost:8080
+cd web
+../bin/go-run . --webpack-dev-server=http://localhost:8080
 ```
 
 To add a JS dependency:
@@ -368,6 +371,7 @@ cargo check
 If you make Protobuf changes, run:
 
 ```bash
+bin/dep ensure
 bin/protoc-go.sh
 ```
 
@@ -410,6 +414,8 @@ build_architecture
     "_log.sh";
     "_tag.sh";
 
+    "dep";
+
     "docker-build" -> "docker-build-controller";
     "docker-build" -> "docker-build-web";
     "docker-build" -> "docker-build-proxy";
@@ -442,7 +448,6 @@ build_architecture
 
     "docker-build-proxy" -> "_docker.sh";
     "docker-build-proxy" -> "_tag.sh";
-    "docker-build-proxy" -> "docker-build-base";
     "docker-build-proxy" -> "proxy/Dockerfile";
 
     "docker-build-proxy-init" -> "_docker.sh";
@@ -473,6 +478,7 @@ build_architecture
     "docker-retag-all" -> "_docker.sh";
 
     "go-run" -> ".gorun";
+    "go-run" -> "root-tag";
 
     "minikube-start-hyperv.bat";
 
@@ -484,15 +490,15 @@ build_architecture
 
     "root-tag" -> "_tag.sh";
 
-    "travis.yml" -> "_gcp.sh";
-    "travis.yml" -> "docker-build";
-    "travis.yml" -> "docker-pull";
-    "travis.yml" -> "docker-pull-deps";
-    "travis.yml" -> "docker-push";
-    "travis.yml" -> "docker-push-deps";
-    "travis.yml" -> "docker-retag-all";
-    "travis.yml" -> "protoc-go.sh";
-    "travis.yml" -> "root-tag";
+    ".travis.yml" -> "_gcp.sh";
+    ".travis.yml" -> "dep";
+    ".travis.yml" -> "docker-build";
+    ".travis.yml" -> "docker-pull";
+    ".travis.yml" -> "docker-pull-deps";
+    ".travis.yml" -> "docker-push";
+    ".travis.yml" -> "docker-push-deps";
+    ".travis.yml" -> "docker-retag-all";
+    ".travis.yml" -> "protoc-go.sh";
 
     "update-go-deps-shas" -> "_tag.sh";
     "update-go-deps-shas" -> "cli/Dockerfile-bin";

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -1,11 +1,8 @@
-#!/bin/sh
-#
-# docker
-#
-
 set -eu
 
-. bin/_log.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_log.sh
 
 # TODO this should be set to the canonical public docker regsitry; we can override this
 # docker regsistry in, for instance, CI.
@@ -42,8 +39,10 @@ docker_build() {
         output="/dev/stderr"
     fi
 
-    log_debug "  :; docker build . -t $repo:$tag -f $file $extra"
-    docker build . \
+    rootdir="$( cd $bindir/.. && pwd )"
+
+    log_debug "  :; docker build $rootdir -t $repo:$tag -f $file $extra"
+    docker build $rootdir \
         -t "$repo:$tag" \
         -f "$file" \
         $extra \

--- a/bin/_gcp.sh
+++ b/bin/_gcp.sh
@@ -1,8 +1,3 @@
-#!/bin/sh
-#
-# gcp -- mostly for CI
-#
-
 set -eu
 
 get_k8s_ctx() {

--- a/bin/_log.sh
+++ b/bin/_log.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 set -eu
 
 # build debug logging is disabled by default; enable with BUILD_DEBUG=1

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 set -eu
 
 git_sha_head() {
@@ -7,7 +5,9 @@ git_sha_head() {
 }
 
 go_deps_sha() {
-    cat Gopkg.lock Dockerfile-go-deps | shasum - | awk '{print $1}' |cut -c 1-8
+    bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    rootdir="$( cd $bindir/.. && pwd )"
+    cat $rootdir/Gopkg.lock $rootdir/Dockerfile-go-deps | shasum - | awk '{print $1}' |cut -c 1-8
 }
 
 clean_head() {
@@ -59,9 +59,9 @@ validate_tag() {
     fi
 }
 
-# These functions should be called by any docker-build-* script that relies on
-# Go or Rust dependencies. To confirm the set of scripts that should call this
-# function, run:
+# This function should be called by any docker-build-* script that relies on Go
+# dependencies. To confirm the set of scripts that should call this function,
+# run:
 # $ grep -ER 'docker-build-go-deps' .
 
 validate_go_deps_tag() {

--- a/bin/conduit
+++ b/bin/conduit
@@ -1,13 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
 
 system=$(uname -s)
 
 if [ "$system" = "Darwin" ]; then
-  bin=target/cli/darwin/conduit
+  bin=$rootdir/target/cli/darwin/conduit
 elif [ "$system" = "Linux" ]; then
-  bin=target/cli/linux/conduit
+  bin=$rootdir/target/cli/linux/conduit
 else
   echo "unknown system: $system" >&2
   exit 1
@@ -15,7 +18,7 @@ fi
 
 # build conduit executable if it does not exist
 if [ ! -f $bin ]; then
-  bin/docker-build-cli-bin >/dev/null
+  $bindir/docker-build-cli-bin >/dev/null
 fi
 
 exec $bin "$@"

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,9 +7,11 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-bin/docker-build-controller
-bin/docker-build-web
-bin/docker-build-proxy-init
-bin/docker-build-cli
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-bin/docker-build-proxy
+$bindir/docker-build-controller
+$bindir/docker-build-web
+$bindir/docker-build-proxy-init
+$bindir/docker-build-cli
+
+$bindir/docker-build-proxy

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Builds (or pulls) our base runtime docker image.
 
@@ -9,12 +9,15 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+
+. $bindir/_docker.sh
 
 tag="2017-10-30.01"
 
 if (docker_pull base "${tag}"); then
     echo "$(docker_repo base):${tag}"
 else
-    docker_build base "${tag}" Dockerfile-base
+    docker_build base "${tag}" $rootdir/Dockerfile-base
 fi

--- a/bin/docker-build-cli
+++ b/bin/docker-build-cli
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,10 +7,13 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
 
 # Build gcr.io/runconduit/cli-bin, which is used by cli/Dockerfile.
-bin/docker-build-cli-bin >/dev/null
+$bindir/docker-build-cli-bin >/dev/null
 
-docker_build cli "$(head_root_tag)" cli/Dockerfile
+docker_build cli "$(head_root_tag)" $rootdir/cli/Dockerfile

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,16 +7,19 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
 
-dockerfile=cli/Dockerfile-bin
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+dockerfile=$rootdir/cli/Dockerfile-bin
 
 validate_go_deps_tag $dockerfile
 
 (
-    bin/docker-build-base
-    bin/docker-build-go-deps
+    $bindir/docker-build-base
+    $bindir/docker-build-go-deps
 ) >/dev/null
 
 tag="$(head_root_tag)"
@@ -26,7 +29,7 @@ ID=$(docker create "$IMG")
 
 # copy the newly built conduit cli binaries to the local system
 for OS in darwin linux windows ; do
-    DIR="target/cli/${OS}"
+    DIR="${rootdir}/target/cli/${OS}"
     mkdir -p "$DIR"
 
     if docker cp "$ID:/out/conduit-${OS}" "$DIR/conduit" ; then

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,16 +7,19 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
 
-dockerfile=controller/Dockerfile
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+dockerfile=$rootdir/controller/Dockerfile
 
 validate_go_deps_tag $dockerfile
 
 (
-    bin/docker-build-base
-    bin/docker-build-go-deps
+    $bindir/docker-build-base
+    $bindir/docker-build-go-deps
 ) >/dev/null
 
 tag="$(head_root_tag)"

--- a/bin/docker-build-go-deps
+++ b/bin/docker-build-go-deps
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Builds (or pulls) our go-deps docker image.
 
@@ -9,13 +9,16 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
 
 tag=$(go_deps_sha)
 
 if (docker_pull go-deps "${tag}"); then
     echo "$(docker_repo go-deps):${tag}"
 else
-    docker_build go-deps "${tag}" Dockerfile-go-deps
+    rootdir="$( cd $bindir/.. && pwd )"
+    docker_build go-deps "${tag}" $rootdir/Dockerfile-go-deps
 fi

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,9 +7,12 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
 
-docker_build proxy "$(head_root_tag)" proxy/Dockerfile \
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+docker_build proxy "$(head_root_tag)" $rootdir/proxy/Dockerfile \
     --build-arg="PROXY_SKIP_TESTS=${PROXY_SKIP_TESTS:-}" \
     --build-arg="PROXY_UNOPTIMIZED=${PROXY_UNOPTIMIZED:-}"

--- a/bin/docker-build-proxy-init
+++ b/bin/docker-build-proxy-init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,16 +7,19 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
 
-dockerfile=proxy-init/Dockerfile
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+dockerfile=$rootdir/proxy-init/Dockerfile
 
 validate_go_deps_tag $dockerfile
 
 (
-    bin/docker-build-base
-    bin/docker-build-go-deps
+    $bindir/docker-build-base
+    $bindir/docker-build-go-deps
 ) >/dev/null
 
 docker_build proxy-init "$(head_root_tag)" $dockerfile

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,16 +7,19 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
 
-dockerfile=web/Dockerfile
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+dockerfile=$rootdir/web/Dockerfile
 
 validate_go_deps_tag $dockerfile
 
 (
-    bin/docker-build-base
-    bin/docker-build-go-deps
+    $bindir/docker-build-base
+    $bindir/docker-build-go-deps
 ) >/dev/null
 
 tag="$(head_root_tag)"

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
 
 docker_image() {
     repo="$(docker_repo "$1")"

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -9,7 +9,9 @@ else
     exit 64
 fi
 
-. bin/_docker.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
 
 docker_pull proxy        "${tag}"  || true
 docker_pull proxy-init   "${tag}"  || true

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
 
 docker_pull base       2017-10-30.01       || true
 docker_pull go-deps    "$(go_deps_sha)"    || true

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -9,7 +9,9 @@ else
     exit 64
 fi
 
-. bin/_docker.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
 
 docker_push proxy        "${tag}"
 docker_push proxy-init   "${tag}"

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
-. bin/_docker.sh
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
 
 docker_push base         2017-10-30.01
 docker_push go-deps      "$(go_deps_sha)"

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -9,7 +9,9 @@ fi
 from="${1}"
 to="${2}"
 
-. bin/_docker.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_docker.sh
 
 docker_retag proxy        "$from" "$to"
 docker_retag proxy-init   "$from" "$to"

--- a/bin/go-run
+++ b/bin/go-run
@@ -1,13 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ "$#" -eq 0 ]; then
   echo "Usage: bin/go-run path/to/main [args]" >&2
   exit 1
 fi
 
-ldflags="-X github.com/runconduit/conduit/pkg/version.Version=$(bin/root-tag)"
+ldflags="-X github.com/runconduit/conduit/pkg/version.Version=$($bindir/root-tag)"
 go build -v -i -race -o .gorun -ldflags "$ldflags" "./$1"
 shift
 exec ./.gorun "$@"

--- a/bin/mkube
+++ b/bin/mkube
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # A wrapper for interacting with minikube.
 #

--- a/bin/protoc
+++ b/bin/protoc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 

--- a/bin/root-tag
+++ b/bin/root-tag
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
-. bin/_tag.sh
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_tag.sh
 
 head_root_tag

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -1,12 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
 # Updates the tag for `runconduit/go-deps` across all Dockerfiles in this repository.
 
-sha=$(. bin/_tag.sh ; go_deps_sha)
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-for f in $( grep -lR --include=Dockerfile\* go-deps: . ) ; do
+sha=$(. $bindir/_tag.sh ; go_deps_sha)
+
+for f in $( grep -lR --include=Dockerfile\* go-deps: $bindir/.. ) ; do
     sed -E -i.bak -e "s|runconduit/go-deps:[^ ]+|runconduit/go-deps:${sha}|" "$f"
     rm "$f".bak
 done


### PR DESCRIPTION
The build scripts assume they are executed from the root of this repo.
This prevents running scripts from other locations, for example,
`cd web && ../bin/go-run .`.

Modify the build scripts to work regardless of current directory.

Fixes #301

Signed-off-by: Andrew Seigner <siggy@buoyant.io>