### PR TITLE
Run go fix to fix context package imports

### DIFF
--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -3,6 +3,7 @@ package public
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,7 +14,6 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -1,6 +1,7 @@
 package public
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"runtime"
@@ -15,7 +16,6 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type (

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -1,6 +1,7 @@
 package public
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -12,7 +13,6 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/controller/telemetry/server.go
+++ b/controller/telemetry/server.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -21,7 +22,6 @@ import (
 	"github.com/runconduit/conduit/controller/util"
 	pkgK8s "github.com/runconduit/conduit/pkg/k8s"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	k8sV1 "k8s.io/api/core/v1"
@@ -68,7 +68,7 @@ var (
 	)
 
 	reportsLabels = []string{"pod"}
-	reportsTotal = prometheus.NewCounterVec(
+	reportsTotal  = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: reportsMetric,
 			Help: "Total number of telemetry reports received",
@@ -228,7 +228,7 @@ func (s *server) ListPods(ctx context.Context, req *read.ListPodsRequest) (*publ
 	// report from that instance.
 	reports := make(map[string]time.Time)
 	// Query Prometheus for reports in the last 30 seconds.
-	res, err := s.prometheusAPI.Query(ctx, reportsMetric + "[30s]", time.Time{})
+	res, err := s.prometheusAPI.Query(ctx, reportsMetric+"[30s]", time.Time{})
 	if err != nil {
 		return nil, err
 	}

--- a/controller/telemetry/server_test.go
+++ b/controller/telemetry/server_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	read "github.com/runconduit/conduit/controller/gen/controller/telemetry"
-	"golang.org/x/net/context"
 )
 
 type mockProm struct {


### PR DESCRIPTION
I noticed that in go-1.10, the [fix command was updated](https://golang.org/doc/go1.10#fix) to fix imports of the "golang.org/x/net/context" package. Here's a PR with the changes from running `go fix` on the non-generated go files in our code base, and running `goimports` on the modified files.