### PR TITLE
Remove mention of Grafana from BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -144,10 +144,6 @@ bin/conduit stat deployments
 
 # view a live pipeline of requests
 bin/conduit tap deploy emojivoto/voting
-
-# view grafana dashboard
-kubectl -n conduit port-forward $(kubectl --namespace=conduit get po --selector=app=grafana -o jsonpath='{.items[*].metadata.name}') 3000:3000
-open http://localhost:3000
 ```
 
 ## Go


### PR DESCRIPTION
Grafana dashboards will not be available for the 0.3.1 release, but BUILD.md
provides an (incorrect) way to access Grafana.

Remove mention of Grafana for now. Re-add when dashboards are integrated
into Conduit.

Part of #420.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>