### PR TITLE
Install: Don't install buoyantio/kubectl into the prometheus pod.

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -447,13 +447,6 @@ spec:
         - mountPath: /etc/prometheus
           name: prometheus-config
           readOnly: true
-      - args:
-        - proxy
-        - -p
-        - "8001"
-        image: buoyantio/kubectl:v1.6.2
-        name: kubectl
-        resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -450,13 +450,6 @@ spec:
         - mountPath: /etc/prometheus
           name: prometheus-config
           readOnly: true
-      - args:
-        - proxy
-        - -p
-        - "8001"
-        image: buoyantio/kubectl:v1.6.2
-        name: kubectl
-        resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -330,11 +330,6 @@ spec:
         - "--storage.tsdb.retention=6h"
         - "--config.file=/etc/prometheus/prometheus.yml"
 
-      # TODO remove/replace?
-      - name: kubectl
-        image: buoyantio/kubectl:v1.6.2
-        args: ["proxy", "-p", "8001"]
-
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
In the initial review for this code (preceding the creation of the
runconduit/conduit repository), it was noted that this container is not
actually used, so this is actually dead code.

Further, this container actualy causes a minor problem, as it doesn't
implement any retry logic, thus it will sometimes often cause errors to
be logged. See
https://github.com/runconduit/conduit/issues/496#issuecomment-370105328.

Further, this is a "buoyantio/" branded container. IF we actually need
such a container then it should be a Conduit-branded branded container.

See https://github.com/runconduit/conduit/issues/478 for additional
context.

Signed-off-by: Brian Smith <brian@briansmith.org>