### PR TITLE
Refactor `ReconstructUri` into a `Service` inside of `Bind`

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use futures::{future, Future, Poll};
 use futures::future::{Either, Map};
-use http::{self, header,uri};
+use http::{self, header, uri};
 use tokio_core::reactor::Handle;
 use tower;
 use tower_h2;
@@ -301,6 +301,24 @@ where
 
 impl<'a, B> From<&'a http::Request<B>> for Protocol {
     fn from(req: &'a http::Request<B>) -> Protocol {
+        // No authority part in the request URI, so try and use the
+        // Host: header value, if one is present and it can be parsed
+        // as an Authority.
+        //
+        // (this is its own function to make the map below less deeply nested)
+        let authority_from_host_header = || -> Option<uri::Authority> {
+            req.headers().get(header::HOST)
+                .and_then(|header| {
+                    header.to_str().ok()
+                        .and_then(|header|
+                            if header != "" {
+                                header.parse::<uri::Authority>().ok()
+                            } else {
+                                None
+                            })
+                })
+        };
+
         if req.version() == http::Version::HTTP_2 {
             return Protocol::Http2
         }
@@ -309,17 +327,7 @@ impl<'a, B> From<&'a http::Request<B>> for Protocol {
         // the key for an HTTP/1.x request.
         let host = req.uri().authority_part()
             .cloned()
-            .or_else(|| {
-                // No authority part in the request URI, so try and use the
-                // Host: header value, if one is present and it can be parsed
-                // as an Authority.
-                    req.headers().get(header::HOST)
-                        .and_then(|header| {
-                            header.to_str().ok()
-                                .and_then(|header|
-                                    header.parse::<uri::Authority>().ok())
-                        })
-                })
+            .or_else(authority_from_host_header)
             .map(Host::Authority)
             .unwrap_or_else(|| Host::NoAuthority);
 

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -217,11 +217,6 @@ where
         let mut req: http::Request<hyper::Body> = req.into();
         req.extensions_mut().insert(self.srv_ctx.clone());
 
-        if let Err(()) = h1::reconstruct_uri(&mut req) {
-            let res = hyper::Response::new()
-                .with_status(hyper::BadRequest);
-            return Either::B(future::ok(res));
-        }
         h1::strip_connection_headers(req.headers_mut());
 
         let req = req.map(|b| HttpBody::Http1(b));

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -26,20 +26,9 @@ pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     }
 
     // try to parse the Host header
-    if let Some(host) = req.headers().get(HOST).cloned() {
-        let auth = host.to_str()
-            .ok()
-            .and_then(|s| {
-                if s.is_empty() {
-                    None
-                } else {
-                    s.parse::<Authority>().ok()
-                }
-            });
-        if let Some(auth) = auth {
-            set_authority(req.uri_mut(), auth);
-            return Ok(());
-        }
+    if let Some(auth) = authority_from_host(&req) {
+        set_authority(req.uri_mut(), auth);
+        return Ok(());
     }
 
     // last resort is to use the so_original_dst
@@ -61,6 +50,20 @@ pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     Err(())
 }
 
+/// Returns an Authority from a request's Host header.
+pub fn authority_from_host<B>(req: &http::Request<B>) -> Option<Authority> {
+    req.headers().get(HOST).cloned()
+        .and_then(|host| {
+             host.to_str().ok()
+                .and_then(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        s.parse::<Authority>().ok()
+                    }
+                })
+        })
+}
 fn set_authority(uri: &mut http::Uri, auth: Authority) {
     let mut parts = Parts::from(mem::replace(uri, Uri::default()));
     parts.scheme = Some(Scheme::HTTP);

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -8,15 +8,6 @@ use http::header::{HeaderValue, HOST};
 use http::uri::{Authority, Parts, Scheme, Uri};
 use ctx::transport::{Server as ServerCtx};
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AuthorityRewriting {
-    // Unmodified,
-    // HostFromAuthority,
-    // AuthorityFromHost,
-    SoOriginalDst,
-}
-
-
 pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     // RFC7230#section-5.4
     // If an absolute-form uri is received, it must replace
@@ -63,10 +54,6 @@ pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
         let auth = Authority::from_shared(bytes)
             .expect("socket address is valid authority");
         set_authority(req.uri_mut(), auth);
-
-        // note that the request originally had no authority.
-        let _ = req.extensions_mut()
-            .insert(AuthorityRewriting::SoOriginalDst);
 
         return Ok(());
     }

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -6,7 +6,6 @@ use bytes::BytesMut;
 use http;
 use http::header::{HeaderValue, HOST};
 use http::uri::{Authority, Parts, Scheme, Uri};
-
 use ctx::transport::{Server as ServerCtx};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -16,6 +15,7 @@ pub enum AuthorityRewriting {
     // AuthorityFromHost,
     SoOriginalDst,
 }
+
 
 pub fn reconstruct_uri<B>(req: &mut http::Request<B>) -> Result<(), ()> {
     // RFC7230#section-5.4


### PR DESCRIPTION
This PR replaces the call to `reconstruct_uri` in `transparency::glue::HyperServerSvc` into its own middleware `Service`, which wraps the `NewService` returned in `Bind`. This way, we can make routing decisions based on whether or not the request had an authority, but the `sensors` still see the reconstructed request URI. This allows the kludgy `AuthorityRewriting` extension that was previously used in #492 to be removed, and just seems like an overall better factoring.