### PR TITLE
 Add unit test ensuring connections are created per-host 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "h2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -389,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.11.20"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1278,7 @@ dependencies = [
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf8217d8829cc05dedadc08b4bc0684e5e3fbba1126c5edc680af49053fa230c"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)" = "1545100ac38f42f338c63bff290d7285b7117021a564b3c0f34e8d57cf81451f"
+"checksum hyper 0.11.21 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a77dea5dccbf32ba4e9ddd7d80a5a3bb3b9f1f3835e18daf5dbea6bee0efbf"
 "checksum indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7164c96d6e18ccc3ce43f3dedac996c21a220670a106c275b96ad92110401362"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "h2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -389,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.11.19"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1278,7 @@ dependencies = [
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum http 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf8217d8829cc05dedadc08b4bc0684e5e3fbba1126c5edc680af49053fa230c"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)" = "47659bb1cb7ef3cd7b4f9bd2a11349b8d92097d34f9597a3c09e9bcefaf92b61"
+"checksum hyper 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)" = "1545100ac38f42f338c63bff290d7285b7117021a564b3c0f34e8d57cf81451f"
 "checksum indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7164c96d6e18ccc3ce43f3dedac996c21a220670a106c275b96ad92110401362"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.1"
 h2 = "0.1"
 http = "0.1"
 httparse = "1.2"
-hyper = { version = "0.11.19", default-features = false, features = ["compat"] }
+hyper = { version = "0.11.20", default-features = false, features = ["compat"] }
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "0.4.1"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.1"
 h2 = "0.1"
 http = "0.1"
 httparse = "1.2"
-hyper = { version = "0.11.20", default-features = false, features = ["compat"] }
+hyper = { version = "0.11.21", default-features = false, features = ["compat"] }
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "0.4.1"

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -263,7 +263,8 @@ where
                         Entry::Vacant(vac) => {
                             let req = Destination {
                                 scheme: "k8s".into(),
-                                path: vac.key().without_trailing_dot().into(),
+                                path: vac.key().without_trailing_dot()
+                                        .as_str().into(),
                             };
                             // TODO: Can grpc::Request::new be removed?
                             let mut svc = DestinationSvc::new(client.lift_ref());
@@ -298,7 +299,7 @@ where
                 trace!("Destination.Get reconnect {:?}", auth);
                 let req = Destination {
                     scheme: "k8s".into(),
-                    path: auth.without_trailing_dot().into(),
+                    path: auth.without_trailing_dot().as_str().into(),
                 };
                 let mut svc = DestinationSvc::new(client.lift_ref());
                 let response = svc.get(grpc::Request::new(req));

--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -174,7 +174,7 @@ where
                 let is_body_empty = req.body().is_end_stream();
                 let mut req = hyper::Request::from(req.map(BodyStream::new));
                 if is_body_empty {
-                    req.headers_mut().set(hyper::header::ContentLength(0));
+                    req.body_mut().take();
                 }
                 ClientServiceFuture::Http1(h1.request(req))
             },

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -81,7 +81,7 @@ impl tower_h2::Body for HttpBody {
 
     fn is_end_stream(&self) -> bool {
         match *self {
-            HttpBody::Http1(_) => false,
+            HttpBody::Http1(ref b) => b.is_empty(),
             HttpBody::Http2(ref b) => b.is_end_stream(),
         }
     }

--- a/proxy/tests/support/client.rs
+++ b/proxy/tests/support/client.rs
@@ -102,6 +102,7 @@ fn run(addr: SocketAddr, version: Run) -> Sender {
                     .build(&reactor);
                 Box::new(rx.for_each(move |(req, cb)| {
                     let mut req = hyper::Request::from(req.map(|()| hyper::Body::empty()));
+                    assert!(req.body_mut().take().unwrap().is_empty());
                     if absolute_uris {
                         req.set_proxy(true);
                     }

--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -20,7 +20,7 @@ use self::bytes::{BigEndian, Bytes, BytesMut};
 pub use self::conduit_proxy::*;
 pub use self::futures::*;
 use self::futures::sync::oneshot;
-pub use self::http::{HeaderMap, Request, Response};
+pub use self::http::{HeaderMap, Request, Response, StatusCode};
 use self::http::header::HeaderValue;
 use self::tokio_connect::Connect;
 use self::tokio_core::net::{TcpListener, TcpStream};

--- a/proxy/tests/support/proxy.rs
+++ b/proxy/tests/support/proxy.rs
@@ -23,6 +23,9 @@ pub struct Listening {
     pub inbound: SocketAddr,
     pub outbound: SocketAddr,
 
+    pub outbound_server: Option<server::Listening>,
+    pub inbound_server: Option<server::Listening>,
+
     shutdown: Shutdown,
 }
 
@@ -150,8 +153,8 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
         .name("support proxy".into())
         .spawn(move || {
             let _c = controller;
-            let _i = inbound;
-            let _o = outbound;
+            // let _i = inbound;
+            // let _o = outbound;
 
             let _ = running_tx.send(());
             main.run_until(rx);
@@ -165,6 +168,10 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
         control: control_addr,
         inbound: inbound_addr,
         outbound: outbound_addr,
+
+        outbound_server: outbound,
+        inbound_server: inbound,
+
         shutdown: tx,
     }
 }

--- a/proxy/tests/support/server.rs
+++ b/proxy/tests/support/server.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use support::*;
@@ -30,6 +30,13 @@ pub struct Server {
 pub struct Listening {
     pub addr: SocketAddr,
     pub(super) shutdown: Shutdown,
+    pub(super) conn_count: Arc<Mutex<usize>>,
+}
+
+impl Listening {
+    pub fn connections(&self) -> usize {
+        *self.conn_count.lock().unwrap()
+    }
 }
 
 impl Server {
@@ -81,6 +88,8 @@ impl Server {
     pub fn run(self) -> Listening {
         let (tx, rx) = shutdown_signal();
         let (addr_tx, addr_rx) = oneshot::channel();
+        let conn_count = Arc::new(Mutex::new(0));
+        let srv_conn_count = Arc::clone(&conn_count);
         ::std::thread::Builder::new().name("support server".into()).spawn(move || {
             let mut core = Core::new().unwrap();
             let reactor = core.handle();
@@ -93,7 +102,11 @@ impl Server {
 
                     Box::new(move |sock| {
                         let h1_clone = h1.clone();
+                        let srv_conn_count = Arc::clone(&srv_conn_count);
                         let conn = new_svc.new_service()
+                            .inspect(move |_| {
+                                *(srv_conn_count.lock().unwrap()) += 1;
+                            })
                             .from_err()
                             .and_then(move |svc| h1_clone.serve_connection(sock, svc))
                             .map(|_| ())
@@ -108,8 +121,12 @@ impl Server {
                         reactor.clone(),
                     );
                     Box::new(move |sock| {
+                        let srv_conn_count = Arc::clone(&srv_conn_count);
                         let conn = h2.serve(sock)
-                            .map_err(|e| println!("server h2 error: {:?}", e));
+                            .map_err(|e| println!("server h2 error: {:?}", e))
+                            .inspect(move |_| {
+                                *(srv_conn_count.lock().unwrap()) += 1;
+                            });
                         Box::new(conn)
                     })
                 },
@@ -122,7 +139,7 @@ impl Server {
             let _ = addr_tx.send(local_addr);
 
             let serve = bind.incoming()
-                .fold((srv, reactor), |(srv, reactor), (sock, _)| {
+                .fold((srv, reactor), move |(srv, reactor), (sock, _)| {
                     if let Err(e) = sock.set_nodelay(true) {
                         return Err(e);
                     }
@@ -145,6 +162,7 @@ impl Server {
         Listening {
             addr,
             shutdown: tx,
+            conn_count,
         }
     }
 }

--- a/proxy/tests/support/server.rs
+++ b/proxy/tests/support/server.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 use support::*;
@@ -30,12 +31,12 @@ pub struct Server {
 pub struct Listening {
     pub addr: SocketAddr,
     pub(super) shutdown: Shutdown,
-    pub(super) conn_count: Arc<Mutex<usize>>,
+    pub(super) conn_count: Arc<AtomicUsize>,
 }
 
 impl Listening {
     pub fn connections(&self) -> usize {
-        *self.conn_count.lock().unwrap()
+        self.conn_count.load(Ordering::Acquire)
     }
 }
 
@@ -88,7 +89,7 @@ impl Server {
     pub fn run(self) -> Listening {
         let (tx, rx) = shutdown_signal();
         let (addr_tx, addr_rx) = oneshot::channel();
-        let conn_count = Arc::new(Mutex::new(0));
+        let conn_count = Arc::new(AtomicUsize::from(0));
         let srv_conn_count = Arc::clone(&conn_count);
         ::std::thread::Builder::new().name("support server".into()).spawn(move || {
             let mut core = Core::new().unwrap();
@@ -105,7 +106,7 @@ impl Server {
                         let srv_conn_count = Arc::clone(&srv_conn_count);
                         let conn = new_svc.new_service()
                             .inspect(move |_| {
-                                *(srv_conn_count.lock().unwrap()) += 1;
+                                srv_conn_count.fetch_add(1, Ordering::Release);
                             })
                             .from_err()
                             .and_then(move |svc| h1_clone.serve_connection(sock, svc))
@@ -125,7 +126,7 @@ impl Server {
                         let conn = h2.serve(sock)
                             .map_err(|e| println!("server h2 error: {:?}", e))
                             .inspect(move |_| {
-                                *(srv_conn_count.lock().unwrap()) += 1;
+                                srv_conn_count.fetch_add(1, Ordering::Release);
                             });
                         Box::new(conn)
                     })

--- a/proxy/tests/support/tcp.rs
+++ b/proxy/tests/support/tcp.rs
@@ -2,7 +2,8 @@ use support::*;
 
 use std::collections::VecDeque;
 use std::io;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use self::futures::sync::{mpsc, oneshot};
 use self::tokio_core::net::TcpStream;
@@ -152,7 +153,7 @@ fn run_client(addr: SocketAddr) -> TcpSender {
 fn run_server(tcp: TcpServer) -> server::Listening {
     let (tx, rx) = shutdown_signal();
     let (addr_tx, addr_rx) = oneshot::channel();
-    let conn_count = Arc::new(Mutex::new(0));
+    let conn_count = Arc::new(AtomicUsize::from(0));
     let srv_conn_count = Arc::clone(&conn_count);
     ::std::thread::Builder::new().name("support server".into()).spawn(move || {
         let mut core = Core::new().unwrap();
@@ -168,7 +169,7 @@ fn run_server(tcp: TcpServer) -> server::Listening {
 
         let work = bind.incoming().for_each(move |(sock, _)| {
             let cb = accepts.pop_front().expect("no more accepts");
-            *(srv_conn_count.lock().unwrap()) += 1;
+            srv_conn_count.fetch_add(1, Ordering::Release);
             let fut = tokio_io::io::read(sock, vec![0; 1024])
                 .and_then(move |(sock, mut vec, n)| {
                     vec.truncate(n);

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -389,14 +389,66 @@ fn http1_one_connection_per_host() {
     assert_eq!(res2.version(), http::Version::HTTP_11);
     assert_eq!(inbound.connections(), 2);
 
-        // Make a request with a different Host header. This request must use a new
+    // Make a request with a different Host header. This request must use a new
     // connection.
     let res3 = client.request(client.request_builder("/")
         .version(http::Version::HTTP_11)
         .header("host", "quuuux.com"));
     assert_eq!(res3.status(), http::StatusCode::OK);
-    assert_eq!(res3
-
-    .version(), http::Version::HTTP_11);
+    assert_eq!(res3.version(), http::Version::HTTP_11);
     assert_eq!(inbound.connections(), 3);
+}
+
+#[test]
+fn http1_requests_without_host_have_unique_connections() {
+    let _ = env_logger::try_init();
+
+    let srv = server::http1().route("/", "hello").run();
+    let ctrl = controller::new()
+        .run();
+    let proxy = proxy::new().controller(ctrl).inbound(srv).run();
+
+    let client = client::http1(proxy.inbound, "foo.bar");
+
+    let inbound = &proxy.inbound_server.as_ref()
+        .expect("no inbound server!");
+
+    // Make a request with no Host header and no authority in the request path.
+    let res = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "")
+    );
+    assert_eq!(res.status(), http::StatusCode::OK);
+    assert_eq!(res.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 1);
+
+    // Another request with no Host. The proxy must open a new connection
+    // for that request.
+    let res = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "")
+    );
+    assert_eq!(res.status(), http::StatusCode::OK);
+    assert_eq!(res.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 2);
+
+    // Make a request with a host header. It must also receive its
+    // own connection.
+    let res = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "foo.bar")
+    );
+    assert_eq!(res.status(), http::StatusCode::OK);
+    assert_eq!(res.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 3);
+
+    // Another request with no Host. The proxy must open a new connection
+    // for that request.
+    let res = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "")
+    );
+    assert_eq!(res.status(), http::StatusCode::OK);
+    assert_eq!(res.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 4);
 }

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -395,6 +395,8 @@ fn http1_one_connection_per_host() {
         .version(http::Version::HTTP_11)
         .header("host", "quuuux.com"));
     assert_eq!(res3.status(), http::StatusCode::OK);
-    assert_eq!(res3.version(), http::Version::HTTP_11);
+    assert_eq!(res3
+
+    .version(), http::Version::HTTP_11);
     assert_eq!(inbound.connections(), 3);
 }

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -351,27 +351,50 @@ fn http1_one_connection_per_host() {
 
     let client = client::http1(proxy.inbound, "foo.bar");
 
-    let res1 = client.request(client.request_builder("/")
-        .version(http::Version::HTTP_11)
-        .header("host", "foo.bar")
-    );
-    assert_eq!(res1.status(), http::StatusCode::OK);
-    assert_eq!(res1.version(), http::Version::HTTP_11);
-    let res1 = client.request(client.request_builder("/")
-        .version(http::Version::HTTP_11)
-        .header("host", "foo.bar")
-    );
-    assert_eq!(res1.status(), http::StatusCode::OK);
-    assert_eq!(res1.version(), http::Version::HTTP_11);
+    let inbound = &proxy.inbound_server.as_ref()
+        .expect("no inbound server!");
 
-    let client = client::http1(proxy.inbound, "bar.baz");
+    // Make a request with the header "Host: foo.bar". After the request, the
+    // server should have seen one connection.
+    let res1 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "foo.bar")
+    );
+    assert_eq!(res1.status(), http::StatusCode::OK);
+    assert_eq!(res1.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 1);
+
+    // Another request with the same host. The proxy may reuse the connection.
+    let res1 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "foo.bar")
+    );
+    assert_eq!(res1.status(), http::StatusCode::OK);
+    assert_eq!(res1.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 1);
+
+    // Make a request with a different Host header. This request must use a new
+    // connection.
     let res2 = client.request(client.request_builder("/")
         .version(http::Version::HTTP_11)
         .header("host", "bar.baz"));
     assert_eq!(res2.status(), http::StatusCode::OK);
     assert_eq!(res2.version(), http::Version::HTTP_11);
-
-    let inbound = &proxy.inbound_server.as_ref()
-        .expect("no inbound server!");
     assert_eq!(inbound.connections(), 2);
+
+    let res2 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "bar.baz"));
+    assert_eq!(res2.status(), http::StatusCode::OK);
+    assert_eq!(res2.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 2);
+
+        // Make a request with a different Host header. This request must use a new
+    // connection.
+    let res3 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "quuuux.com"));
+    assert_eq!(res3.status(), http::StatusCode::OK);
+    assert_eq!(res3.version(), http::Version::HTTP_11);
+    assert_eq!(inbound.connections(), 3);
 }

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -339,3 +339,39 @@ fn http1_requests_without_body_doesnt_add_transfer_encoding() {
         assert_eq!(resp.status(), StatusCode::OK, "method={:?}", method);
     }
 }
+
+#[test]
+fn http1_one_connection_per_host() {
+    let _ = env_logger::try_init();
+
+    let srv = server::http1().route("/", "hello").run();
+    let ctrl = controller::new()
+        .run();
+    let proxy = proxy::new().controller(ctrl).inbound(srv).run();
+
+    let client = client::http1(proxy.inbound, "foo.bar");
+
+    let res1 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "foo.bar")
+    );
+    assert_eq!(res1.status(), http::StatusCode::OK);
+    assert_eq!(res1.version(), http::Version::HTTP_11);
+    let res1 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "foo.bar")
+    );
+    assert_eq!(res1.status(), http::StatusCode::OK);
+    assert_eq!(res1.version(), http::Version::HTTP_11);
+
+    let client = client::http1(proxy.inbound, "bar.baz");
+    let res2 = client.request(client.request_builder("/")
+        .version(http::Version::HTTP_11)
+        .header("host", "bar.baz"));
+    assert_eq!(res2.status(), http::StatusCode::OK);
+    assert_eq!(res2.version(), http::Version::HTTP_11);
+
+    let inbound = &proxy.inbound_server.as_ref()
+        .expect("no inbound server!");
+    assert_eq!(inbound.connections(), 2);
+}


### PR DESCRIPTION
This PR adds a test that if multiple Hosts correspond to the same server, HTTP/1.1 requests with different Hosts will have separate connections. This already happens as a result of Hyper's connection pooling behaviour, but the unit test will ensure that it _continues_ to do so.

This requires @seanmonstar's  `proxy-te` branch, so we should merge this branch after we merge #457