### PR TITLE
Enforce that requests are mapped to connections for each Host: header values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "h2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -389,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.11.20"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,7 +1269,7 @@ dependencies = [
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)" = "1545100ac38f42f338c63bff290d7285b7117021a564b3c0f34e8d57cf81451f"
+"checksum hyper 0.11.21 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a77dea5dccbf32ba4e9ddd7d80a5a3bb3b9f1f3835e18daf5dbea6bee0efbf"
 "checksum indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7164c96d6e18ccc3ce43f3dedac996c21a220670a106c275b96ad92110401362"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.1"
 h2 = "0.1"
 http = "0.1"
 httparse = "1.2"
-hyper = { version = "0.11.20", default-features = false, features = ["compat"] }
+hyper = { version = "0.11.21", default-features = false, features = ["compat"] }
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "0.4.1"

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use tower::Service;
 
 use std::{error, fmt, mem};
+use std::convert::AsRef;
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
@@ -40,7 +41,7 @@ pub trait Recognize {
                             Error = Self::Error>;
 
     /// Obtains a Key for a request.
-    fn recognize(&self, req: &Self::Request) -> Option<Self::Key>;
+    fn recognize(&self, req: &Self::Request) -> Option<Cachability<Self::Key>>;
 
     /// Return a `Service` to handle requests from the provided authority.
     ///
@@ -50,6 +51,13 @@ pub trait Recognize {
 }
 
 pub struct Single<S>(Option<S>);
+
+/// Whether or not the service to a given key may be cached.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Cachability<T> {
+    Reusable(T),
+    Unique(T),
+}
 
 #[derive(Debug)]
 pub enum Error<T, U> {
@@ -123,13 +131,22 @@ where T: Recognize,
             let service;
 
             if let Some(key) = inner.recognize.recognize(&request) {
-                if let Some(s) = inner.routes.get_mut(&key) {
+                // Is the bound service for that key reusable?
+                let cached = if let Cachability::Reusable(ref key) = key {
+                    // The key is reusable --- look in the cache.
+                    inner.routes.get_mut(key)
+                } else {
+                    // If the key is not reuseable, then the cached service is
+                    // always None.
+                    None
+                };
+                if let Some(s) = cached {
                     // The service for the authority is already cached
                     service = s;
                 } else {
                     // The authority does not match an existing route, try to
                     // recognize it.
-                    match inner.recognize.bind_service(&key) {
+                    match inner.recognize.bind_service(key.as_ref()) {
                         Ok(s) => {
                             // A new service has been matched. Set the outer
                             // variables and jump out o the loop
@@ -156,8 +173,10 @@ where T: Recognize,
         // First, route the request to the new service
         let response = new_service.call(request);
 
-        // Now, cache the new service
-        inner.routes.insert(new_key, new_service);
+        // Now, cache the new service'
+        if let Cachability::Reusable(new_key) = new_key {
+            inner.routes.insert(new_key, new_service);
+        }
 
         // And finally, return the response
         ResponseFuture { state: State::Inner(response) }
@@ -190,8 +209,8 @@ impl<S: Service> Recognize for Single<S> {
     type RouteError = ();
     type Service = S;
 
-    fn recognize(&self, _: &Self::Request) -> Option<Self::Key> {
-        Some(())
+    fn recognize(&self, _: &Self::Request) -> Option<Cachability<Self::Key>> {
+        Some(Cachability::Reusable(()))
     }
 
     fn bind_service(&mut self, _: &Self::Key) -> Result<S, Self::RouteError> {
@@ -259,6 +278,17 @@ where
             Error::Inner(_) => "inner service error",
             Error::Route(_) => "route recognition failed",
             Error::NotRecognized => "route not recognized",
+        }
+    }
+}
+
+// ===== impl Cachability=====
+
+impl<T> AsRef<T> for Cachability<T> {
+    fn as_ref(&self) -> &T {
+        match *self {
+            Cachability::Reusable(ref key) => key,
+            Cachability::Unique(ref key) => key,
         }
     }
 }

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -41,7 +41,7 @@ pub trait Recognize {
                             Error = Self::Error>;
 
     /// Obtains a Key for a request.
-    fn recognize(&self, req: &Self::Request) -> Option<Cachability<Self::Key>>;
+    fn recognize(&self, req: &Self::Request) -> Option<Uses<Self::Key>>;
 
     /// Return a `Service` to handle requests from the provided authority.
     ///
@@ -54,9 +54,9 @@ pub struct Single<S>(Option<S>);
 
 /// Whether or not the service to a given key may be cached.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Cachability<T> {
+pub enum Uses<T> {
     Reusable(T),
-    Unique(T),
+    SingleUse(T),
 }
 
 #[derive(Debug)]
@@ -132,7 +132,7 @@ where T: Recognize,
 
             if let Some(key) = inner.recognize.recognize(&request) {
                 // Is the bound service for that key reusable?
-                let cached = if let Cachability::Reusable(ref key) = key {
+                let cached = if let Uses::Reusable(ref key) = key {
                     // The key is reusable --- look in the cache.
                     inner.routes.get_mut(key)
                 } else {
@@ -174,7 +174,7 @@ where T: Recognize,
         let response = new_service.call(request);
 
         // Now, cache the new service'
-        if let Cachability::Reusable(new_key) = new_key {
+        if let Uses::Reusable(new_key) = new_key {
             inner.routes.insert(new_key, new_service);
         }
 
@@ -209,8 +209,8 @@ impl<S: Service> Recognize for Single<S> {
     type RouteError = ();
     type Service = S;
 
-    fn recognize(&self, _: &Self::Request) -> Option<Cachability<Self::Key>> {
-        Some(Cachability::Reusable(()))
+    fn recognize(&self, _: &Self::Request) -> Option<Uses<Self::Key>> {
+        Some(Uses::Reusable(()))
     }
 
     fn bind_service(&mut self, _: &Self::Key) -> Result<S, Self::RouteError> {
@@ -282,13 +282,13 @@ where
     }
 }
 
-// ===== impl Cachability=====
+// ===== impl Uses=====
 
-impl<T> AsRef<T> for Cachability<T> {
+impl<T> AsRef<T> for Uses<T> {
     fn as_ref(&self) -> &T {
         match *self {
-            Cachability::Reusable(ref key) => key,
-            Cachability::Unique(ref key) => key,
+            Uses::Reusable(ref key) => key,
+            Uses::SingleUse(ref key) => key,
         }
     }
 }

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -15,7 +15,7 @@ use tower_h2;
 use tower_reconnect::Reconnect;
 
 use conduit_proxy_controller_grpc;
-use conduit_proxy_router::Uses;
+use conduit_proxy_router::Reuse;
 use control;
 use ctx;
 use telemetry::{self, sensor};
@@ -202,7 +202,8 @@ where
             &client_ctx
         );
 
-        // Rewrite the HTTP/1 URI, if necessary.
+        // Rewrite the HTTP/1 URI, if the authorities in the Host header
+        // and request URI are not in agreement, or are not present.
         let proxy = ReconstructUri::new(sensors);
 
         // Automatically perform reconnects if the connection fails.
@@ -341,11 +342,11 @@ impl Protocol {
         }
     }
 
-    pub fn into_key<T>(self, key: T) -> Uses<(T, Protocol)> {
+    pub fn into_key<T>(self, key: T) -> Reuse<(T, Protocol)> {
         if self.is_cachable() {
-            Uses::Reusable((key, self))
+            Reuse::Reusable((key, self))
         } else {
-            Uses::SingleUse((key, self))
+            Reuse::SingleUse((key, self))
         }
     }
 }

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -13,7 +13,7 @@ use tower_h2;
 use tower_reconnect::Reconnect;
 
 use conduit_proxy_controller_grpc;
-use conduit_proxy_router::Cachability;
+use conduit_proxy_router::Uses;
 use control;
 use ctx;
 use telemetry::{self, sensor};
@@ -263,11 +263,11 @@ impl Protocol {
         }
     }
 
-    pub fn into_key<T>(self, key: T) -> Cachability<(T, Protocol)> {
+    pub fn into_key<T>(self, key: T) -> Uses<(T, Protocol)> {
         if self.is_cachable() {
-            Cachability::Reusable((key, self))
+            Uses::Reusable((key, self))
         } else {
-            Cachability::Unique((key, self))
+            Uses::SingleUse((key, self))
         }
     }
 }

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -14,6 +14,7 @@ use tower_reconnect::Reconnect;
 use conduit_proxy_controller_grpc;
 use control;
 use ctx;
+use fully_qualified_authority::FullyQualifiedAuthority;
 use telemetry::{self, sensor};
 use transparency::{self, HttpBody};
 use transport;
@@ -40,10 +41,17 @@ pub struct BindProtocol<C, B> {
 }
 
 /// Mark whether to use HTTP/1 or HTTP/2
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Protocol {
-    Http1,
+    Http1(Host),
     Http2
+}
+
+/// Mark whether to use HTTP/1 or HTTP/2
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Host {
+    LocalSvc(FullyQualifiedAuthority),
+    External(http::uri::Authority),
 }
 
 pub type Service<B> = Reconnect<NewHttp<B>>;
@@ -83,6 +91,12 @@ impl Error for BufferSpawnError {
     fn cause(&self) -> Option<&Error> { None }
 }
 
+
+pub fn request_orig_dst<B>(req: &http::Request<B>) -> Option<SocketAddr> {
+    req.extensions()
+        .get::<Arc<ctx::transport::Server>>().map(AsRef::as_ref)
+        .and_then(ctx::transport::Server::orig_dst_if_not_local)
+}
 
 impl<B> Bind<(), B> {
     pub fn new(executor: Handle) -> Self {
@@ -150,7 +164,7 @@ impl<B> Bind<Arc<ctx::Proxy>, B>
 where
     B: tower_h2::Body + 'static,
 {
-    pub fn bind_service(&self, addr: &SocketAddr, protocol: Protocol) -> Service<B> {
+    pub fn bind_service(&self, addr: &SocketAddr, protocol: &Protocol) -> Service<B> {
         trace!("bind_service addr={}, protocol={:?}", addr, protocol);
         let client_ctx = ctx::transport::Client::new(
             &self.ctx,
@@ -202,7 +216,46 @@ where
     type BindError = ();
 
     fn bind(&self, addr: &SocketAddr) -> Result<Self::Service, Self::BindError> {
-        Ok(self.bind.bind_service(addr, self.protocol))
+        Ok(self.bind.bind_service(addr, &self.protocol))
     }
 }
 
+// ===== impl Protocol =====
+
+
+impl Protocol {
+    pub fn from_req<B>(req: &http::Request<B>,
+                       fqa: Option<&FullyQualifiedAuthority>)
+                       -> Option<Protocol>
+    {
+        if req.version() == http::Version::HTTP_2 {
+            return Some(Protocol::Http2)
+        }
+
+        let host = fqa
+            .map(Host::from)
+            .or_else(|| req
+                .uri()
+                .authority_part()
+                .map(Host::from)
+            );
+
+
+        Some(Protocol::Http1(host?))
+    }
+}
+
+// ===== impl Host =====
+
+
+impl<'a> From<&'a FullyQualifiedAuthority> for Host {
+    fn from(fqa: &'a FullyQualifiedAuthority) -> Self {
+        Host::LocalSvc(fqa.clone())
+    }
+}
+
+impl<'a> From<&'a http::uri::Authority> for Host {
+    fn from(authority: &'a http::uri::Authority) -> Self {
+        Host::External(authority.clone())
+    }
+}

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -1,11 +1,12 @@
 use std::error::Error;
 use std::fmt;
+use std::cmp;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
-use http;
+use http::{self, header, uri};
 use tokio_core::reactor::Handle;
 use tower;
 use tower_h2;
@@ -14,7 +15,6 @@ use tower_reconnect::Reconnect;
 use conduit_proxy_controller_grpc;
 use control;
 use ctx;
-use fully_qualified_authority::FullyQualifiedAuthority;
 use telemetry::{self, sensor};
 use transparency::{self, HttpBody};
 use transport;
@@ -40,18 +40,21 @@ pub struct BindProtocol<C, B> {
     protocol: Protocol,
 }
 
-/// Mark whether to use HTTP/1 or HTTP/2
+/// Protocol portion of the `Recognize` key for a request.
+///
+/// This marks whether to use HTTP/2 or HTTP/1.x for a request. In
+/// the case of HTTP/1.x requests, it also stores a "host" key to ensure
+/// that each host receives its own connection.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Protocol {
     Http1(Host),
     Http2
 }
 
-/// Mark whether to use HTTP/1 or HTTP/2
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash)]
 pub enum Host {
-    LocalSvc(FullyQualifiedAuthority),
-    External(http::uri::Authority),
+    Authority(uri::Authority),
+    NoAuthority,
 }
 
 pub type Service<B> = Reconnect<NewHttp<B>>;
@@ -223,39 +226,43 @@ where
 // ===== impl Protocol =====
 
 
-impl Protocol {
-    pub fn from_req<B>(req: &http::Request<B>,
-                       fqa: Option<&FullyQualifiedAuthority>)
-                       -> Option<Protocol>
-    {
+impl<'a, B> From<&'a http::Request<B>> for Protocol {
+    fn from(req: &'a http::Request<B>) -> Protocol {
         if req.version() == http::Version::HTTP_2 {
-            return Some(Protocol::Http2)
+            return Protocol::Http2
         }
 
-        let host = fqa
-            .map(Host::from)
-            .or_else(|| req
-                .uri()
-                .authority_part()
-                .map(Host::from)
-            );
+        // If the request has an authority part, use that as the host part of
+        // the key for an HTTP/1.x request.
+        let host = req.uri().authority_part()
+            .cloned()
+            .or_else(|| {
+                // No authority part in the request URI, so try and use the
+                // Host: header value, if one is present and it can be parsed
+                // as an Authority.
+                    req.headers().get(header::HOST)
+                        .and_then(|header| {
+                            header.to_str().ok()
+                                .and_then(|header|
+                                    header.parse::<uri::Authority>().ok())
+                        })
+                })
+            .map(Host::Authority)
+            .unwrap_or_else(|| Host::NoAuthority);
 
-
-        Some(Protocol::Http1(host?))
+        Protocol::Http1(host)
     }
 }
 
 // ===== impl Host =====
 
-
-impl<'a> From<&'a FullyQualifiedAuthority> for Host {
-    fn from(fqa: &'a FullyQualifiedAuthority) -> Self {
-        Host::LocalSvc(fqa.clone())
-    }
-}
-
-impl<'a> From<&'a http::uri::Authority> for Host {
-    fn from(authority: &'a http::uri::Authority) -> Self {
-        Host::External(authority.clone())
+impl cmp::PartialEq for Host {
+    // Override the equality rules for `Host` so that the `NoAuthority` case
+    // is *never* equal, even to other `NoAuthority` values.
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (&Host::Authority(ref a), &Host::Authority(ref b)) => a == b,
+            _ => false,
+        }
     }
 }

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
-use http::{self, header, uri};
+use http::{self, uri};
 use tokio_core::reactor::Handle;
 use tower;
 use tower_h2;
@@ -234,20 +234,10 @@ impl<'a, B> From<&'a http::Request<B>> for Protocol {
 
         // If the request has an authority part, use that as the host part of
         // the key for an HTTP/1.x request.
-        let host = req.uri().authority_part()
-                .cloned()
-                .or_else(|| {
-                    // No authority part in the request URI, so try and use the
-                    // Host: header value, if one is present and it can be parsed
-                    // as an Authority.
-                        req.headers().get(header::HOST)
-                            .and_then(|header| {
-                                header.to_str().ok()
-                                    .and_then(|header|
-                                        header.parse::<uri::Authority>().ok())
-                            })
-                    })
-                .map(Host::Authority)
+        let host = req.uri()
+            .authority_part()
+            .cloned()
+            .map(Host::Authority)
             .unwrap_or_else(|| Host::NoAuthority);
 
         Protocol::Http1(host)

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt;
-use std::cmp;
 use std::default::Default;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
@@ -298,6 +297,11 @@ where
     }
 
     fn call(&mut self, mut request: S::Request) -> Self::Future {
+        if request.version() == http::Version::HTTP_2 {
+            // skip `reconstruct_uri` entirely if the request is HTTP/2.
+            return Either::A(self.inner.call(request));
+        }
+
         if let Err(_) = h1::reconstruct_uri(&mut request) {
             let res = http::Response::builder()
                 .status(http::StatusCode::BAD_REQUEST)

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -312,9 +312,9 @@ where
 // ===== impl Protocol =====
 
 
-impl<'a, B> From<&'a http::Request<B>> for Protocol {
-    fn from(req: &'a http::Request<B>) -> Protocol {
+impl Protocol {
 
+    pub fn detect<B>(req: &http::Request<B>) -> Self {
         if req.version() == http::Version::HTTP_2 {
             return Protocol::Http2
         }
@@ -329,9 +329,6 @@ impl<'a, B> From<&'a http::Request<B>> for Protocol {
 
         Protocol::Http1(host)
     }
-}
-
-impl Protocol {
 
     pub fn is_cachable(&self) -> bool {
         match *self {

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -94,13 +94,6 @@ impl Error for BufferSpawnError {
     fn cause(&self) -> Option<&Error> { None }
 }
 
-
-pub fn request_orig_dst<B>(req: &http::Request<B>) -> Option<SocketAddr> {
-    req.extensions()
-        .get::<Arc<ctx::transport::Server>>().map(AsRef::as_ref)
-        .and_then(ctx::transport::Server::orig_dst_if_not_local)
-}
-
 impl<B> Bind<(), B> {
     pub fn new(executor: Handle) -> Self {
         Self {

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -13,10 +13,11 @@ use tower_h2;
 use tower_reconnect::Reconnect;
 
 use conduit_proxy_controller_grpc;
+use conduit_proxy_router::Cachability;
 use control;
 use ctx;
 use telemetry::{self, sensor};
-use transparency::{self, HttpBody};
+use transparency::{self, HttpBody, h1};
 use transport;
 
 /// Binds a `Service` from a `SocketAddr`.
@@ -51,7 +52,7 @@ pub enum Protocol {
     Http2
 }
 
-#[derive(Clone, Debug, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Host {
     Authority(uri::Authority),
     NoAuthority,
@@ -225,37 +226,48 @@ impl<'a, B> From<&'a http::Request<B>> for Protocol {
             return Protocol::Http2
         }
 
+        if req.extensions().get::<h1::AuthorityRewriting>() ==
+            Some(&h1::AuthorityRewriting::SoOriginalDst)
+        {
+            return Protocol::Http1(Host::NoAuthority);
+        }
+
         // If the request has an authority part, use that as the host part of
         // the key for an HTTP/1.x request.
         let host = req.uri().authority_part()
-            .cloned()
-            .or_else(|| {
-                // No authority part in the request URI, so try and use the
-                // Host: header value, if one is present and it can be parsed
-                // as an Authority.
-                    req.headers().get(header::HOST)
-                        .and_then(|header| {
-                            header.to_str().ok()
-                                .and_then(|header|
-                                    header.parse::<uri::Authority>().ok())
-                        })
-                })
-            .map(Host::Authority)
+                .cloned()
+                .or_else(|| {
+                    // No authority part in the request URI, so try and use the
+                    // Host: header value, if one is present and it can be parsed
+                    // as an Authority.
+                        req.headers().get(header::HOST)
+                            .and_then(|header| {
+                                header.to_str().ok()
+                                    .and_then(|header|
+                                        header.parse::<uri::Authority>().ok())
+                            })
+                    })
+                .map(Host::Authority)
             .unwrap_or_else(|| Host::NoAuthority);
 
         Protocol::Http1(host)
     }
 }
 
-// ===== impl Host =====
+impl Protocol {
 
-impl cmp::PartialEq for Host {
-    // Override the equality rules for `Host` so that the `NoAuthority` case
-    // is *never* equal, even to other `NoAuthority` values.
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (&Host::Authority(ref a), &Host::Authority(ref b)) => a == b,
+    pub fn is_cachable(&self) -> bool {
+        match *self {
+            Protocol::Http2 | Protocol::Http1(Host::Authority(_)) => true,
             _ => false,
+        }
+    }
+
+    pub fn into_key<T>(self, key: T) -> Cachability<(T, Protocol)> {
+        if self.is_cachable() {
+            Cachability::Reusable((key, self))
+        } else {
+            Cachability::Unique((key, self))
         }
     }
 }

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -55,7 +55,7 @@ where
             })
             .or_else(|| self.default_addr);
 
-        let proto = bind::Protocol::from(req);
+        let proto = bind::Protocol::detect(req);
 
         let key = key.map(move|addr| proto.into_key(addr));
         trace!("recognize key={:?}", key);

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -6,7 +6,7 @@ use tower;
 use tower_buffer::{self, Buffer};
 use tower_in_flight_limit::{self, InFlightLimit};
 use tower_h2;
-use conduit_proxy_router::{Uses, Recognize};
+use conduit_proxy_router::{Reuse, Recognize};
 
 use bind;
 use ctx;
@@ -46,7 +46,7 @@ where
     type RouteError = bind::BufferSpawnError;
     type Service = InFlightLimit<Buffer<bind::Service<B>>>;
 
-    fn recognize(&self, req: &Self::Request) -> Option<Uses<Self::Key>> {
+    fn recognize(&self, req: &Self::Request) -> Option<Reuse<Self::Key>> {
         let key = req.extensions()
             .get::<Arc<ctx::transport::Server>>()
             .and_then(|ctx| {

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -6,7 +6,7 @@ use tower;
 use tower_buffer::{self, Buffer};
 use tower_in_flight_limit::{self, InFlightLimit};
 use tower_h2;
-use conduit_proxy_router::{Cachability, Recognize};
+use conduit_proxy_router::{Uses, Recognize};
 
 use bind;
 use ctx;
@@ -46,7 +46,7 @@ where
     type RouteError = bind::BufferSpawnError;
     type Service = InFlightLimit<Buffer<bind::Service<B>>>;
 
-    fn recognize(&self, req: &Self::Request) -> Option<Cachability<Self::Key>> {
+    fn recognize(&self, req: &Self::Request) -> Option<Uses<Self::Key>> {
         let key = req.extensions()
             .get::<Arc<ctx::transport::Server>>()
             .and_then(|ctx| {

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clone_on_ref_ptr))]
 #![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
-// #![deny(warnings)]
+#![deny(warnings)]
 
 extern crate abstract_ns;
 extern crate bytes;

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clone_on_ref_ptr))]
 #![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
-#![deny(warnings)]
+// #![deny(warnings)]
 
 extern crate abstract_ns;
 extern crate bytes;

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -12,7 +12,7 @@ use tower_buffer::Buffer;
 use tower_discover::{Change, Discover};
 use tower_in_flight_limit::InFlightLimit;
 use tower_h2;
-use conduit_proxy_router::{Cachability, Recognize};
+use conduit_proxy_router::{Uses, Recognize};
 
 use bind::{self, Bind, Protocol};
 use control::{self, discovery};
@@ -87,7 +87,7 @@ where
         choose::PowerOfTwoChoices<rand::ThreadRng>
     >>>>;
 
-    fn recognize(&self, req: &Self::Request) -> Option<Cachability<Self::Key>> {
+    fn recognize(&self, req: &Self::Request) -> Option<Uses<Self::Key>> {
         let proto = bind::Protocol::from(req);
 
         let local = req.uri().authority_part().map(|authority| {

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -88,7 +88,7 @@ where
     >>>>;
 
     fn recognize(&self, req: &Self::Request) -> Option<Uses<Self::Key>> {
-        let proto = bind::Protocol::from(req);
+        let proto = bind::Protocol::detect(req);
 
         let local = req.uri().authority_part().map(|authority| {
             FullyQualifiedAuthority::normalize(

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -58,6 +58,21 @@ pub enum Destination {
     External(SocketAddr),
 }
 
+impl From<FullyQualifiedAuthority> for Destination {
+    #[inline]
+    fn from(authority: FullyQualifiedAuthority) -> Self {
+        Destination::LocalSvc(authority)
+    }
+}
+
+impl From<SocketAddr> for Destination {
+    #[inline]
+    fn from(addr: SocketAddr) -> Self {
+        Destination::External(addr)
+    }
+}
+
+
 impl<B> Recognize for Outbound<B>
 where
     B: tower_h2::Body + 'static,
@@ -80,6 +95,8 @@ where
                 self.default_zone.as_ref().map(|s| s.as_ref()))
 
         });
+
+        let proto = bind::Protocol::from_req(req, local.as_ref())?;
 
         // If we can't fully qualify the authority as a local service,
         // and there is no original dst, then we have nothing! In that
@@ -123,18 +140,19 @@ where
         &mut self,
         key: &Self::Key,
     ) -> Result<Self::Service, Self::RouteError> {
-        let &(ref dest, protocol) = key;
+        let &(ref dest, ref protocol) = key;
         debug!("building outbound {:?} client to {:?}", protocol, dest);
 
         let resolve = match *dest {
             Destination::LocalSvc(ref authority) => {
                 Discovery::LocalSvc(self.discovery.resolve(
                     authority,
-                    self.bind.clone().with_protocol(protocol),
+                    self.bind.clone().with_protocol(protocol.clone()),
                 ))
             },
             Destination::External(addr) => {
-                Discovery::External(Some((addr, self.bind.clone().with_protocol(protocol))))
+                Discovery::External(Some((addr, self.bind.clone()
+                    .with_protocol(protocol.clone()))))
             }
         };
 

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -12,7 +12,7 @@ use tower_buffer::Buffer;
 use tower_discover::{Change, Discover};
 use tower_in_flight_limit::InFlightLimit;
 use tower_h2;
-use conduit_proxy_router::{Uses, Recognize};
+use conduit_proxy_router::{Reuse, Recognize};
 
 use bind::{self, Bind, Protocol};
 use control::{self, discovery};
@@ -87,7 +87,7 @@ where
         choose::PowerOfTwoChoices<rand::ThreadRng>
     >>>>;
 
-    fn recognize(&self, req: &Self::Request) -> Option<Uses<Self::Key>> {
+    fn recognize(&self, req: &Self::Request) -> Option<Reuse<Self::Key>> {
         let proto = bind::Protocol::detect(req);
 
         let local = req.uri().authority_part().map(|authority| {

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -96,8 +96,6 @@ where
 
         });
 
-        let proto = bind::Protocol::from_req(req, local.as_ref())?;
-
         // If we can't fully qualify the authority as a local service,
         // and there is no original dst, then we have nothing! In that
         // case, we return `None`, which results an "unrecognized" error.
@@ -119,10 +117,7 @@ where
             Destination::External(orig_dst?)
         };
 
-        let proto = match req.version() {
-            http::Version::HTTP_2 => Protocol::Http2,
-            _ => Protocol::Http1,
-        };
+        let proto = bind::Protocol::from(req);
 
         Some((dest, proto))
     }

--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -73,9 +73,13 @@ where
     B: tower_h2::Body + 'static,
 {
     /// Create a new `Client`, bound to a specific protocol (HTTP/1 or HTTP/2).
-    pub fn new(protocol: bind::Protocol, connect: C, executor: Handle) -> Self {
-        match protocol {
-            bind::Protocol::Http1 => {
+    pub fn new(protocol: &bind::Protocol,
+               connect: C,
+               executor: Handle)
+               -> Self
+    {
+        match *protocol {
+            bind::Protocol::Http1(_) => {
                 let h1 = hyper::Client::configure()
                     .connector(HyperConnect::new(connect))
                     .body()

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -217,11 +217,6 @@ where
         let mut req: http::Request<hyper::Body> = req.into();
         req.extensions_mut().insert(self.srv_ctx.clone());
 
-        if let Err(()) = h1::reconstruct_uri(&mut req) {
-            let res = hyper::Response::new()
-                .with_status(hyper::BadRequest);
-            return Either::B(future::ok(res));
-        }
         h1::strip_connection_headers(req.headers_mut());
 
         let req = req.map(|b| HttpBody::Http1(b));

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -6,16 +6,7 @@ use bytes::BytesMut;
 use http;
 use http::header::{HeaderValue, HOST};
 use http::uri::{Authority, Parts, Scheme, Uri};
-
 use ctx::transport::{Server as ServerCtx};
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AuthorityRewriting {
-    // Unmodified,
-    // HostFromAuthority,
-    // AuthorityFromHost,
-    SoOriginalDst,
-}
 
 pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     // RFC7230#section-5.4
@@ -35,20 +26,9 @@ pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     }
 
     // try to parse the Host header
-    if let Some(host) = req.headers().get(HOST).cloned() {
-        let auth = host.to_str()
-            .ok()
-            .and_then(|s| {
-                if s.is_empty() {
-                    None
-                } else {
-                    s.parse::<Authority>().ok()
-                }
-            });
-        if let Some(auth) = auth {
-            set_authority(req.uri_mut(), auth);
-            return Ok(());
-        }
+    if let Some(auth) = authority_from_host(&req) {
+        set_authority(req.uri_mut(), auth);
+        return Ok(());
     }
 
     // last resort is to use the so_original_dst
@@ -64,16 +44,26 @@ pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
             .expect("socket address is valid authority");
         set_authority(req.uri_mut(), auth);
 
-        // note that the request originally had no authority.
-        let _ = req.extensions_mut()
-            .insert(AuthorityRewriting::SoOriginalDst);
-
         return Ok(());
     }
 
     Err(())
 }
 
+/// Returns an Authority from a request's Host header.
+pub fn authority_from_host<B>(req: &http::Request<B>) -> Option<Authority> {
+    req.headers().get(HOST).cloned()
+        .and_then(|host| {
+             host.to_str().ok()
+                .and_then(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        s.parse::<Authority>().ok()
+                    }
+                })
+        })
+}
 fn set_authority(uri: &mut http::Uri, auth: Authority) {
     let mut parts = Parts::from(mem::replace(uri, Uri::default()));
     parts.scheme = Some(Scheme::HTTP);

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -64,6 +64,7 @@ pub fn authority_from_host<B>(req: &http::Request<B>) -> Option<Authority> {
                 })
         })
 }
+
 fn set_authority(uri: &mut http::Uri, auth: Authority) {
     let mut parts = Parts::from(mem::replace(uri, Uri::default()));
     parts.scheme = Some(Scheme::HTTP);

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -9,6 +9,14 @@ use http::uri::{Authority, Parts, Scheme, Uri};
 
 use ctx::transport::{Server as ServerCtx};
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum AuthorityRewriting {
+    // Unmodified,
+    // HostFromAuthority,
+    // AuthorityFromHost,
+    SoOriginalDst,
+}
+
 pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     // RFC7230#section-5.4
     // If an absolute-form uri is received, it must replace
@@ -55,6 +63,10 @@ pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
         let auth = Authority::from_shared(bytes)
             .expect("socket address is valid authority");
         set_authority(req.uri_mut(), auth);
+
+        // note that the request originally had no authority.
+        let _ = req.extensions_mut()
+            .insert(AuthorityRewriting::SoOriginalDst);
 
         return Ok(());
     }

--- a/proxy/src/transparency/mod.rs
+++ b/proxy/src/transparency/mod.rs
@@ -1,6 +1,6 @@
 mod client;
 mod glue;
-mod h1;
+pub mod h1;
 mod protocol;
 mod server;
 mod tcp;

--- a/proxy/tests/support/proxy.rs
+++ b/proxy/tests/support/proxy.rs
@@ -153,8 +153,6 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
         .name("support proxy".into())
         .spawn(move || {
             let _c = controller;
-            // let _i = inbound;
-            // let _o = outbound;
 
             let _ = running_tx.send(());
             main.run_until(rx);

--- a/proxy/tests/support/proxy.rs
+++ b/proxy/tests/support/proxy.rs
@@ -23,6 +23,9 @@ pub struct Listening {
     pub inbound: SocketAddr,
     pub outbound: SocketAddr,
 
+    pub outbound_server: Option<server::Listening>,
+    pub inbound_server: Option<server::Listening>,
+
     shutdown: Shutdown,
 }
 
@@ -150,8 +153,8 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
         .name("support proxy".into())
         .spawn(move || {
             let _c = controller;
-            let _i = inbound;
-            let _o = outbound;
+            // let _i = inbound;
+            // let _o = outbound;
 
             let _ = running_tx.send(());
             main.run_until(rx);
@@ -165,6 +168,10 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
         control: control_addr,
         inbound: inbound_addr,
         outbound: outbound_addr,
+
+        outbound_server: outbound,
+        inbound_server: inbound,
+
         shutdown: tx,
     }
 }

--- a/proxy/tests/support/server.rs
+++ b/proxy/tests/support/server.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use support::*;
@@ -30,6 +30,13 @@ pub struct Server {
 pub struct Listening {
     pub addr: SocketAddr,
     pub(super) shutdown: Shutdown,
+    pub(super) conn_count: Arc<Mutex<usize>>,
+}
+
+impl Listening {
+    pub fn connections(&self) -> usize {
+        *self.conn_count.lock().unwrap()
+    }
 }
 
 impl Server {
@@ -81,6 +88,8 @@ impl Server {
     pub fn run(self) -> Listening {
         let (tx, rx) = shutdown_signal();
         let (addr_tx, addr_rx) = oneshot::channel();
+        let conn_count = Arc::new(Mutex::new(0));
+        let srv_conn_count = Arc::clone(&conn_count);
         ::std::thread::Builder::new().name("support server".into()).spawn(move || {
             let mut core = Core::new().unwrap();
             let reactor = core.handle();
@@ -93,7 +102,11 @@ impl Server {
 
                     Box::new(move |sock| {
                         let h1_clone = h1.clone();
+                        let srv_conn_count = Arc::clone(&srv_conn_count);
                         let conn = new_svc.new_service()
+                            .inspect(move |_| {
+                                *(srv_conn_count.lock().unwrap()) += 1;
+                            })
                             .from_err()
                             .and_then(move |svc| h1_clone.serve_connection(sock, svc))
                             .map(|_| ())
@@ -108,8 +121,12 @@ impl Server {
                         reactor.clone(),
                     );
                     Box::new(move |sock| {
+                        let srv_conn_count = Arc::clone(&srv_conn_count);
                         let conn = h2.serve(sock)
-                            .map_err(|e| println!("server h2 error: {:?}", e));
+                            .map_err(|e| println!("server h2 error: {:?}", e))
+                            .inspect(move |_| {
+                                *(srv_conn_count.lock().unwrap()) += 1;
+                            });
                         Box::new(conn)
                     })
                 },
@@ -122,7 +139,7 @@ impl Server {
             let _ = addr_tx.send(local_addr);
 
             let serve = bind.incoming()
-                .fold((srv, reactor), |(srv, reactor), (sock, _)| {
+                .fold((srv, reactor), move |(srv, reactor), (sock, _)| {
                     if let Err(e) = sock.set_nodelay(true) {
                         return Err(e);
                     }
@@ -145,6 +162,7 @@ impl Server {
         Listening {
             addr,
             shutdown: tx,
+            conn_count,
         }
     }
 }

--- a/proxy/tests/support/server.rs
+++ b/proxy/tests/support/server.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 use support::*;
@@ -30,12 +31,12 @@ pub struct Server {
 pub struct Listening {
     pub addr: SocketAddr,
     pub(super) shutdown: Shutdown,
-    pub(super) conn_count: Arc<Mutex<usize>>,
+    pub(super) conn_count: Arc<AtomicUsize>,
 }
 
 impl Listening {
     pub fn connections(&self) -> usize {
-        *self.conn_count.lock().unwrap()
+        self.conn_count.load(Ordering::Acquire)
     }
 }
 
@@ -88,7 +89,7 @@ impl Server {
     pub fn run(self) -> Listening {
         let (tx, rx) = shutdown_signal();
         let (addr_tx, addr_rx) = oneshot::channel();
-        let conn_count = Arc::new(Mutex::new(0));
+        let conn_count = Arc::new(AtomicUsize::from(0));
         let srv_conn_count = Arc::clone(&conn_count);
         ::std::thread::Builder::new().name("support server".into()).spawn(move || {
             let mut core = Core::new().unwrap();
@@ -105,7 +106,7 @@ impl Server {
                         let srv_conn_count = Arc::clone(&srv_conn_count);
                         let conn = new_svc.new_service()
                             .inspect(move |_| {
-                                *(srv_conn_count.lock().unwrap()) += 1;
+                                srv_conn_count.fetch_add(1, Ordering::Release);
                             })
                             .from_err()
                             .and_then(move |svc| h1_clone.serve_connection(sock, svc))
@@ -125,7 +126,7 @@ impl Server {
                         let conn = h2.serve(sock)
                             .map_err(|e| println!("server h2 error: {:?}", e))
                             .inspect(move |_| {
-                                *(srv_conn_count.lock().unwrap()) += 1;
+                                srv_conn_count.fetch_add(1, Ordering::Release);
                             });
                         Box::new(conn)
                     })

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -357,7 +357,7 @@ fn http1_requests_without_body_doesnt_add_transfer_encoding() {
             } else {
                 StatusCode::OK
             };
-            let mut res = Response::new(Default::default());
+            let mut res = Response::new("".into());
             *res.status_mut() = status;
             res
         })

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -661,6 +661,8 @@ fn http1_one_connection_per_host() {
         .version(http::Version::HTTP_11)
         .header("host", "quuuux.com"));
     assert_eq!(res3.status(), http::StatusCode::OK);
-    assert_eq!(res3.version(), http::Version::HTTP_11);
+    assert_eq!(res3
+
+    .version(), http::Version::HTTP_11);
     assert_eq!(inbound.connections(), 3);
 }


### PR DESCRIPTION
This ended up being a much bigger branch than anticipated --- sorry for so much code to review!

This PR ensures that the mapping of requests to outbound connections is segregated by `Host:` header values. In most cases, the desired behavior is provided by Hyper's connection pooling. However, Hyper does not handle the case where a request had no `Host:` header and the request URI had no authority part, and the request was routed based on the SO_ORIGINAL_DST in the desired manner. We would like these requests to each have their own outbound connection, but Hyper will reuse the same connection for such requests. 

Therefore, I have modified `conduit_proxy_router::Recognize` to allow implementations of `Recognize` to indicate whether the service for a given key can be cached, and to only cache the service when it is marked as cachable. I've also changed the `reconstruct_uri` function, which rewrites HTTP/1 requests, to mark when a request had no authority and no `Host:` header, and the authority was rewritten to be the request's ORIGINAL_DST. When this is the case, the `Recognize` implementations for `Inbound` and `Outbound` will mark these requests as non-cachable.

I've also added unit tests ensuring that A, connections are created per `Host:` header, and B, that requests with no `Host:` header each create a new connection. The first test passes without any additional changes, but the second only passes on this branch. The tests were added in PR #489, but this branch supersedes that branch.

Fixes #415. Closes #489.