### PR TITLE
Handle ExternalName-type svcs in destination service

### DIFF
--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -1,0 +1,146 @@
+package destination
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	common "github.com/runconduit/conduit/controller/gen/common"
+	"github.com/runconduit/conduit/controller/util"
+	log "github.com/sirupsen/logrus"
+)
+
+type DnsListener interface {
+	Update(add []common.TcpAddress, remove []common.TcpAddress)
+}
+
+type DnsWatcher struct {
+	hosts map[string]*informer
+	mutex sync.Mutex
+}
+
+func NewDnsWatcher() *DnsWatcher {
+	return &DnsWatcher{
+		hosts: make(map[string]*informer),
+	}
+}
+
+func (w *DnsWatcher) Subscribe(host string, listener DnsListener) error {
+	log.Printf("Establishing dns watch on host %s", host)
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	informer, ok := w.hosts[host]
+	if !ok {
+		informer = newInformer(host)
+		go informer.run()
+		w.hosts[host] = informer
+	}
+
+	informer.add(listener)
+
+	return nil
+}
+
+func (w *DnsWatcher) Unsubscribe(host string, listener DnsListener) error {
+	log.Printf("Stopping dns watch on host %s", host)
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	informer, ok := w.hosts[host]
+	if !ok {
+		return fmt.Errorf("Cannot unsubscribe from %s: not subscribed", host)
+	}
+
+	informer.mutex.Lock()
+	defer informer.mutex.Unlock()
+
+	for i, v := range informer.listeners {
+		if v == listener {
+			num := len(informer.listeners)
+			if num == 1 {
+				// last subscription being removed, close me up!
+				informer.stopCh <- struct{}{}
+				delete(w.hosts, host)
+				return nil
+			} else if num == i+1 {
+				informer.listeners = informer.listeners[:i]
+			} else {
+				informer.listeners = append(informer.listeners[:i], informer.listeners[i+1:]...)
+			}
+		}
+	}
+
+	return nil
+}
+
+type informer struct {
+	host      string
+	addresses []common.TcpAddress
+	listeners []DnsListener
+	mutex     sync.Mutex
+	stopCh    chan struct{}
+}
+
+func newInformer(host string) *informer {
+	i := &informer{
+		host:      host,
+		addresses: make([]common.TcpAddress, 0),
+		listeners: make([]DnsListener, 0),
+		stopCh:    make(chan struct{}),
+	}
+
+	return i
+}
+
+func (i *informer) run() {
+	ticker := time.NewTicker(10 * time.Second)
+	for {
+		addrs, err := net.LookupHost(i.host)
+		if err != nil {
+			log.Printf("host lookup failed [%s]: %s", i.host, err)
+		} else {
+			addresses := make([]common.TcpAddress, 0)
+			for _, addr := range addrs {
+				ip, err := util.ParseIPV4(addr)
+				if err != nil {
+					log.Printf("%s is not a valid IP address", addr)
+				} else {
+					address := common.TcpAddress{Ip: ip, Port: 80}
+					addresses = append(addresses, address)
+				}
+			}
+			i.update(addresses)
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-i.stopCh:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (i *informer) update(newAddresses []common.TcpAddress) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	add, remove := util.DiffAddresses(i.addresses, newAddresses)
+	for _, listener := range i.listeners {
+		listener.Update(add, remove)
+	}
+	i.addresses = newAddresses
+}
+
+func (i *informer) add(listener DnsListener) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	listener.Update(i.addresses, nil)
+	i.listeners = append(i.listeners, listener)
+}

--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var refreshInterval = 10 * time.Second
+
 type DnsListener interface {
 	Update(add []common.TcpAddress, remove []common.TcpAddress)
 }
@@ -97,7 +99,7 @@ func newInformer(host string) *informer {
 }
 
 func (i *informer) run() {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(refreshInterval)
 	for {
 		addrs, err := net.LookupHost(i.host)
 		if err != nil {

--- a/controller/destination/dns_test.go
+++ b/controller/destination/dns_test.go
@@ -1,0 +1,77 @@
+package destination
+
+import (
+	"testing"
+
+	common "github.com/runconduit/conduit/controller/gen/common"
+	"github.com/runconduit/conduit/controller/util"
+	"github.com/stretchr/testify/assert"
+)
+
+type testListener struct {
+	t       *testing.T
+	added   []common.TcpAddress
+	removed []common.TcpAddress
+}
+
+func (me testListener) Update(add []common.TcpAddress, remove []common.TcpAddress) {
+	assert.Equal(me.t, len(me.added), len(add))
+	assert.Equal(me.t, len(me.removed), len(remove))
+
+	for i, addr := range add {
+		assert.Equal(me.t, me.added[i], addr)
+	}
+
+	for i, addr := range remove {
+		assert.Equal(me.t, me.removed[i], addr)
+	}
+}
+
+func TestInformerUpdate(t *testing.T) {
+	informer := newInformer("example.com")
+	listener := &testListener{
+		t:       t,
+		added:   nil,
+		removed: nil,
+	}
+
+	informer.add(listener)
+
+	updates := []struct {
+		update  []common.TcpAddress
+		added   []common.TcpAddress
+		removed []common.TcpAddress
+	}{
+		{
+			update:  []common.TcpAddress{strToTcp("10.0.0.1"), strToTcp("10.0.0.2")},
+			added:   []common.TcpAddress{strToTcp("10.0.0.1"), strToTcp("10.0.0.2")},
+			removed: nil,
+		},
+		{
+			update:  []common.TcpAddress{strToTcp("10.0.0.1"), strToTcp("10.0.0.2")},
+			added:   nil,
+			removed: nil,
+		},
+		{
+			update:  []common.TcpAddress{strToTcp("10.0.0.2"), strToTcp("10.0.0.3")},
+			added:   []common.TcpAddress{strToTcp("10.0.0.3")},
+			removed: []common.TcpAddress{strToTcp("10.0.0.1")},
+		},
+		{
+			update:  nil,
+			added:   nil,
+			removed: []common.TcpAddress{strToTcp("10.0.0.2"), strToTcp("10.0.0.3")},
+		},
+	}
+
+	for _, tc := range updates {
+		listener.added = tc.added
+		listener.removed = tc.removed
+		informer.update(tc.update)
+	}
+}
+
+func strToTcp(addr string) common.TcpAddress {
+	ip, _ := util.ParseIPV4(addr)
+	return common.TcpAddress{Ip: ip, Port: 80}
+}

--- a/controller/destination/server_test.go
+++ b/controller/destination/server_test.go
@@ -53,7 +53,7 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d: (%s, %s)", i, tc.k8sDNSZone, tc.host), func(t *testing.T) {
-			srv, err := newServer(tc.k8sDNSZone, nil)
+			srv, err := newServer(tc.k8sDNSZone, nil, nil)
 			assert.Nil(t, err)
 			result, err := srv.localKubernetesServiceIdFromDNSName(tc.host)
 			assert.Equal(t, tc.result, result)

--- a/controller/util/util.go
+++ b/controller/util/util.go
@@ -59,3 +59,36 @@ func decodeIPToOctets(ip uint32) [4]uint8 {
 		uint8(ip & 255),
 	}
 }
+
+func DiffAddresses(oldAddrs []pb.TcpAddress, newAddrs []pb.TcpAddress) ([]pb.TcpAddress, []pb.TcpAddress) {
+	addSet := make(map[string]pb.TcpAddress)
+	removeSet := make(map[string]pb.TcpAddress)
+
+	for _, addr := range newAddrs {
+		key := AddressToString(&addr)
+		addSet[key] = addr
+	}
+
+	for _, addr := range oldAddrs {
+		key := AddressToString(&addr)
+		delete(addSet, key)
+		removeSet[key] = addr
+	}
+
+	for _, addr := range newAddrs {
+		key := AddressToString(&addr)
+		delete(removeSet, key)
+	}
+
+	add := make([]pb.TcpAddress, 0)
+	for _, addr := range addSet {
+		add = append(add, addr)
+	}
+
+	remove := make([]pb.TcpAddress, 0)
+	for _, addr := range removeSet {
+		remove = append(remove, addr)
+	}
+
+	return add, remove
+}


### PR DESCRIPTION
This branch modifies the destination service to properly handle services of type "ExternalName", by using DNS to resolve the addresses of the name that's represented by the service. The original DNS implementation was written by @seanmonstar in #360. Relates to #155.