### PR TITLE
Add DNS label validation in destination service

### DIFF
--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -26,9 +26,8 @@ type (
 )
 
 var (
-	dnsCharactersRegexp             = regexp.MustCompile("^[a-zA-Z0-9-]{0,63}$")
-	startsAndEndsWithAlphanumRegexp = regexp.MustCompile("^(([a-zA-Z0-9].*[a-zA-Z0-9])|[a-zA-Z0-9])$")
-	containsAlphaRegexp             = regexp.MustCompile("[a-zA-Z]")
+	dnsCharactersRegexp = regexp.MustCompile("^[a-zA-Z0-9_-]{0,63}$")
+	containsAlphaRegexp = regexp.MustCompile("[a-zA-Z]")
 )
 
 // The Destination service serves service discovery information to the proxy.
@@ -294,11 +293,11 @@ func splitDNSName(dnsName string) ([]string, error) {
 		if !dnsCharactersRegexp.MatchString(l) {
 			return []string{}, errors.New("DNS name is too long or contains invalid characters: " + dnsName)
 		}
-		if !startsAndEndsWithAlphanumRegexp.MatchString(l) {
+		if strings.HasPrefix(l, "-") || strings.HasSuffix(l, "-") {
 			return []string{}, errors.New("DNS name cannot start or end with a dash: " + dnsName)
 		}
 		if !containsAlphaRegexp.MatchString(l) {
-			return []string{}, errors.New("DNS name cannot only contain numerals: " + dnsName)
+			return []string{}, errors.New("DNS name cannot only contain digits and hyphens: " + dnsName)
 		}
 	}
 	return labels, nil

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -83,11 +83,16 @@ func TestSplitDNSName(t *testing.T) {
 		{"", []string{}, true},
 		{"ALL-CAPS", []string{"ALL-CAPS"}, false},
 		{"This-dns-label-has-63-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{"This-dns-label-has-63-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}, false},
+		{"This-dns-label-has-64-character-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{}, true},
+		{"ThisDnsLabelHas63Charactersxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{"ThisDnsLabelHas63Charactersxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}, false},
+		{"ThisDnsLabelHas64Charactersxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{}, true},
 		{"0O0", []string{"0O0"}, false},
 		{"-hi", []string{}, true},
+		{"hi-", []string{}, true},
+		{"---", []string{}, true},
 		{"123", []string{}, true},
-		{"This-dns-label-has-64-character-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{}, true},
 		{"a", []string{"a"}, false},
+		{"underscores_are_okay", []string{"underscores_are_okay"}, false},
 	}
 
 	for i, tc := range testCases {

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -13,7 +13,7 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 	testCases := []struct {
 		k8sDNSZone string
 		host       string
-		result    *string
+		result     *string
 		resultErr  bool
 	}{
 		{"cluster.local", "", nil, true},
@@ -81,6 +81,13 @@ func TestSplitDNSName(t *testing.T) {
 		{"foo.example.com", []string{"foo", "example", "com"}, false},
 		{"invalid/character", []string{}, true},
 		{"", []string{}, true},
+		{"ALL-CAPS", []string{"ALL-CAPS"}, false},
+		{"This-dns-label-has-63-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{"This-dns-label-has-63-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}, false},
+		{"0O0", []string{"0O0"}, false},
+		{"-hi", []string{}, true},
+		{"123", []string{}, true},
+		{"This-dns-label-has-64-character-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", []string{}, true},
+		{"a", []string{"a"}, false},
 	}
 
 	for i, tc := range testCases {

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -79,6 +79,8 @@ func TestSplitDNSName(t *testing.T) {
 		{"example.com..", []string{}, true},
 		{"..example.com.", []string{}, true},
 		{"foo.example.com", []string{"foo", "example", "com"}, false},
+		{"invalid/character", []string{}, true},
+		{"", []string{}, true},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Add a validation in the destination service that ensures that DNS destinations consist of valid labels.

Fixes #170 

Signed-off-by: Alex Leong <alex@buoyant.io>