### PR TITLE
Change DEFAULT_PRIVATE_CONNECT_TIMEOUT to 10 seconds

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -158,7 +158,7 @@ const DEFAULT_REPORT_TIMEOUT_SECS: u64 = 10; // TODO: is this a reasonable defau
 const DEFAULT_PRIVATE_LISTENER: &str = "tcp://127.0.0.1:4140";
 const DEFAULT_PUBLIC_LISTENER: &str = "tcp://0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTENER: &str = "tcp://0.0.0.0:4190";
-const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
+const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 10_000;
 const DEFAULT_BIND_TIMEOUT_MS: u64 = 10_000; // ten seconds, as in Linkerd.
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 


### PR DESCRIPTION
Previously, the default private connect timeout was 20 ms. I noticed that [after switching to a higher-resolution timer](https://github.com/runconduit/conduit/pull/480#issue-171830434), a number of proxy unit tests were failing due to this timeout. 

I discussed this with @briansmith and we agreed this timeout was probably too high. In https://github.com/runconduit/conduit/pull/480#discussion_r171138857, Brian suggested changing it to 10 seconds (10,000 ms) to be consistent with the default bind timeout. This appears to be more than sufficient to fix the timeout failures on my tokio-timer branch. 

It's also possible that this change may help with the issues seen in #478 as well.