### PR TITLE
Fix infinite loop in `tcp::HalfDuplex::copy_into()`

### DIFF
--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -183,9 +183,7 @@ where
     fn read(&mut self) -> Poll<(), io::Error> {
         let mut is_eof = false;
         if let Some(ref mut buf) = self.buf {
-            let has_remaining = buf.has_remaining();
-                has_remaining);
-            if !has_remaining {
+            if !buf.has_remaining() {
                 buf.reset();
                 let n = try_ready!(self.io.read_buf(buf));
                 is_eof = n == 0;

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -283,32 +283,33 @@ impl BufMut for CopyBuf {
 #[cfg(test)]
 mod tests {
     use std::io::{Error, Read, Write, Result};
-    use tokio_io::{AsyncRead, AsyncWrite};
-    use futures::{Async, Poll};
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    use tokio_io::{AsyncRead, AsyncWrite};
+    use futures::{Async, Poll};
     use super::*;
 
     struct DoneIo(AtomicBool);
 
     impl<'a> Read for &'a DoneIo {
-        fn read(&mut self, _buf: &mut [u8]) -> Result<usize> {
-            if self.0.load(Ordering::Relaxed) { Ok(0) } else { Ok(1) }
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            if self.0.swap(false, Ordering::Relaxed) {
+                Ok(buf.len())
+            } else {
+                Ok(0)
+            }
         }
     }
 
     impl<'a> AsyncRead for &'a DoneIo {
-        unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
-            for mut i in buf {
-                *i = 0;
-            };
+        unsafe fn prepare_uninitialized_buffer(&self, _buf: &mut [u8]) -> bool {
             true
         }
     }
 
     impl<'a> Write for &'a DoneIo {
-        fn write(&mut self, _buf: &[u8]) -> Result<usize> {
-            if self.0.load(Ordering::Relaxed) { Ok(1) } else { Ok(1) }
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            Ok(buf.len())
         }
         fn flush(&mut self) -> Result<()> {
             Ok(())
@@ -316,7 +317,11 @@ mod tests {
     }
     impl<'a> AsyncWrite for &'a DoneIo {
         fn shutdown(&mut self) -> Poll<(), Error> {
-            Ok(Async::Ready(()))
+            if self.0.swap(false, Ordering::Relaxed) {
+                Ok(Async::NotReady)
+            } else {
+                Ok(Async::Ready(()))
+            }
         }
     }
 
@@ -325,19 +330,11 @@ mod tests {
         // Test reproducing an infinite loop in Duplex that caused issue #519,
         // where a Duplex would enter an infinite loop when one half finishes.
         let io_1 = DoneIo(AtomicBool::new(true));
-        let io_2 = DoneIo(AtomicBool::new(false));
+        let io_2 = DoneIo(AtomicBool::new(true));
         let mut duplex = Duplex::new(&io_1, &io_2);
 
-        // poll the duplex once
         assert_eq!(duplex.poll().unwrap(), Async::NotReady);
-
-        // both ios are now done. the duplex should be done.
-        io_2.0.store(true, Ordering::Relaxed);
-
-        // the test will hang instead of failing.
-        // TODO: it would be nice if we could fail the test if the future
-        //       isn't finished after a minute or so...
-        duplex.wait().unwrap()
+        assert_eq!(duplex.poll().unwrap(), Async::Ready(()));
     }
 
 }

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -132,11 +132,6 @@ where
         // could make progress.
         self.half_in.copy_into(&mut self.half_out)?;
         self.half_out.copy_into(&mut self.half_in)?;
-        trace!(
-            "Duplex::poll(); half_in.is_done={:?}; half_out.is_done={:?};",
-            self.half_in.is_done(),
-            self.half_out.is_done(),
-        );
         if self.half_in.is_done() && self.half_out.is_done() {
             Ok(Async::Ready(()))
         } else {
@@ -174,7 +169,7 @@ where
             try_ready!(self.write_into(dst));
             if self.buf.is_none() {
                 debug_assert!(!dst.is_shutdown,
-                    "attempted shut down destination twice");
+                    "attempted to shut down destination twice");
                 try_ready!(dst.io.shutdown());
                 dst.is_shutdown = true;
 
@@ -189,18 +184,15 @@ where
         let mut is_eof = false;
         if let Some(ref mut buf) = self.buf {
             let has_remaining = buf.has_remaining();
-            trace!("HalfDuplex::read(); buf.has_remaining() = {:?};",
                 has_remaining);
             if !has_remaining {
                 buf.reset();
                 let n = try_ready!(self.io.read_buf(buf));
-                trace!("HalfDuplex::read(); n={:?}", n);
                 is_eof = n == 0;
             }
         }
 
         if is_eof {
-            trace!("HalfDuplex::read(); is_eof=true");
             self.buf.take();
         }
 


### PR DESCRIPTION
An infinite loop exists in the TCP proxy, which could be triggered by any raw TCP connection (including HTTPS requests). The connection will be proxied successfully, but instead of closing, it will remain open, and the proxy's CPU usage will remain extremely high indefinitely.

Since `Duplex::poll` will call `half_in.copy_into()`/`half_out.copy_into()` repeatedly, even after they return `Async::Ready`, when one half has shut down and returned ready, it may still be polled again, as `Duplex::poll` waits until _both_ halves have returned `Ready`. Because of the guard that `!dst.is_shutdown`, intended to prevent the destination from shutting down twice, the function will not return if it is polled again after returning `Async::Ready` once.

I've fixed this by moving the guard against double shutdowns out of the loop, so that the function will return `Async::Ready` again if it is polled after shutting down the destination.

I've also included a unit test against regressions to this bug. The unit test fails against master.

Fixes #519 