### PR TITLE
proxy: improve overall quality of logs

### DIFF
--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -214,7 +214,6 @@ where
         // in `poll_destinations` while the `rpc` service is ready should
         // be reconnected now, otherwise the task would just sleep...
         loop {
-            trace!("poll_rpc");
             self.poll_new_watches(client);
             self.poll_destinations();
 

--- a/proxy/src/control/telemetry.rs
+++ b/proxy/src/control/telemetry.rs
@@ -45,7 +45,6 @@ where
         //let _ctxt = ::logging::context("Telemetry.Report".into());
 
         loop {
-            trace!("poll_rpc");
             if let Some((t0, mut fut)) = self.in_flight.take() {
                 match fut.poll() {
                     Ok(Async::NotReady) => {

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -160,8 +160,7 @@ where
             TimeoutError::Timeout(ref duration) =>
                 // TODO: format the duration nicer.
                 write!(f, "operation timed out after {:?}", duration),
-            TimeoutError::Error(ref err) =>
-                write!(f, "inner operation failed: {}", err),
+            TimeoutError::Error(ref err) => fmt::Display::fmt(err, f),
         }
     }
 }

--- a/proxy/src/transport/so_original_dst.rs
+++ b/proxy/src/transport/so_original_dst.rs
@@ -24,7 +24,7 @@ impl GetOriginalDst for SoOriginalDst {
         use self::linux;
         use std::os::unix::io::AsRawFd;
 
-        debug!("get_original_dst {:?}", sock);
+        trace!("get_original_dst {:?}", sock);
 
         let res = unsafe { linux::so_original_dst(sock.as_raw_fd()) };
         res.ok()


### PR DESCRIPTION
- Removed several useless `trace!("poll")` lines
- Upgraded controller client errors to `error` level
- Made controller client errors human-readable