### PR TITLE
Turn off the `use_logging` default feature of quickcheck.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,8 +688,6 @@ name = "quickcheck"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -54,5 +54,5 @@ tower-util            = { git = "https://github.com/tower-rs/tower" }
 libc = "0.2"
 
 [dev-dependencies]
-quickcheck = "0.6"
+quickcheck = { version = "0.6", default-features = false }
 conduit-proxy-controller-grpc = { path = "./controller-grpc" , features = ["arbitrary"] }

--- a/proxy/controller-grpc/Cargo.toml
+++ b/proxy/controller-grpc/Cargo.toml
@@ -21,7 +21,7 @@ prost-types = "0.3.0"
 tower-grpc = { git = "https://github.com/tower-rs/tower-grpc" }
 tower-h2   = { git = "https://github.com/tower-rs/tower-h2" }
 
-quickcheck = { version = "0.6", optional = true }
+quickcheck = { version = "0.6", default-features = false, optional = true }
 
 
 [build-dependencies]


### PR DESCRIPTION
Turning off the default features of quickcheck removes its
`env_logger` and `log` dependencies. It uses older versions of
those packages than conduit-proxy will use, so this will
(eventually) reduce the number of versions of those packages that
get downloaded and built.

Signed-off-by: Brian Smith <brian@briansmith.org>