### PR TITLE
Filter out controller pod statistics from service mesh metric requests

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -85,7 +85,17 @@ func render(config installConfig, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return InjectYAML(buf, w, conduitVersion)
+
+	proxyConfig := &proxyConfig{
+		version:         conduitVersion,
+		logLevel:        proxyLogLevel,
+		apiPort:         proxyAPIPort,
+		controlPort:     proxyControlPort,
+		outboundPort:    outboundPort,
+		inboundPort:     inboundPort,
+		eventBufferSize: 0,
+	}
+	return InjectYAML(buf, w, proxyConfig)
 }
 
 var alphaNumDash = regexp.MustCompile("^[a-zA-Z0-9-]+$")

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -93,7 +93,7 @@ func render(config installConfig, w io.Writer) error {
 		controlPort:     proxyControlPort,
 		outboundPort:    outboundPort,
 		inboundPort:     inboundPort,
-		eventBufferSize: 0,
+		eventBufferSize: 0, // Sets the telemetry event buffer to zero in order to turn off telemetry from control plane
 	}
 	return InjectYAML(buf, w, proxyConfig)
 }

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -240,6 +240,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
+        - name: CONDUIT_PROXY_EVENT_BUFFER_CAPACITY
+          value: "0"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -360,6 +362,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
+        - name: CONDUIT_PROXY_EVENT_BUFFER_CAPACITY
+          value: "0"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -479,6 +483,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
+        - name: CONDUIT_PROXY_EVENT_BUFFER_CAPACITY
+          value: "0"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -241,6 +241,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
+        - name: CONDUIT_PROXY_EVENT_BUFFER_CAPACITY
+          value: "0"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -362,6 +364,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
+        - name: CONDUIT_PROXY_EVENT_BUFFER_CAPACITY
+          value: "0"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -482,6 +486,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONDUIT_PROXY_DESTINATIONS_AUTOCOMPLETE_FQDN
           value: Kubernetes
+        - name: CONDUIT_PROXY_EVENT_BUFFER_CAPACITY
+          value: "0"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy


### PR DESCRIPTION
When the conduit proxy is injected into the controller pod, we observe controller pod proxy stats show up as an "outbound" deployment for an unrelated upstream deployment. This may cause confusion when monitoring deployments in the service mesh. 

This PR filters out this "misleading" stat in the public api whenever the dashboard requests metric information for a specific deployment.

fixes #370

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>