### PR TITLE
Make absolute names truly absolute.

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	LocalhostDNSNameOverride = "localhost"
+	LocalhostDNSNameOverride = "localhost."
 	ControlPlanePodName      = "controller"
 )
 
@@ -136,7 +136,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec, controlPlaneDNSNameOverride, v
 			Privileged: &f,
 		},
 	}
-	controlPlaneDNS := fmt.Sprintf("proxy-api.%s.svc.cluster.local", controlPlaneNamespace)
+	controlPlaneDNS := fmt.Sprintf("proxy-api.%s.svc.cluster.local.", controlPlaneNamespace)
 	if controlPlaneDNSNameOverride != "" {
 		controlPlaneDNS = controlPlaneDNSNameOverride
 	}

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -40,7 +40,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -40,7 +40,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -133,7 +133,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -41,7 +41,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -42,7 +42,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -137,7 +137,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -205,7 +205,7 @@ spec:
         - -addr=:8087
         - -metrics-addr=:9997
         - -ignore-namespaces=kube-system
-        - -prometheus-url=http://prometheus.conduit.svc.cluster.local:9090
+        - -prometheus-url=http://prometheus.conduit.svc.cluster.local.:9090
         - -log-level=info
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
@@ -220,7 +220,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://localhost:8086
+          value: tcp://localhost.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -321,7 +321,7 @@ spec:
       - args:
         - -addr=:8084
         - -metrics-addr=:9994
-        - -api-addr=api:8085
+        - -api-addr=api.conduit.svc.cluster.local.:8085
         - -static-dir=/dist
         - -template-dir=/templates
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
@@ -340,7 +340,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -452,7 +452,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -526,7 +526,7 @@ data:
     scrape_configs:
     - job_name: 'prometheus'
       static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost.:9090']
 
     - job_name: 'controller'
       kubernetes_sd_configs:
@@ -606,7 +606,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+          value: tcp://proxy-api.conduit.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -710,7 +710,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://prometheus.conduit.svc.cluster.local:9090
+      url: http://prometheus.conduit.svc.cluster.local.:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -206,7 +206,7 @@ spec:
         - -addr=:8087
         - -metrics-addr=:9997
         - -ignore-namespaces=kube-system
-        - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
+        - -prometheus-url=http://prometheus.Namespace.svc.cluster.local.:9090
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
@@ -221,7 +221,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://localhost:8086
+          value: tcp://localhost.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -323,7 +323,7 @@ spec:
       - args:
         - -addr=:8084
         - -metrics-addr=:9994
-        - -api-addr=api:8085
+        - -api-addr=api.Namespace.svc.cluster.local.:8085
         - -static-dir=/dist
         - -template-dir=/templates
         - -uuid=UUID
@@ -342,7 +342,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.Namespace.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -455,7 +455,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.Namespace.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -529,7 +529,7 @@ data:
     scrape_configs:
     - job_name: 'prometheus'
       static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost.:9090']
 
     - job_name: 'controller'
       kubernetes_sd_configs:
@@ -610,7 +610,7 @@ spec:
         - name: CONDUIT_PROXY_LOG
           value: warn,conduit_proxy=info
         - name: CONDUIT_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.Namespace.svc.cluster.local.:8086
         - name: CONDUIT_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: CONDUIT_PROXY_PRIVATE_LISTENER
@@ -714,7 +714,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://prometheus.Namespace.svc.cluster.local:9090
+      url: http://prometheus.Namespace.svc.cluster.local.:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -208,7 +208,7 @@ spec:
         - "-addr=:8087"
         - "-metrics-addr=:9997"
         - "-ignore-namespaces=kube-system"
-        - "-prometheus-url=http://prometheus.{{.Namespace}}.svc.cluster.local:9090"
+        - "-prometheus-url=http://prometheus.{{.Namespace}}.svc.cluster.local.:9090"
         - "-log-level={{.ControllerLogLevel}}"
 
 ### Web ###
@@ -265,7 +265,7 @@ spec:
         args:
         - "-addr=:8084"
         - "-metrics-addr=:9994"
-        - "-api-addr=api:8085"
+        - "-api-addr=api.{{.Namespace}}.svc.cluster.local.:8085"
         - "-static-dir=/dist"
         - "-template-dir=/templates"
         - "-uuid={{.UUID}}"
@@ -350,7 +350,7 @@ data:
     scrape_configs:
     - job_name: 'prometheus'
       static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost.:9090']
 
     - job_name: 'controller'
       kubernetes_sd_configs:
@@ -476,7 +476,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://prometheus.{{.Namespace}}.svc.cluster.local:9090
+      url: http://prometheus.{{.Namespace}}.svc.cluster.local.:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"


### PR DESCRIPTION
Kubernetes will do multiple DNS lookups for a name like
`proxy-api.conduit.svc.cluster.local` based on the default search settings
in /etc/resolv.conf for each container:

1. proxy-api.conduit.svc.cluster.local.conduit.svc.cluster.local. IN A
2. proxy-api.conduit.svc.cluster.local.svc.cluster.local. IN A
3. proxy-api.conduit.svc.cluster.local.cluster.local. IN A
4. proxy-api.conduit.svc.cluster.local. IN A

We do not need or want this search to be done, so avoid it by making each
name absolute by appending a period so that the first three DNS queries
are skipped for each name.

The case for `localhost` is even worse because we expect that `localhost` will
always resolve to 127.0.0.1 and/or ::1, but this is not guaranteed if the default
search is done:

1. localhost.conduit.svc.cluster.local. IN A
2. localhost.svc.cluster.local. IN A
3. localhost.cluster.local. IN A
4. localhost. IN A

Avoid these unnecessary DNS queries by making each name absolute, so that the
first three DNS queries are skipped for each name.

Signed-off-by: Brian Smith <brian@briansmith.org>