### PR TITLE
Make prometheus URL in config fully qualified DNS name

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -204,7 +204,7 @@ spec:
         - -addr=:8087
         - -metrics-addr=:9997
         - -ignore-namespaces=kube-system
-        - -prometheus-url=http://prometheus:9090
+        - -prometheus-url=http://prometheus.conduit.svc.cluster.local:9090
         - -log-level=info
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -205,7 +205,7 @@ spec:
         - -addr=:8087
         - -metrics-addr=:9997
         - -ignore-namespaces=kube-system
-        - -prometheus-url=http://prometheus:9090
+        - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -207,7 +207,7 @@ spec:
         - "-addr=:8087"
         - "-metrics-addr=:9997"
         - "-ignore-namespaces=kube-system"
-        - "-prometheus-url=http://prometheus:9090"
+        - "-prometheus-url=http://prometheus.{{.Namespace}}.svc.cluster.local:9090"
         - "-log-level={{.ControllerLogLevel}}"
 
 ### Web ###


### PR DESCRIPTION
The telemetry service in the controller pod uses a non-fully qualified URL to connect to the prometheus pod in the control plane. This PR changes the URL the telemetry's prometheus URL to be fully qualified to be consistent with other URLs in the control plane. This change was tested in minikube. The logs report no errors and looking at the prometheus dashboard shows that stats are being recorded from all conduit proxies.

fixes #414 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>