### PR TITLE
Set -logtostderr flag on controller components

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -147,6 +147,7 @@ spec:
         - -tap-addr=127.0.0.1:8088
         - -controller-namespace=conduit
         - -log-level=info
+        - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
         name: public-api
@@ -161,6 +162,7 @@ spec:
         - -addr=:8089
         - -metrics-addr=:9999
         - -log-level=info
+        - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
         name: destination
@@ -177,6 +179,7 @@ spec:
         - -destination-addr=:8089
         - -telemetry-addr=:8087
         - -log-level=info
+        - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
         name: proxy-api
@@ -191,6 +194,7 @@ spec:
         - -addr=:8088
         - -metrics-addr=:9998
         - -log-level=info
+        - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
         name: tap
@@ -207,6 +211,7 @@ spec:
         - -ignore-namespaces=kube-system
         - -prometheus-url=http://prometheus.conduit.svc.cluster.local:9090
         - -log-level=info
+        - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
         name: telemetry

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -148,6 +148,7 @@ spec:
         - -tap-addr=127.0.0.1:8088
         - -controller-namespace=Namespace
         - -log-level=ControllerLogLevel
+        - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         name: public-api
@@ -162,6 +163,7 @@ spec:
         - -addr=:8089
         - -metrics-addr=:9999
         - -log-level=ControllerLogLevel
+        - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         name: destination
@@ -178,6 +180,7 @@ spec:
         - -destination-addr=:8089
         - -telemetry-addr=:8087
         - -log-level=ControllerLogLevel
+        - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         name: proxy-api
@@ -192,6 +195,7 @@ spec:
         - -addr=:8088
         - -metrics-addr=:9998
         - -log-level=ControllerLogLevel
+        - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         name: tap
@@ -208,6 +212,7 @@ spec:
         - -ignore-namespaces=kube-system
         - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
         - -log-level=ControllerLogLevel
+        - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         name: telemetry

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -154,6 +154,7 @@ spec:
         - "-tap-addr=127.0.0.1:8088"
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"
+        - "-logtostderr=true"
       - name: destination
         ports:
         - name: grpc
@@ -167,6 +168,7 @@ spec:
         - "-addr=:8089"
         - "-metrics-addr=:9999"
         - "-log-level={{.ControllerLogLevel}}"
+        - "-logtostderr=true"
       - name: proxy-api
         ports:
         - name: grpc
@@ -182,6 +184,7 @@ spec:
         - "-destination-addr=:8089"
         - "-telemetry-addr=:8087"
         - "-log-level={{.ControllerLogLevel}}"
+        - "-logtostderr=true"
       - name: tap
         ports:
         - name: grpc
@@ -195,6 +198,7 @@ spec:
         - "-addr=:8088"
         - "-metrics-addr=:9998"
         - "-log-level={{.ControllerLogLevel}}"
+        - "-logtostderr=true"
       - name: telemetry
         ports:
         - name: grpc
@@ -210,6 +214,7 @@ spec:
         - "-ignore-namespaces=kube-system"
         - "-prometheus-url=http://prometheus.{{.Namespace}}.svc.cluster.local:9090"
         - "-log-level={{.ControllerLogLevel}}"
+        - "-logtostderr=true"
 
 ### Web ###
 ---


### PR DESCRIPTION
By default, the `glog` package, which is used by packages in the `k8s.io` org, writes log output to files in the `/tmp` directory. This doesn't work for our controller containers because they're built from the `scratch` image. This branch updates the conduit controller configuration to start setting glog's `-logtostderr` flag, so that we no longer try to write to `/tmp`. Fixes #522.