### PR TITLE
proxy: fix intermittent tap match method quickcheck failure

### DIFF
--- a/proxy/src/telemetry/tap/match_.rs
+++ b/proxy/src/telemetry/tap/match_.rs
@@ -416,7 +416,7 @@ mod tests {
                                 let ok =
                                     b'A' <= c && c <= b'Z' ||
                                     b'a' <= c && c <= b'z' ||
-                                    b'0' <= c && c <= b'0' ;
+                                    b'0' <= c && c <= b'9' ;
                                 if !ok {
                                     err = Some(InvalidMatch::InvalidHttpMethod);
                                     break;


### PR DESCRIPTION
Closes #413 

Things like `g2` were failing, since `b'2'` is not withing the range of `b'0'...b'0'` :D