### PR TITLE
Skip flaky tests in non-Docker CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       install:
         - cargo fetch --locked
       script:
-        - cargo test --frozen
+        - cargo test --frozen --no-default-features
 
     - language: go
       # XXX; The "1.10" must be quoted or it will get intrepreted as 1.1. See


### PR DESCRIPTION
@briansmith pointed out in https://github.com/runconduit/conduit/pull/441#discussion_r170816351 that I forgot to add `--no-default-features` to the Travis CI non-Docker test step in PR #441, to actually skip the timing dependent tests on CI.

This fixes that.