### PR TITLE
 Retry k8s watch endpoints on error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -627,6 +627,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e3a8afa4366f2a0d708b17872eedc54622fdb42dcd751d1bbebd60a571a016a0"
+  inputs-digest = "9888b29b2129861a72b0b4fa725a2f9687de3bede92963ddf7296fa64ce70d7f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:d45c01b4 as golang
+FROM gcr.io/runconduit/go-deps:5a44df7f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:d45c01b4 as golang
+FROM gcr.io/runconduit/go-deps:5a44df7f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen

--- a/controller/k8s/endpoints.go
+++ b/controller/k8s/endpoints.go
@@ -136,8 +136,11 @@ type informer struct {
 }
 
 func (i *informer) run() error {
-	go i.informer.Run(i.stopCh)
-	return newWatcher(i.informer, endpointResource, nil, i.stopCh).run()
+	initializer := func(stopCh <-chan struct{}) (err error) {
+		i.informer.Run(stopCh)
+		return nil
+	}
+	return newWatcher(i.informer, endpointResource, initializer, i.stopCh).run()
 }
 
 func (i *informer) stop() {

--- a/controller/k8s/endpoints.go
+++ b/controller/k8s/endpoints.go
@@ -137,7 +137,7 @@ type informer struct {
 
 func (i *informer) run() error {
 	go i.informer.Run(i.stopCh)
-	return newWatcher(i.informer, endpointResource).run()
+	return newWatcher(i.informer, endpointResource, nil, i.stopCh).run()
 }
 
 func (i *informer) stop() {

--- a/controller/k8s/endpoints.go
+++ b/controller/k8s/endpoints.go
@@ -136,7 +136,7 @@ type informer struct {
 }
 
 func (i *informer) run() error {
-	initializer := func(stopCh <-chan struct{}) (err error) {
+	initializer := func(stopCh <-chan struct{}) error {
 		i.informer.Run(stopCh)
 		return nil
 	}

--- a/controller/k8s/pods.go
+++ b/controller/k8s/pods.go
@@ -46,7 +46,7 @@ func NewPodIndex(clientset *kubernetes.Clientset, index cache.IndexFunc) (*PodIn
 
 func (p *PodIndex) Run() error {
 	go p.reflector.ListAndWatch(p.stopCh)
-	return newWatcher(p.reflector, podResource).run()
+	return newWatcher(p.reflector, podResource, p.reflector.ListAndWatch, p.stopCh).run()
 }
 
 func (p *PodIndex) Stop() {

--- a/controller/k8s/pods.go
+++ b/controller/k8s/pods.go
@@ -45,7 +45,6 @@ func NewPodIndex(clientset *kubernetes.Clientset, index cache.IndexFunc) (*PodIn
 }
 
 func (p *PodIndex) Run() error {
-	go p.reflector.ListAndWatch(p.stopCh)
 	return newWatcher(p.reflector, podResource, p.reflector.ListAndWatch, p.stopCh).run()
 }
 

--- a/controller/k8s/replicasets.go
+++ b/controller/k8s/replicasets.go
@@ -46,7 +46,6 @@ func NewReplicaSetStore(clientset *kubernetes.Clientset) (*ReplicaSetStore, erro
 }
 
 func (p *ReplicaSetStore) Run() error {
-	go p.reflector.ListAndWatch(p.stopCh)
 	return newWatcher(p.reflector, replicaSetResource, p.reflector.ListAndWatch, p.stopCh).run()
 }
 

--- a/controller/k8s/replicasets.go
+++ b/controller/k8s/replicasets.go
@@ -47,7 +47,7 @@ func NewReplicaSetStore(clientset *kubernetes.Clientset) (*ReplicaSetStore, erro
 
 func (p *ReplicaSetStore) Run() error {
 	go p.reflector.ListAndWatch(p.stopCh)
-	return newWatcher(p.reflector, replicaSetResource).run()
+	return newWatcher(p.reflector, replicaSetResource, p.reflector.ListAndWatch, p.stopCh).run()
 }
 
 func (p *ReplicaSetStore) Stop() {

--- a/controller/k8s/watcher.go
+++ b/controller/k8s/watcher.go
@@ -41,17 +41,15 @@ func (w *watcher) run() error {
 	initialized := make(chan struct{}, 1)
 	defer close(initialized)
 
-	if w.watchInit != nil {
-		go func() {
-			for {
-				err := w.watchInit(w.stopCh)
-				if err != nil {
-					log.Errorf("Error establishing watch in [%s watcher]. Retrying", w.resourceType)
-				}
-				time.Sleep(1 * time.Second)
+	go func() {
+		for {
+			err := w.watchInit(w.stopCh)
+			if err != nil {
+				log.Errorf("Error establishing watch in [%s watcher]. Retrying", w.resourceType)
 			}
-		}()
-	}
+			time.Sleep(1 * time.Second)
+		}
+	}()
 
 	go func() {
 		for {

--- a/controller/k8s/watcher.go
+++ b/controller/k8s/watcher.go
@@ -2,9 +2,8 @@ package k8s
 
 import (
 	"fmt"
-	"time"
-
 	"math"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/controller/k8s/watcher_test.go
+++ b/controller/k8s/watcher_test.go
@@ -12,6 +12,10 @@ type resourceToWatchImpl struct {
 	lastSyncResourceVersion string
 }
 
+func watchInitializerImpl(_ <-chan struct{}) error {
+	return nil
+}
+
 func (w *resourceToWatchImpl) LastSyncResourceVersion() string {
 	w.RLock()
 	defer w.RUnlock()
@@ -28,7 +32,7 @@ func TestWatcher(t *testing.T) {
 	t.Run("Returns nil if the resource initializes in the time limit", func(t *testing.T) {
 		resource := &resourceToWatchImpl{}
 		stopCh := make(chan struct{}, 1)
-		watcher := newWatcher(resource, "resourcestring", nil, stopCh)
+		watcher := newWatcher(resource, "resourcestring", watchInitializerImpl, stopCh)
 		watcher.timeout = 2 * time.Second
 		go func() {
 			time.Sleep(1 * time.Second)
@@ -43,7 +47,7 @@ func TestWatcher(t *testing.T) {
 	t.Run("Returns error if the watcher does not initialize in the time limit", func(t *testing.T) {
 		resource := &resourceToWatchImpl{}
 		stopCh := make(chan struct{}, 1)
-		watcher := newWatcher(resource, "resourcestring", nil, stopCh)
+		watcher := newWatcher(resource, "resourcestring", watchInitializerImpl, stopCh)
 		watcher.timeout = 2 * time.Second
 		go func() {
 			time.Sleep(3 * time.Second)

--- a/controller/k8s/watcher_test.go
+++ b/controller/k8s/watcher_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -58,31 +59,24 @@ func TestWatcher(t *testing.T) {
 			t.Fatalf("Expected error, got nil")
 		}
 	})
-	t.Run("Returns error if the watcher does not initialize in the time limit", func(t *testing.T) {
+	t.Run("Retries establishing the watch if it fails to establish the first time", func(t *testing.T) {
 		resource := &resourceToWatchImpl{}
-		var lock sync.RWMutex
-		didRetry := false
+		watchInitNumOfCalls := int32(0)
+		expectedWatchInitNumOfCalls := int32(4)
 
 		testWatchInit := func(stop <-chan struct{}) error {
-			lock.Lock()
-			defer lock.Unlock()
-			didRetry = true
+			atomic.AddInt32(&watchInitNumOfCalls, 1)
 			return errors.New("mock error")
 		}
 		stopCh := make(chan struct{}, 1)
 		watcher := newWatcher(resource, "resourcestring", testWatchInit, stopCh)
-		watcher.timeout = 1 * time.Second
-		go func() {
-			time.Sleep(3 * time.Second)
-			resource.SetLastSyncResourceVersion("synced")
-		}()
+		watcher.timeout = 500 * time.Millisecond
 		_ = watcher.run()
 		select {
 		case <-stopCh:
-			lock.Lock()
-			defer lock.Unlock()
-			if !didRetry {
-				t.Fatalf("watchInitializer failed to retry")
+			calls := atomic.LoadInt32(&watchInitNumOfCalls)
+			if calls != expectedWatchInitNumOfCalls {
+				t.Fatalf("expected [%d] calls but observed [%d]", expectedWatchInitNumOfCalls, watchInitNumOfCalls)
 			}
 
 		}

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:d45c01b4 as golang
+FROM gcr.io/runconduit/go-deps:5a44df7f as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:d45c01b4 as golang
+FROM gcr.io/runconduit/go-deps:5a44df7f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Shortly after conduit is installed in k8s environment. The control plane component that establishes a watch endpoint with k8s run in to networking issues during proxy initialization. During failure, each watcher fails to retry its connection to k8s watch endpoint which leads to timeouts and eventually, multiple controller pod restarts. 

This PR adds retry logic to each "watch" enabled package.

fixes #478 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>