### PR TITLE
Exclude telemetry generated by the control plane when requesting depl…

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -145,6 +145,7 @@ spec:
         - -metrics-addr=:9995
         - -telemetry-addr=127.0.0.1:8087
         - -tap-addr=127.0.0.1:8088
+        - -controller-namespace=conduit
         - -log-level=info
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -146,6 +146,7 @@ spec:
         - -metrics-addr=:9995
         - -telemetry-addr=127.0.0.1:8087
         - -tap-addr=127.0.0.1:8088
+        - -controller-namespace=Namespace
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -152,6 +152,7 @@ spec:
         - "-metrics-addr=:9995"
         - "-telemetry-addr=127.0.0.1:8087"
         - "-tap-addr=127.0.0.1:8088"
+        - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"
       - name: destination
         ports:

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -20,8 +20,9 @@ import (
 
 type (
 	grpcServer struct {
-		telemetryClient telemPb.TelemetryClient
-		tapClient       tapPb.TapClient
+		telemetryClient     telemPb.TelemetryClient
+		tapClient           tapPb.TapClient
+		controllerNamespace string
 	}
 
 	successRate struct {
@@ -86,8 +87,8 @@ var (
 	emptyMetadata = pb.MetricMetadata{}
 )
 
-func newGrpcServer(telemetryClient telemPb.TelemetryClient, tapClient tapPb.TapClient) *grpcServer {
-	return &grpcServer{telemetryClient: telemetryClient, tapClient: tapClient}
+func newGrpcServer(telemetryClient telemPb.TelemetryClient, tapClient tapPb.TapClient, controllerNamespace string) *grpcServer {
+	return &grpcServer{telemetryClient: telemetryClient, tapClient: tapClient, controllerNamespace: controllerNamespace}
 }
 
 func (s *grpcServer) Stat(ctx context.Context, req *pb.MetricRequest) (*pb.MetricResponse, error) {
@@ -356,7 +357,7 @@ func (s *grpcServer) latency(ctx context.Context, req *pb.MetricRequest) ([]pb.M
 }
 
 func (s *grpcServer) queryCount(ctx context.Context, req *pb.MetricRequest, rawQuery, sumBy string) queryResult {
-	query, err := formatQuery(rawQuery, req, sumBy)
+	query, err := formatQuery(rawQuery, req, sumBy, []string{s.controllerNamespace})
 	if err != nil {
 		return queryResult{res: telemPb.QueryResponse{}, err: err}
 	}
@@ -372,7 +373,7 @@ func (s *grpcServer) queryCount(ctx context.Context, req *pb.MetricRequest, rawQ
 func (s *grpcServer) queryLatency(ctx context.Context, req *pb.MetricRequest) (map[pb.HistogramLabel]telemPb.QueryResponse, error) {
 	queryRsps := make(map[pb.HistogramLabel]telemPb.QueryResponse)
 
-	query, err := formatQuery(latencyQuery, req, "le")
+	query, err := formatQuery(latencyQuery, req, "le", []string{s.controllerNamespace})
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +445,7 @@ func reqToQueryReq(req *pb.MetricRequest, query string) (telemPb.QueryRequest, e
 	return queryReq, nil
 }
 
-func formatQuery(query string, req *pb.MetricRequest, sumBy string) (string, error) {
+func formatQuery(query string, req *pb.MetricRequest, sumBy string, filterExclusions []string) (string, error) {
 	sumLabels := make([]string, 0)
 	filterLabels := make([]string, 0)
 
@@ -470,6 +471,11 @@ func formatQuery(query string, req *pb.MetricRequest, sumBy string) (string, err
 			filterLabels = append(filterLabels, fmt.Sprintf("%s=\"%s\"", jobLabel, metadata.Component))
 			sumLabels = append(sumLabels, jobLabel)
 		}
+	}
+
+	for _, exclusion := range filterExclusions {
+		filterLabels = append(filterLabels, fmt.Sprintf("%s!~\"%s\"", targetDeployLabel, fmt.Sprintf("%s/.*", exclusion)))
+		filterLabels = append(filterLabels, fmt.Sprintf("%s!~\"%s\"", sourceDeployLabel, fmt.Sprintf("%s/.*", exclusion)))
 	}
 
 	return fmt.Sprintf(

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -214,11 +214,11 @@ func TestStat(t *testing.T) {
 
 func TestFormatQueryExclusions(t *testing.T) {
 	testCases := []struct {
-		input          []string
+		input          string
 		expectedOutput string
 	}{
-		{[]string{"conduit"}, `target_deployment!~"conduit/.*",source_deployment!~"conduit/.*"`},
-		{[]string{}, ""},
+		{"conduit", `target_deployment!~"conduit/(web|controller|prometheus|grafana)",source_deployment!~"conduit/(web|controller|prometheus|grafana)"`},
+		{"", ""},
 	}
 
 	for i, tc := range testCases {

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -192,9 +192,9 @@ func fullUrlPathFor(method string) string {
 	return ApiRoot + ApiPrefix + method
 }
 
-func NewServer(addr string, telemetryClient telemPb.TelemetryClient, tapClient tapPb.TapClient) *http.Server {
+func NewServer(addr string, telemetryClient telemPb.TelemetryClient, tapClient tapPb.TapClient, controllerNamespace string) *http.Server {
 	baseHandler := &handler{
-		grpcServer: newGrpcServer(telemetryClient, tapClient),
+		grpcServer: newGrpcServer(telemetryClient, tapClient, controllerNamespace),
 	}
 
 	instrumentedHandler := util.WithTelemetry(baseHandler)

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -21,6 +21,7 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9995", "address to serve scrapable metrics on")
 	telemetryAddr := flag.String("telemetry-addr", ":8087", "address of telemetry service")
 	tapAddr := flag.String("tap-addr", ":8088", "address of tap service")
+	controllerNamespace := flag.String("controller-namespace", "conduit", "namespace in which Conduit is installed")
 	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
 	printVersion := version.VersionFlag()
 	flag.Parse()
@@ -49,7 +50,7 @@ func main() {
 	}
 	defer tapConn.Close()
 
-	server := public.NewServer(*addr, telemetryClient, tapClient)
+	server := public.NewServer(*addr, telemetryClient, tapClient, *controllerNamespace)
 
 	go func() {
 		log.Infof("starting HTTP server on %+v", *addr)


### PR DESCRIPTION
When the conduit proxy is injected into the controller pod, we observe controller pod proxy stats show up as an "outbound" deployment for an unrelated upstream deployment. This may cause confusion when monitoring deployments in the service mesh.

This PR filters out this "misleading" stat in the public api whenever the dashboard requests metric information for a specific deployment.

fixes #370 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>