### PR TITLE
Use fmt::Display to format error messages in logs

### DIFF
--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -6,6 +6,7 @@ use futures::{Future, Poll};
 use indexmap::IndexMap;
 use tower::Service;
 
+use std::error;
 use std::hash::Hash;
 use std::mem;
 use std::sync::{Arc, Mutex};

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -228,15 +228,14 @@ where T: Recognize,
 
 impl<T, U> fmt::Display for Error<T, U>
 where
-    T: fmt::Debug,
-    U: fmt::Debug,
+    T: fmt::Display,
+    U: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Inner(ref why) =>
-                write!(f, "inner service error: {:?}", why),
+            Error::Inner(ref why) => fmt::Display::fmt(why, f),
             Error::Route(ref why) =>
-                write!(f, "route recognition failed: {:?}", why),
+                write!(f, "route recognition failed: {}", why),
             Error::NotRecognized => f.pad("route not recognized"),
         }
     }

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -59,6 +61,33 @@ pub type Client<B> = transparency::Client<
     sensor::Connect<transport::TimeoutConnect<transport::Connect>>,
     B,
 >;
+
+#[derive(Copy, Clone, Debug)]
+pub enum BufferSpawnError {
+    Inbound,
+    Outbound,
+}
+
+impl fmt::Display for BufferSpawnError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad(self.description())
+    }
+}
+
+impl Error for BufferSpawnError {
+
+    fn description(&self) -> &str {
+        match *self {
+            BufferSpawnError::Inbound =>
+                "error spawning inbound buffer task",
+            BufferSpawnError::Outbound =>
+                "error spawning outbound buffer task",
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> { None }
+}
+
 
 impl<B> Bind<(), B> {
     pub fn new(executor: Handle) -> Self {

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -43,7 +43,7 @@ where
         >
     >;
     type Key = (SocketAddr, bind::Protocol);
-    type RouteError = ();
+    type RouteError = bind::BufferSpawnError;
     type Service = InFlightLimit<Buffer<bind::Service<B>>>;
 
     fn recognize(&self, req: &Self::Request) -> Option<Self::Key> {
@@ -81,7 +81,7 @@ where
             .map(|buffer| {
                 InFlightLimit::new(buffer, MAX_IN_FLIGHT)
             })
-            .map_err(|_| {})
+            .map_err(|_| bind::BufferSpawnError::Inbound)
     }
 }
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -53,7 +53,7 @@ use std::time::Duration;
 use tokio_core::reactor::{Core, Handle};
 use tower::NewService;
 use tower_fn::*;
-use conduit_proxy_router::{Recognize, Router};
+use conduit_proxy_router::{Recognize, Router, Error as RouteError};
 
 pub mod app;
 mod bind;
@@ -318,7 +318,22 @@ where
         let router = router.clone();
 
         // Map errors to 500 responses
-        MapErr::new(router)
+        MapErr::new(router, |e| {
+            match e {
+                RouteError::Route(r) => {
+                    error!("route error: {:?}", r);
+                    http::StatusCode::INTERNAL_SERVER_ERROR
+                }
+                RouteError::Inner(i) => {
+                    error!("inner error: {:?}", i);
+                    http::StatusCode::INTERNAL_SERVER_ERROR
+                }
+                RouteError::NotRecognized => {
+                    error!("route not recognized");
+                    http::StatusCode::NOT_FOUND
+                }
+            }
+        })
     }));
 
     let listen_addr = bound_port.local_addr();

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -320,22 +320,14 @@ where
 
         // Map errors to appropriate response error codes.
         MapErr::new(router, |e| {
-
             match e {
                 RouteError::Route(r) => {
-                    error!("route error: {:?}", r);
+                    error!("route error: {}", r);
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
                 RouteError::Inner(i) => {
-                    // TODO: type system hates this...
-                    // if let Some(cause) = i.cause() {
-                    //         error!("{}: timed out after {:?}",
-                    //             i.description(), after);
-                    //         http::StatusCode::GATEWAY_TIMEOUT
-                    // } else {
-                        error!("{}", i);
-                        http::StatusCode::INTERNAL_SERVER_ERROR
-                    // }
+                    error!("{}", i);
+                    http::StatusCode::INTERNAL_SERVER_ERROR
                 }
                 RouteError::NotRecognized => {
                     error!("route not recognized");

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -218,12 +218,17 @@ where
 
             let tcp_connect_timeout = bind.connect_timeout();
 
+            let bind_timeout = timeout::NewTimeout::new(
+                config.bind_timeout,
+                &executor
+            );
+
             let outgoing = Outbound::new(
                 bind,
                 control,
                 config.default_destination_namespace().cloned(),
                 config.default_destination_zone().cloned(),
-                config.bind_timeout,
+                bind_timeout,
             );
 
             let fut = serve(

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -322,15 +322,15 @@ where
         MapErr::new(router, |e| {
             match e {
                 RouteError::Route(r) => {
-                    error!("route error: {}", r);
+                    error!(" turning route error: {} into 500", r);
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
                 RouteError::Inner(i) => {
-                    error!("{}", i);
+                    error!("turning {} into 500", i);
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
                 RouteError::NotRecognized => {
-                    error!("route not recognized");
+                    error!("turning route not recognized error into 500");
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
             }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -331,7 +331,7 @@ where
                 }
                 RouteError::NotRecognized => {
                     error!("route not recognized");
-                    http::StatusCode::NOT_FOUND
+                    http::StatusCode::INTERNAL_SERVER_ERROR
                 }
             }
         })

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -333,7 +333,7 @@ where
                     //             i.description(), after);
                     //         http::StatusCode::GATEWAY_TIMEOUT
                     // } else {
-                        error!("inner service error: {}", i);
+                        error!("{}", i);
                         http::StatusCode::INTERNAL_SERVER_ERROR
                     // }
                 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -224,7 +224,6 @@ where
                 config.default_destination_namespace().cloned(),
                 config.default_destination_zone().cloned(),
                 config.bind_timeout,
-                &executor,
             );
 
             let fut = serve(

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -301,7 +301,7 @@ fn serve<R, B, E, F, G>(
 ) -> Box<Future<Item = (), Error = io::Error> + 'static>
 where
     B: tower_h2::Body + Default + 'static,
-    E: ::std::fmt::Debug + 'static,
+    E: ::std::fmt::Debug + ::std::error::Error + 'static,
     F: ::std::fmt::Debug + 'static,
     R: Recognize<
         Request = http::Request<HttpBody>,
@@ -324,6 +324,10 @@ where
                     error!("route error: {:?}", r);
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
+                // RouteError::Inner(i) => {
+                //     error!("timed out after {:?}", after);
+                //     http::StatusCode::GATEWAY_TIMED_OUT
+                // }
                 RouteError::Inner(i) => {
                     error!("inner error: {:?}", i);
                     http::StatusCode::INTERNAL_SERVER_ERROR

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -218,17 +218,13 @@ where
 
             let tcp_connect_timeout = bind.connect_timeout();
 
-            let bind_timeout = timeout::NewTimeout::new(
-                config.bind_timeout,
-                &executor
-            );
-
             let outgoing = Outbound::new(
                 bind,
                 control,
                 config.default_destination_namespace().cloned(),
                 config.default_destination_zone().cloned(),
-                bind_timeout,
+                config.bind_timeout,
+                &executor,
             );
 
             let fut = serve(

--- a/proxy/src/map_err.rs
+++ b/proxy/src/map_err.rs
@@ -1,50 +1,81 @@
+// use std::any::Any;
+// use std::error::Error;
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use futures::{Future, Poll};
 use h2;
 use http;
+use http::StatusCode;
 use http::header::CONTENT_LENGTH;
 use tower::Service;
 
 /// Map an HTTP service's error to an appropriate 500 response.
-pub struct MapErr<T, E> {
+pub struct MapErr<T, E, F> {
     inner: T,
+    f: Arc<F>,
     _p: PhantomData<E>,
 }
 
 /// Catches errors from the inner future and maps them to 500 responses.
-pub struct ResponseFuture<T, E> {
+pub struct ResponseFuture<T, E, F> {
     inner: T,
+    f: Arc<F>,
     _p: PhantomData<E>,
 }
 
+// pub fn get_cause<E>(whatever: &E) -> Option<&Error> {
+//     match whatever {
+//         e @ &Error => Some(e),
+//         _ => None
+//     }
+// }
+
 // ===== impl MapErr =====
 
-impl<T, E> MapErr<T, E>
+impl<T, E, F> MapErr<T, E, F>
 where
     T: Service<Error = E>,
-    E: Debug,
+    F: Fn(E) -> http::StatusCode,
 {
     /// Crete a new `MapErr`
-    pub fn new(inner: T) -> Self {
+    pub fn new(inner: T, f: F) -> Self {
         MapErr {
             inner,
+            f: Arc::new(f),
             _p: PhantomData,
         }
     }
 }
 
-impl<T, B, E> Service for MapErr<T, E>
+impl<T, E> MapErr<T, E, fn(E) -> http::StatusCode>
+where
+    T: Service<Error = E>,
+    E: Debug,
+{
+    /// Crete a new `MapErr` with the default behaviour
+    /// (mapping all errors to HTTP 500).
+    #[allow(dead_code)]
+    pub fn internal_error(inner: T) -> Self {
+        let default_map = |error: E| -> http::StatusCode {
+            error!("turning service error into 500: {:?}", error);
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+        Self::new(inner, default_map)
+    }
+}
+
+impl<T, B, E, F> Service for MapErr<T, E, F>
 where
     T: Service<Response = http::Response<B>, Error = E>,
     B: Default,
-    E: Debug,
+    F: Fn(E) -> http::StatusCode,
 {
     type Request = T::Request;
     type Response = T::Response;
     type Error = h2::Error;
-    type Future = ResponseFuture<T::Future, E>;
+    type Future = ResponseFuture<T::Future, E, F>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready()
@@ -56,6 +87,7 @@ where
         let inner = self.inner.call(request);
         ResponseFuture {
             inner,
+            f: self.f.clone(),
             _p: PhantomData,
         }
     }
@@ -63,20 +95,20 @@ where
 
 // ===== impl ResponseFuture =====
 
-impl<T, B, E> Future for ResponseFuture<T, E>
+impl<T, B, E, F> Future for ResponseFuture<T, E, F>
 where
     T: Future<Item = http::Response<B>, Error = E>,
     B: Default,
-    E: Debug,
+    F: Fn(E) -> http::StatusCode,
 {
     type Item = T::Item;
     type Error = h2::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll().or_else(|e| {
-            error!("turning service error into 500: {:?}", e);
+            let status = (self.f)(e);
             let response = http::Response::builder()
-                .status(500)
+                .status(status)
                 .header(CONTENT_LENGTH, "0")
                 .body(Default::default())
                 .unwrap();

--- a/proxy/src/map_err.rs
+++ b/proxy/src/map_err.rs
@@ -1,13 +1,9 @@
-// use std::any::Any;
-// use std::error::Error;
-use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 use futures::{Future, Poll};
 use h2;
 use http;
-use http::StatusCode;
 use http::header::CONTENT_LENGTH;
 use tower::Service;
 

--- a/proxy/src/map_err.rs
+++ b/proxy/src/map_err.rs
@@ -25,12 +25,6 @@ pub struct ResponseFuture<T, E, F> {
     _p: PhantomData<E>,
 }
 
-// pub fn get_cause<E>(whatever: &E) -> Option<&Error> {
-//     match whatever {
-//         e @ &Error => Some(e),
-//         _ => None
-//     }
-// }
 
 // ===== impl MapErr =====
 
@@ -46,23 +40,6 @@ where
             f: Arc::new(f),
             _p: PhantomData,
         }
-    }
-}
-
-impl<T, E> MapErr<T, E, fn(E) -> http::StatusCode>
-where
-    T: Service<Error = E>,
-    E: Debug,
-{
-    /// Crete a new `MapErr` with the default behaviour
-    /// (mapping all errors to HTTP 500).
-    #[allow(dead_code)]
-    pub fn internal_error(inner: T) -> Self {
-        let default_map = |error: E| -> http::StatusCode {
-            error!("turning service error into 500: {:?}", error);
-            StatusCode::INTERNAL_SERVER_ERROR
-        };
-        Self::new(inner, default_map)
     }
 }
 

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -1,13 +1,14 @@
+use std::{error, fmt};
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::sync::Arc;
 
 use futures::{Async, Poll};
 use http;
 use rand;
-use std::sync::Arc;
 use tower;
 use tower_balance::{self, choose, load, Balance};
-use tower_buffer::Buffer;
+use tower_buffer::{self, Buffer};
 use tower_discover::{Change, Discover};
 use tower_in_flight_limit::InFlightLimit;
 use tower_h2;
@@ -65,7 +66,7 @@ where
     type Response = bind::HttpResponse;
     type Error = <Self::Service as tower::Service>::Error;
     type Key = (Destination, Protocol);
-    type RouteError = ();
+    type RouteError = BufferSpawnError;
     type Service = InFlightLimit<Timeout<Buffer<Balance<
         load::WithPendingRequests<Discovery<B>>,
         choose::PowerOfTwoChoices<rand::ThreadRng>
@@ -142,7 +143,7 @@ where
         // `Timeout`.
         let handle = self.bind.executor();
 
-        let buffer = Buffer::new(balance, handle).map_err(|_| {})?;
+        let buffer = Buffer::new(balance, handle)?;
 
         let timeout = Timeout::new(buffer, self.bind_timeout, handle);
 
@@ -165,11 +166,12 @@ where
     type Response = bind::HttpResponse;
     type Error = <bind::Service<B> as tower::Service>::Error;
     type Service = bind::Service<B>;
-    type DiscoverError = ();
+    type DiscoverError = BindError;
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {
         match *self {
-            Discovery::LocalSvc(ref mut w) => w.poll(),
+            Discovery::LocalSvc(ref mut w) => w.poll()
+                .map_err(|_| BindError::Internal),
             Discovery::External(ref mut opt) => {
                 // This "discovers" a single address for an external service
                 // that never has another change. This can mean it floats
@@ -177,7 +179,8 @@ where
                 // circuit-breaking, this should be able to take care of itself,
                 // closing down when the connection is no longer usable.
                 if let Some((addr, bind)) = opt.take() {
-                    let svc = bind.bind(&addr)?;
+                    let svc = bind.bind(&addr)
+                        .map_err(|_| BindError::External{ addr })?;
                     Ok(Async::Ready(Change::Insert(addr, svc)))
                 } else {
                     Ok(Async::NotReady)
@@ -185,4 +188,57 @@ where
             }
         }
     }
+}
+
+
+#[derive(Copy, Clone, Debug)]
+pub struct BufferSpawnError;
+
+impl fmt::Display for BufferSpawnError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("error spawning outbound buffer task")
+    }
+}
+
+impl error::Error for BufferSpawnError {
+    fn description(&self) -> &str {
+        "error spawning outbound buffer task"
+    }
+
+    fn cause(&self) -> Option<&error::Error> { None }
+}
+
+impl<T> From<tower_buffer::SpawnError<T>> for BufferSpawnError {
+    fn from(_t: tower_buffer::SpawnError<T>) -> Self {
+        BufferSpawnError
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum BindError {
+    External { addr: SocketAddr },
+    Internal,
+}
+
+impl fmt::Display for BindError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BindError::External { addr } =>
+                write!(f, "binding external service for {:?} failed", addr),
+            BindError::Internal =>
+                write!(f, "binding internal service failed"),
+        }
+    }
+
+}
+
+impl error::Error for BindError {
+    fn description(&self) -> &str {
+        match *self {
+            BindError::External { .. } => "binding external service failed",
+            BindError::Internal => "binding internal service failed",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> { None }
 }

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -1,16 +1,17 @@
 use std::net::SocketAddr;
-use std::time::Duration;
+use std::{fmt, io};
 
 use futures::{Async, Poll};
 use http;
 use rand;
 use std::sync::Arc;
-use tower;
+use tower::{self, Service};
 use tower_balance::{self, choose, load, Balance};
-use tower_buffer::Buffer;
+use tower_buffer::{Buffer, Error as BufferError};
 use tower_discover::{Change, Discover};
-use tower_in_flight_limit::InFlightLimit;
+use tower_in_flight_limit::{InFlightLimit, Error as InFlightLimitError};
 use tower_h2;
+use tower_reconnect::Error as ReconnectError;
 use conduit_proxy_router::Recognize;
 
 use bind::{self, Bind, Protocol};
@@ -18,7 +19,7 @@ use control::{self, discovery};
 use control::discovery::Bind as BindTrait;
 use ctx;
 use fully_qualified_authority::FullyQualifiedAuthority;
-use timeout::{NewTimeout, Timeout};
+use timeout::{NewTimeout, Timeout, TimeoutError};
 
 type BindProtocol<B> = bind::BindProtocol<Arc<ctx::Proxy>, B>;
 
@@ -66,10 +67,10 @@ where
     type Error = <Self::Service as tower::Service>::Error;
     type Key = (Destination, Protocol);
     type RouteError = ();
-    type Service = Timeout<InFlightLimit<Buffer<Balance<
+    type Service = LogErrors<Timeout<InFlightLimit<Buffer<Balance<
         load::WithPendingRequests<Discovery<B>>,
         choose::PowerOfTwoChoices<rand::ThreadRng>
-    >>>>;
+    >>>>>;
 
     fn recognize(&self, req: &Self::Request) -> Option<Self::Key> {
         let local = req.uri().authority_part().and_then(|authority| {
@@ -141,7 +142,8 @@ where
         Buffer::new(balance, self.bind.executor())
             .map(|buffer| {
                 let inflight = InFlightLimit::new(buffer, MAX_IN_FLIGHT);
-                self.timeout.apply(inflight)
+                let timeout = self.timeout.apply(inflight);
+                LogErrors::new(timeout)
             })
             .map_err(|_| {})
     }
@@ -154,7 +156,7 @@ pub enum Discovery<B> {
 
 impl<B> Discover for Discovery<B>
 where
-    B: tower_h2::Body + 'static,
+    B: tower_h2::Body + 'static
 {
     type Key = SocketAddr;
     type Request = http::Request<B>;
@@ -179,6 +181,70 @@ where
                     Ok(Async::NotReady)
                 }
             }
+        }
+    }
+}
+
+// ===== impl LogErrors
+
+/// Log errors talking to the controller in human format.
+pub
+struct LogErrors<S> {
+    inner: S,
+}
+
+// We want some friendly logs, but the stack of services don't have fmt::Display
+// errors, so we have to build that ourselves. For now, this hard codes the
+// expected error stack, and so any new middleware added will need to adjust this.
+//
+// The dead_code allowance is because rustc is being stupid and doesn't see it
+// is used down below.
+// #[allow(dead_code)]
+type LogError = TimeoutError<InFlightLimitError<BufferError<tower_balance::Error<ReconnectError<tower_h2::client::Error, tower_h2::client::ConnectError<TimeoutError<io::Error>>>, ()>>>>;
+
+impl<S> LogErrors<S>
+where
+    S: Service<Error=LogError>,
+{
+    fn new(service: S) -> Self {
+        LogErrors {
+            inner: service,
+        }
+    }
+}
+
+impl<S> Service for LogErrors<S>
+where
+    S: Service<Error=LogError>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready().map_err(|e| {
+            error!("bind service error: {}", HumanError(&e));
+            e
+        })
+    }
+
+    fn call(&mut self, req: Self::Request) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+struct HumanError<'a>(&'a LogError);
+
+impl<'a> fmt::Display for HumanError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self.0 {
+            TimeoutError::Error(ref e) => {
+                fmt::Debug::fmt(e, f)
+            },
+            TimeoutError::Timeout(ref after) => {
+               write!(f, "binding timed out after {:?}", after)
+            },
         }
     }
 }

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -11,6 +11,14 @@ use tokio_core::reactor::{Timeout as ReactorTimeout, Handle};
 use tokio_io;
 use tower::Service;
 
+/// Generates timeouts wrapping a `Service`.
+#[derive(Debug, Clone)]
+pub struct NewTimeout {
+    duration: Duration,
+    handle: Handle,
+}
+
+
 /// A timeout that wraps an underlying operation.
 #[derive(Debug, Clone)]
 pub struct Timeout<U> {
@@ -211,4 +219,27 @@ where
            .field("duration", &self.duration)
            .finish()
     }
+}
+
+//===== impl NewTimeout =====
+
+impl NewTimeout {
+
+    /// Returns a new NewTimeout
+    pub fn new(duration: Duration, handle: &Handle) -> Self {
+        Self {
+            duration,
+            handle: handle.clone(),
+        }
+    }
+
+    /// Wrap the provided `Service` with a `Timeout`.
+    pub fn apply<S>(&self, inner: S) -> Timeout<S> {
+        Timeout {
+            inner,
+            duration: self.duration,
+            handle: self.handle.clone(),
+        }
+    }
+
 }

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -11,14 +11,6 @@ use tokio_core::reactor::{Timeout as ReactorTimeout, Handle};
 use tokio_io;
 use tower::Service;
 
-/// Generates timeouts wrapping a `Service`.
-#[derive(Debug, Clone)]
-pub struct NewTimeout {
-    duration: Duration,
-    handle: Handle,
-}
-
-
 /// A timeout that wraps an underlying operation.
 #[derive(Debug, Clone)]
 pub struct Timeout<U> {
@@ -219,27 +211,4 @@ where
            .field("duration", &self.duration)
            .finish()
     }
-}
-
-//===== impl NewTimeout =====
-
-impl NewTimeout {
-
-    /// Returns a new NewTimeout
-    pub fn new(duration: Duration, handle: &Handle) -> Self {
-        Self {
-            duration,
-            handle: handle.clone(),
-        }
-    }
-
-    /// Wrap the provided `Service` with a `Timeout`.
-    pub fn apply<S>(&self, inner: S) -> Timeout<S> {
-        Timeout {
-            inner,
-            duration: self.duration,
-            handle: self.handle.clone(),
-        }
-    }
-
 }


### PR DESCRIPTION
This PR changes the proxy to log error messages using `fmt::Display` whenever possible, which should lead to much more readable and meaningful error messages

This is part of the work I started last week on issue #442. While I haven't finished everything for that issue (all errors still are mapped to HTTP 500 error codes), I wanted to go ahead and open a PR for the more readable error messages. This is partially because I found myself merging these changes into other branches to aid in debugging, and because I figured we may as well have the nicer logging on master.