### PR TITLE
cli: add check for latest version of cli and control plane

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -12,10 +12,14 @@ import (
 	"github.com/runconduit/conduit/pkg/healthcheck"
 	"github.com/runconduit/conduit/pkg/k8s"
 	"github.com/runconduit/conduit/pkg/shell"
+	"github.com/runconduit/conduit/pkg/version"
 	"github.com/spf13/cobra"
 )
 
-const lineWidth = 80
+const (
+	lineWidth       = 80
+	versionCheckURL = "https://versioncheck.conduit.io/version.json"
+)
 
 var checkCmd = &cobra.Command{
 	Use:   "check",
@@ -45,7 +49,10 @@ problems were found.`,
 			os.Exit(2)
 		}
 
-		err = checkStatus(os.Stdout, kubeApi, healthcheck.NewGrpcStatusChecker(public.ConduitApiSubsystemName, conduitApi))
+		grpcStatusChecker := healthcheck.NewGrpcStatusChecker(public.ConduitApiSubsystemName, conduitApi)
+		versionStatusChecker := version.NewVersionStatusChecker(versionCheckURL, conduitApi)
+
+		err = checkStatus(os.Stdout, kubeApi, grpcStatusChecker, versionStatusChecker)
 		if err != nil {
 			os.Exit(2)
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,16 +1,29 @@
 package version
 
 import (
+	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 
+	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
+	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/pkg/healthcheck"
 	log "github.com/sirupsen/logrus"
 )
 
 // DO NOT EDIT
 // This var is updated automatically as part of the build process
 var Version = "undefined"
+
+const (
+	VersionSubsystemName         = "conduit-version"
+	CliCheckDescription          = "cli is up-to-date"
+	ControlPlaneCheckDescription = "control plane is up-to-date"
+)
 
 func VersionFlag() *bool {
 	return flag.Bool("version", false, "print version and exit")
@@ -22,4 +35,92 @@ func MaybePrintVersionAndExit(printVersion bool) {
 		os.Exit(0)
 	}
 	log.Infof("running conduit version %s", Version)
+}
+
+type versionStatusChecker struct {
+	version         string
+	versionCheckURL string
+	client          pb.ApiClient
+}
+
+func (v versionStatusChecker) SelfCheck() []*healthcheckPb.CheckResult {
+	cliVersion := v.version
+	cliIsUpToDate := &healthcheckPb.CheckResult{
+		Status:           healthcheckPb.CheckStatus_OK,
+		SubsystemName:    VersionSubsystemName,
+		CheckDescription: CliCheckDescription,
+	}
+
+	latestVersion, err := getLatestVersion(v.versionCheckURL)
+	if err != nil {
+		cliIsUpToDate.Status = healthcheckPb.CheckStatus_ERROR
+		cliIsUpToDate.FriendlyMessageToUser = err.Error()
+		return []*healthcheckPb.CheckResult{cliIsUpToDate}
+	}
+	if cliVersion != latestVersion {
+		cliIsUpToDate.Status = healthcheckPb.CheckStatus_FAIL
+		cliIsUpToDate.FriendlyMessageToUser = fmt.Sprintf("is running version %s but the latest version is %s", cliVersion, latestVersion)
+	}
+
+	controlPlaneIsUpToDate := &healthcheckPb.CheckResult{
+		Status:           healthcheckPb.CheckStatus_OK,
+		SubsystemName:    VersionSubsystemName,
+		CheckDescription: ControlPlaneCheckDescription,
+	}
+
+	controlPlaneVersion, err := getServerVersion(v.client)
+	if err != nil {
+		controlPlaneIsUpToDate.Status = healthcheckPb.CheckStatus_ERROR
+		controlPlaneIsUpToDate.FriendlyMessageToUser = err.Error()
+		return []*healthcheckPb.CheckResult{controlPlaneIsUpToDate}
+	}
+	if controlPlaneVersion != latestVersion {
+		controlPlaneIsUpToDate.Status = healthcheckPb.CheckStatus_FAIL
+		controlPlaneIsUpToDate.FriendlyMessageToUser = fmt.Sprintf("is running version %s but the latest version is %s", controlPlaneVersion, latestVersion)
+	}
+
+	checks := []*healthcheckPb.CheckResult{cliIsUpToDate}
+	checks = append(checks, controlPlaneIsUpToDate)
+	return checks
+}
+
+func getServerVersion(client pb.ApiClient) (string, error) {
+	resp, err := client.Version(context.Background(), &pb.Empty{})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.GetReleaseVersion(), nil
+}
+
+func getLatestVersion(versionCheckURL string) (string, error) {
+	resp, err := http.Get(versionCheckURL)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("got %d error from %s", resp.StatusCode, versionCheckURL)
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var l map[string]string
+	err = json.Unmarshal(bodyBytes, &l)
+	if err != nil {
+		return "", err
+	}
+
+	return l["version"], nil
+}
+
+func NewVersionStatusChecker(versionCheckURL string, client pb.ApiClient) healthcheck.StatusChecker {
+	return versionStatusChecker{
+		version:         Version,
+		versionCheckURL: versionCheckURL,
+		client:          client,
+	}
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,96 @@
+package version_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/runconduit/conduit/controller/api/public"
+	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
+	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/pkg/version"
+)
+
+func TestVersionCheck(t *testing.T) {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "{\"version\": \"v0.3.0\"}")
+	})
+	go http.ListenAndServe("localhost:8080", nil)
+
+	t.Run("Passes when versions are latest", func(t *testing.T) {
+		version.Version = "v0.3.0"
+		mockPublicApi := createMockPublicApi("v0.3.0")
+
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", mockPublicApi)
+		checks := versionStatusChecker.SelfCheck()
+
+		expectedName := version.VersionSubsystemName
+		if checks[0].SubsystemName != expectedName {
+			t.Fatalf("Expecting check name to be [%s], got [%s]", expectedName, checks[0].SubsystemName)
+		}
+		if checks[1].SubsystemName != expectedName {
+			t.Fatalf("Expecting check name to be [%s], got [%s]", expectedName, checks[0].SubsystemName)
+		}
+
+		expectedStatus := healthcheckPb.CheckStatus_OK
+		if checks[0].Status != expectedStatus {
+			t.Fatalf("Expecting cli check status to be [%d], got [%d]", expectedStatus, checks[0].Status)
+		}
+		if checks[1].Status != expectedStatus {
+			t.Fatalf("Expecting control plane check status to be [%d], got [%d]", expectedStatus, checks[1].Status)
+		}
+
+		expectedDescription := version.CliCheckDescription
+		if checks[0].CheckDescription != expectedDescription {
+			t.Fatalf("Expecting check description to be [%s], got [%s]", expectedDescription, checks[0].CheckDescription)
+		}
+		expectedDescription = version.ControlPlaneCheckDescription
+		if checks[1].CheckDescription != expectedDescription {
+			t.Fatalf("Expecting check description to be [%s], got [%s]", expectedDescription, checks[0].CheckDescription)
+		}
+	})
+
+	t.Run("Fails when cli version is not latest", func(t *testing.T) {
+		version.Version = "v0.1.1"
+		mockPublicApi := createMockPublicApi("v0.3.0")
+
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", mockPublicApi)
+		checks := versionStatusChecker.SelfCheck()
+
+		expectedStatus := healthcheckPb.CheckStatus_FAIL
+		if checks[0].Status != expectedStatus {
+			t.Fatalf("Expecting check status to be [%d], got [%d]", expectedStatus, checks[0].Status)
+		}
+
+		expectedMessage := "is running version v0.1.1 but the latest version is v0.3.0"
+		if checks[0].FriendlyMessageToUser != expectedMessage {
+			t.Fatalf("Expecting message to be [%s], got [%s]", expectedMessage, checks[0].FriendlyMessageToUser)
+		}
+	})
+
+	t.Run("Fails when control plane version is not latest", func(t *testing.T) {
+		version.Version = "v0.3.0"
+		mockPublicApi := createMockPublicApi("v0.1.1")
+
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", mockPublicApi)
+		checks := versionStatusChecker.SelfCheck()
+
+		expectedStatus := healthcheckPb.CheckStatus_FAIL
+		if checks[1].Status != expectedStatus {
+			t.Fatalf("Expecting check status to be [%d], got [%d]", expectedStatus, checks[1].Status)
+		}
+
+		expectedMessage := "is running version v0.1.1 but the latest version is v0.3.0"
+		if checks[1].FriendlyMessageToUser != expectedMessage {
+			t.Fatalf("Expecting message to be [%s], got [%s]", expectedMessage, checks[1].FriendlyMessageToUser)
+		}
+	})
+}
+
+func createMockPublicApi(version string) *public.MockConduitApiClient {
+	return &public.MockConduitApiClient{
+		VersionInfoToReturn: &pb.VersionInfo{
+			ReleaseVersion: version,
+		},
+	}
+}


### PR DESCRIPTION
As part of `conduit check` command, warn the user if they are
running an outdated version of the cli client or the control
plane components.

Fixes #314

Signed-off-by: Andy Hume <andyhume@gmail.com>