### PR TITLE
Fixed build rust doc

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -320,7 +320,7 @@ To build and run the Rust proxy:
 ```bash
 cargo build -p conduit-proxy
 CONDUIT_PROXY_LOG=trace \
-  CONDUIT_PROXY_PUBLIC_LISTENER=tcp://127.0.0.1:5432 \
+  CONDUIT_PROXY_PUBLIC_LISTENER=tcp://0.0.0.0:5432 \
   CONDUIT_PROXY_PRIVATE_FORWARD=tcp://127.0.0.1:1234 \
   CONDUIT_PROXY_CONTROL_URL=tcp://127.0.0.1:8086 \
   target/debug/conduit-proxy

--- a/BUILD.md
+++ b/BUILD.md
@@ -320,7 +320,7 @@ To build and run the Rust proxy:
 ```bash
 cargo build -p conduit-proxy
 CONDUIT_PROXY_LOG=trace \
-  CONDUIT_PROXY_PUBLIC_LISTENER=tcp://0:5432 \
+  CONDUIT_PROXY_PUBLIC_LISTENER=tcp://127.0.0.1:5432 \
   CONDUIT_PROXY_PRIVATE_FORWARD=tcp://127.0.0.1:1234 \
   CONDUIT_PROXY_CONTROL_URL=tcp://127.0.0.1:8086 \
   target/debug/conduit-proxy


### PR DESCRIPTION
Hey all,

I was following the build guide for building `proxy` and this error popped up

```
➜  conduit git:(master) cargo build -p conduit-proxy
CONDUIT_PROXY_LOG=trace \
  CONDUIT_PROXY_PUBLIC_LISTENER=tcp://0:5432 \
  CONDUIT_PROXY_PRIVATE_FORWARD=tcp://127.0.0.1:1234 \
  CONDUIT_PROXY_CONTROL_URL=tcp://127.0.0.1:8086 \
  target/debug/conduit-proxy
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
ERR! conduit_proxy::config CONDUIT_PROXY_PUBLIC_LISTENER is not valid: HostIsNotAnIpAddress
configuration error: InvalidEnvVar
```

I believe `CONDUIT_PROXY_PUBLIC_LISTENER=tcp://0:5432` should be
`CONDUIT_PROXY_PUBLIC_LISTENER=tcp://127.0.0.1:5432` instead.

Cheers