### PR TITLE
Upgrade to env_logger 0.5 & turn off its regex feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +115,15 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "codegen"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/codegen#6d0fea3634cc1e3f1576c1c321a20e6e56bfb132"
@@ -122,7 +141,7 @@ dependencies = [
  "conduit-proxy-router 0.3.0",
  "convert 0.3.0",
  "domain 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.3.0",
  "h2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -131,7 +150,7 @@ dependencies = [
  "hyper 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ns-dns-tokio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,6 +263,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -580,6 +610,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +810,14 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +944,24 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1176,6 +1264,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1296,7 @@ dependencies = [
 "checksum abstract-ns 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "babdbabd818c2b3f5a8b2c2015f5663d454fc8a69b67c0e65f391cfd362841a3"
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
@@ -1211,6 +1308,7 @@ dependencies = [
 "checksum bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5162604199bbb17690ede847eaa6120a3f33d5ab4dcc8e7c25b16d849ae79b"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum codegen 0.1.0 (git+https://github.com/carllerche/codegen)" = "<none>"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
 "checksum curl 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b70fd6394677d3c0e239ff4be6f2b3176e171ffd1c23ffdc541e78dea2b8bb5e"
@@ -1218,6 +1316,7 @@ dependencies = [
 "checksum domain 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c1850bf2c3c3349e1dba2aa214d86cf9edaa057a09ce46b1a02d5c07d5da5e65"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
@@ -1255,6 +1354,10 @@ dependencies = [
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum ns-dns-tokio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75311dd15a3051ab6adb4ae1de6824146d304a25030b8d12e0ae842e484157c5"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "14ba54ac7d5a4eabd1d5f2c1fdeb7e7c14debfa669d94b983d01b465e767ba9e"
@@ -1276,6 +1379,7 @@ dependencies = [
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
@@ -1294,6 +1398,8 @@ dependencies = [
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)" = "<none>"
@@ -1329,5 +1435,6 @@ dependencies = [
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum zip 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e7341988e4535c60882d5e5f0b7ad0a9a56b080ade8bdb5527cb512f7b2180e0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -12,14 +12,14 @@ conduit-proxy-router            = { path = "./router" }
 
 bytes = "0.4"
 domain = "0.2.2"
-env_logger = "0.4"
+env_logger = { version = "0.5", default-features = false }
 futures = "0.1"
 h2 = "0.1"
 http = "0.1"
 httparse = "1.2"
 hyper = { version = "0.11.19", features = ["compat"] }
 ipnet = "1.0"
-log = "0.3"
+log = "0.4.1"
 ordermap = "0.2"
 rand = "0.4"
 url = "1.5"

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -1,12 +1,13 @@
 use std::cell::RefCell;
 use std::env;
+use std::io::Write;
 use std::fmt;
 use std::rc::Rc;
 
-use env_logger::LogBuilder;
+use env_logger;
 use futures::{Future, Poll};
 use futures::future::{ExecuteError, Executor};
-use log::LogLevel;
+use log::{Level};
 
 const ENV_LOG: &str = "CONDUIT_PROXY_LOG";
 
@@ -15,17 +16,18 @@ thread_local! {
 }
 
 pub fn init() {
-    LogBuilder::new()
-        .format(|record| {
+    env_logger::Builder::new()
+        .format(|fmt, record| {
             CONTEXT.with(|ctxt| {
                 let level = match record.level() {
-                    LogLevel::Trace => "TRCE",
-                    LogLevel::Debug => "DBUG",
-                    LogLevel::Info => "INFO",
-                    LogLevel::Warn => "WARN",
-                    LogLevel::Error => "ERR!",
+                    Level::Trace => "TRCE",
+                    Level::Debug => "DBUG",
+                    Level::Info => "INFO",
+                    Level::Warn => "WARN",
+                    Level::Error => "ERR!",
                 };
-                format!(
+                writeln!(
+                   fmt,
                     "{} {} {:?}{}",
                     level,
                     record.target(),
@@ -35,8 +37,7 @@ pub fn init() {
             })
         })
         .parse(&env::var(ENV_LOG).unwrap_or_default())
-        .init()
-        .expect("logger");
+        .init();
 }
 
 /// Execute a closure with a `Debug` item attached to allow log messages.

--- a/proxy/tests/discovery.rs
+++ b/proxy/tests/discovery.rs
@@ -3,7 +3,7 @@ use self::support::*;
 
 #[test]
 fn outbound_asks_controller_api() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::new().route("/", "hello").route("/bye", "bye").run();
     let ctrl = controller::new()
@@ -18,7 +18,7 @@ fn outbound_asks_controller_api() {
 
 #[test]
 fn outbound_reconnects_if_controller_stream_ends() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::new().route("/recon", "nect").run();
     let ctrl = controller::new()
@@ -33,7 +33,7 @@ fn outbound_reconnects_if_controller_stream_ends() {
 
 #[test]
 fn outbound_updates_newer_services() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     //TODO: when the support server can listen on both http1 and http2
     //at the same time, do that here
@@ -63,7 +63,7 @@ fn outbound_times_out() {
 
 #[test]
 fn outbound_uses_orig_dst_if_not_local_svc() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::new()
         .route("/", "hello")

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -6,7 +6,7 @@ use self::support::*;
 
 #[test]
 fn inbound_sends_telemetry() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     info!("running test server");
     let srv = server::new().route("/hey", "hello").run();
@@ -56,7 +56,7 @@ fn inbound_sends_telemetry() {
 
 #[test]
 fn http1_inbound_sends_telemetry() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     info!("running test server");
     let srv = server::http1().route("/hey", "hello").run();
@@ -102,7 +102,7 @@ fn http1_inbound_sends_telemetry() {
 
 #[test]
 fn inbound_aggregates_telemetry_over_several_requests() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     info!("running test server");
     let srv = server::new()
@@ -184,7 +184,7 @@ fn inbound_aggregates_telemetry_over_several_requests() {
 #[test]
 #[ignore]
 fn records_latency_statistics() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     info!("running test server");
     let srv = server::new()

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -3,7 +3,7 @@ use self::support::*;
 
 #[test]
 fn outbound_http1() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::http1().route("/", "hello h1").run();
     let ctrl = controller::new()
@@ -17,7 +17,7 @@ fn outbound_http1() {
 
 #[test]
 fn inbound_http1() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::http1().route("/", "hello h1").run();
     let ctrl = controller::new().run();
@@ -32,7 +32,7 @@ fn inbound_http1() {
 
 #[test]
 fn http1_connect_not_supported() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::tcp()
         .run();
@@ -53,7 +53,7 @@ fn http1_connect_not_supported() {
 
 #[test]
 fn http1_removes_connection_headers() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::http1()
         .route_fn("/", |req| {
@@ -82,7 +82,7 @@ fn http1_removes_connection_headers() {
 
 #[test]
 fn http10_with_host() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let host = "transparency.test.svc.cluster.local";
     let srv = server::http1()
@@ -112,7 +112,7 @@ fn http10_with_host() {
 
 #[test]
 fn http10_without_host() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::http1()
         .route_fn("/", move |req| {
@@ -142,7 +142,7 @@ fn http10_without_host() {
 
 #[test]
 fn http11_absolute_uri_differs_from_host() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let host = "transparency.test.svc.cluster.local";
     let srv = server::http1()
@@ -171,7 +171,7 @@ fn http11_absolute_uri_differs_from_host() {
 
 #[test]
 fn outbound_tcp() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -198,7 +198,7 @@ fn outbound_tcp() {
 
 #[test]
 fn inbound_tcp() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -225,7 +225,7 @@ fn inbound_tcp() {
 
 #[test]
 fn tcp_with_no_orig_dst() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::tcp()
         .accept(move |_| "don't read me")
@@ -251,7 +251,7 @@ fn tcp_with_no_orig_dst() {
 
 #[test]
 fn http11_upgrade_not_supported() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     // our h1 proxy will strip the Connection header
     // and headers it mentions
@@ -297,7 +297,7 @@ fn http11_upgrade_not_supported() {
 
 #[test]
 fn http1_get_doesnt_add_transfer_encoding() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let srv = server::http1()
         .route_fn("/", |req| {


### PR DESCRIPTION
Reduce memory allocations during logging.

Stop initializing env_logger in every test. In env_logger 0.5, it
may only be initialized once per process.

Also, Prost will soon upgrade to env_logger 0.5 and this will
(eventually) help reduce the number of versions of env_logger we
have to build. Turning off the regex feature will (eventually) also
reduce the number of dependencies we have to build. Unfortunately,
as it is now, the number of dependencies has increased because
env_logger increased its dependencies in 0.5.

Signed-off-by: Brian Smith <brian@briansmith.org>