### PR TITLE
Add --expected-version flag for conduit check command

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -128,7 +128,7 @@ bin/conduit version
 
 # validate installation
 kubectl --namespace=conduit get all
-bin/conduit check
+bin/conduit check --expected-version $(bin/root-tag)
 
 # view conduit dashboard
 bin/conduit dashboard

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -20,6 +20,8 @@ const (
 	versionCheckURL = "https://versioncheck.conduit.io/version.json"
 )
 
+var versionOverride string
+
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check your Conduit installation for potential problems.",
@@ -49,7 +51,7 @@ problems were found.`,
 		}
 
 		grpcStatusChecker := healthcheck.NewGrpcStatusChecker(public.ConduitApiSubsystemName, conduitApi)
-		versionStatusChecker := version.NewVersionStatusChecker(versionCheckURL, conduitApi)
+		versionStatusChecker := version.NewVersionStatusChecker(versionCheckURL, versionOverride, conduitApi)
 
 		err = checkStatus(os.Stdout, kubeApi, grpcStatusChecker, versionStatusChecker)
 		if err != nil {
@@ -117,4 +119,5 @@ func statusCheckResultWasError(w io.Writer) error {
 func init() {
 	RootCmd.AddCommand(checkCmd)
 	addControlPlaneNetworkingArgs(checkCmd)
+	checkCmd.PersistentFlags().StringVar(&versionOverride, "expected-version", "", "Overrides the version used when checking if Conduit is running the latest version (mostly for testing)")
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -21,7 +21,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "v0.3.0"
 		mockPublicApi := createMockPublicApi("v0.3.0")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		expectedName := version.VersionSubsystemName
@@ -54,7 +54,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "v0.1.1"
 		mockPublicApi := createMockPublicApi("v0.3.0")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		expectedStatus := healthcheckPb.CheckStatus_FAIL
@@ -72,7 +72,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "v0.3.0"
 		mockPublicApi := createMockPublicApi("v0.1.1")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		expectedStatus := healthcheckPb.CheckStatus_FAIL
@@ -83,6 +83,21 @@ func TestVersionCheck(t *testing.T) {
 		expectedMessage := "is running version v0.1.1 but the latest version is v0.3.0"
 		if checks[1].FriendlyMessageToUser != expectedMessage {
 			t.Fatalf("Expecting message to be [%s], got [%s]", expectedMessage, checks[1].FriendlyMessageToUser)
+		}
+	})
+
+	t.Run("Supports overriding the expected version", func(t *testing.T) {
+		version.Version = "customversion"
+		mockPublicApi := createMockPublicApi("customversion")
+
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "customversion", mockPublicApi)
+		checks := versionStatusChecker.SelfCheck()
+
+		for _, check := range checks {
+			if check.Status != healthcheckPb.CheckStatus_OK {
+				t.Errorf("Expecting check for [%s] to be [%s], got [%s]",
+					check.CheckDescription, healthcheckPb.CheckStatus_OK, check.Status)
+			}
 		}
 	})
 }


### PR DESCRIPTION
The `conduit check` command was updated in #460 to check that the CLI and controller are both running the latest version of conduit (thanks, @ahume!). This works for stable versions, but the check command fails when testing unreleased versions of conduit. When using an unreleased version, I'd like the ability to override the expected version via a command line flag.

Running the command on this branch without adding the flag produces the same result as on master:

```
$ ./bin/go-run cli/main.go check
kubernetes-api: can initialize the client.......................................[ok]
kubernetes-api: can query the Kubernetes API....................................[ok]
kubernetes-api: is running the minimum Kubernetes API version...................[ok]
conduit-api: can query the Conduit API..........................................[ok]
conduit-api[telemetry]: control plane can use telemetry service.................[ok]
conduit-version: cli is up-to-date..............................................[FAIL]  -- is running version git-0ced3787 but the latest version is v0.3.0
conduit-version: control plane is up-to-date....................................[FAIL]  -- is running version git-0ced3787 but the latest version is v0.3.0

Status check results are [FAIL]
```

Whereas running the command with the `--expected-version` flag set produces:

```
$ ./bin/go-run cli/main.go check --expected-version git-0ced3787
kubernetes-api: can initialize the client.......................................[ok]
kubernetes-api: can query the Kubernetes API....................................[ok]
kubernetes-api: is running the minimum Kubernetes API version...................[ok]
conduit-api: can query the Conduit API..........................................[ok]
conduit-api[telemetry]: control plane can use telemetry service.................[ok]
conduit-version: cli is up-to-date..............................................[ok]
conduit-version: control plane is up-to-date....................................[ok]

Status check results are [ok]
```

I've also added a 10-second timeout on the call to versioncheck.conduit.io as part of this branch.