### PR TITLE
Fix intermittent outbound_times_out failure.

### DIFF
--- a/proxy/tests/discovery.rs
+++ b/proxy/tests/discovery.rs
@@ -59,7 +59,7 @@ fn outbound_updates_newer_services() {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn outbound_times_out() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
     let mut env = config::TestEnv::new();
 
     // set the bind timeout to 100 ms.


### PR DESCRIPTION
This was caused by the fact that a new instance of `env_logger::init()`
was added after the PR that rewrote them all to `env_logger::try_init()`
was added.

Fixes #469

Signed-off-by: Brian Smith <brian@briansmith.org>