### PR TITLE
Add flaky_tests feature for skipping some tests on CI

### DIFF
--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.3.0"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 publish = false
 
+[features]
+default = ["flaky_tests"]
+# Disable to skip certain tests that should not be run on CI.
+flaky_tests = []
+
 [dependencies]
 convert                         = { path = "./convert" }
 conduit-proxy-controller-grpc   = { path = "./controller-grpc" }

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -59,8 +59,8 @@ ARG PROXY_SKIP_TESTS
 RUN if [ -n "$PROXY_SKIP_TESTS" ]; \
     then echo "tests skipped" ; \
     elif [ -n "$PROXY_UNOPTIMIZED" ]; \
-    then cargo test -p conduit-proxy --frozen ; \
-    else cargo test -p conduit-proxy --frozen --release ; \
+    then cargo test -p conduit-proxy --frozen --no-default-features ; \
+    else cargo test -p conduit-proxy --frozen --release --no-default-features ; \
     fi
 RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
     then mv target/debug/conduit-proxy   target/conduit-proxy ; \

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -177,12 +177,12 @@ fn inbound_aggregates_telemetry_over_several_requests() {
 
 }
 
-// Ignore this test for now, because our method of adding latency to requests
-// (calling `thread::sleep`) is likely to be flakey, especially on CI.
+// Ignore this test on CI, because our method of adding latency to requests
+// (calling `thread::sleep`) is likely to be flakey on Travis.
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn records_latency_statistics() {
     let _ = env_logger::init();
 


### PR DESCRIPTION
This PR adds a `flaky_tests` cargo feature to control whether or not to ignore tests that are timing-dependent. This feature is enabled by default in local builds, but disabled on CI and in all Docker builds.

Closes #440 