### PR TITLE
Proxy: Upgrade from ordermap 0.2 crate to indexmap 0.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,11 +148,11 @@ dependencies = [
  "http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ns-dns-tokio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -194,7 +194,7 @@ name = "conduit-proxy-router"
 version = "0.3.0"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -410,6 +410,11 @@ dependencies = [
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "indexmap"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "iovec"
@@ -1262,6 +1267,7 @@ dependencies = [
 "checksum http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf8217d8829cc05dedadc08b4bc0684e5e3fbba1126c5edc680af49053fa230c"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)" = "47659bb1cb7ef3cd7b4f9bd2a11349b8d92097d34f9597a3c09e9bcefaf92b61"
+"checksum indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7164c96d6e18ccc3ce43f3dedac996c21a220670a106c275b96ad92110401362"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"
 "checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -25,7 +25,7 @@ httparse = "1.2"
 hyper = { version = "0.11.19", default-features = false, features = ["compat"] }
 ipnet = "1.0"
 log = "0.4.1"
-ordermap = "0.2"
+indexmap = "0.4.1"
 rand = "0.4"
 
 tokio-core = "0.1"

--- a/proxy/router/Cargo.toml
+++ b/proxy/router/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 futures = "0.1"
-ordermap = "0.2"
+indexmap = "0.4.1"
 tower = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -1,9 +1,9 @@
 extern crate futures;
-extern crate ordermap;
+extern crate indexmap;
 extern crate tower;
 
 use futures::{Future, Poll};
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 use tower::Service;
 
 use std::hash::Hash;
@@ -67,7 +67,7 @@ where T: Recognize,
 struct Inner<T>
 where T: Recognize,
 {
-    routes: OrderMap<T::Key, T::Service>,
+    routes: IndexMap<T::Key, T::Service>,
     recognize: T,
 }
 

--- a/proxy/src/control/observe.rs
+++ b/proxy/src/control/observe.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use futures::{future, Poll, Stream};
 use futures_mpsc_lossy;
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 use tower_grpc::{self as grpc, Response};
 
 use conduit_proxy_controller_grpc::common::TapEvent;
@@ -22,7 +22,7 @@ pub struct Observe {
 pub struct TapEvents {
     rx: futures_mpsc_lossy::Receiver<Event>,
     remaining: usize,
-    current: OrderMap<Arc<ctx::http::Request>, ()>,
+    current: IndexMap<Arc<ctx::http::Request>, ()>,
     tap_id: usize,
     taps: Arc<Mutex<Taps>>,
 }
@@ -77,7 +77,7 @@ impl server::Tap for Observe {
         let events = TapEvents {
             rx,
             tap_id,
-            current: OrderMap::default(),
+            current: IndexMap::default(),
             remaining: req.limit as usize,
             taps: self.taps.clone(),
         };

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -21,7 +21,7 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate ns_dns_tokio;
-extern crate ordermap;
+extern crate indexmap;
 extern crate prost;
 extern crate prost_types;
 #[cfg(test)]

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::{u32, u64};
 
 use http;
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 
 use conduit_proxy_controller_grpc::common::{
     TcpAddress,
@@ -30,9 +30,9 @@ mod latency;
 
 #[derive(Debug)]
 pub struct Metrics {
-    sources: OrderMap<net::IpAddr, TransportStats>,
-    destinations: OrderMap<net::SocketAddr, TransportStats>,
-    requests: OrderMap<RequestKey, RequestStats>,
+    sources: IndexMap<net::IpAddr, TransportStats>,
+    destinations: IndexMap<net::SocketAddr, TransportStats>,
+    requests: IndexMap<RequestKey, RequestStats>,
     process_ctx: Arc<ctx::Process>,
 }
 
@@ -47,12 +47,12 @@ struct RequestKey {
 #[derive(Debug, Default)]
 struct RequestStats {
     count: u32,
-    responses: OrderMap<Option<http::StatusCode>, ResponseStats>,
+    responses: IndexMap<Option<http::StatusCode>, ResponseStats>,
 }
 
 #[derive(Debug, Default)]
 struct ResponseStats {
-    ends: OrderMap<End, u32>,
+    ends: IndexMap<End, u32>,
     /// Response latencies in tenths of a millisecond.
     ///
     /// Observed latencies are mapped to a count of the times that
@@ -88,9 +88,9 @@ impl RequestKey {
 impl Metrics {
     pub fn new(process_ctx: Arc<ctx::Process>) -> Self {
         Metrics {
-            sources: OrderMap::new(),
-            destinations: OrderMap::new(),
-            requests: OrderMap::new(),
+            sources: IndexMap::new(),
+            destinations: IndexMap::new(),
+            requests: IndexMap::new(),
             process_ctx,
         }
     }

--- a/proxy/src/telemetry/tap/mod.rs
+++ b/proxy/src/telemetry/tap/mod.rs
@@ -1,5 +1,5 @@
 use futures_mpsc_lossy;
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 
 use conduit_proxy_controller_grpc::tap::observe_request;
 
@@ -12,7 +12,7 @@ pub use self::match_::InvalidMatch;
 
 #[derive(Default, Debug)]
 pub struct Taps {
-    by_id: OrderMap<usize, Tap>,
+    by_id: IndexMap<usize, Tap>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Currently we have to download and build two different versions of
the ordermap crate.

I will submit similar PRs for the dependent crates so that we will
eventually all be using the same version of indexmap.

Signed-off-by: Brian Smith <brian@briansmith.org>