### PR TITLE
Disable Grafana update check

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -700,6 +700,9 @@ data:
     [auth.basic]
     enabled = false
 
+    [analytics]
+    check_for_updates = false
+
   datasources.yaml: |-
     apiVersion: 1
     datasources:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -704,6 +704,9 @@ data:
     [auth.basic]
     enabled = false
 
+    [analytics]
+    check_for_updates = false
+
   datasources.yaml: |-
     apiVersion: 1
     datasources:

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -466,6 +466,9 @@ data:
     [auth.basic]
     enabled = false
 
+    [analytics]
+    check_for_updates = false
+
   datasources.yaml: |-
     apiVersion: 1
     datasources:


### PR DESCRIPTION
Grafana by default calls out to grafana.com to check for updates. As
user's of Conduit do not have direct control over updating Grafana
directly, this update check is not needed.

Disable Grafana's update check via grafana.ini.

This is also a workaround for #155, root cause of #519.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>