### PR TITLE
Add /metrics endpoint server to the proxy

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -26,6 +26,9 @@ pub struct Config {
     /// Where to listen for connectoins initiated by the control planey.
     pub control_listener: Listener,
 
+    /// Where to serve scrapable metrics.
+    pub metrics_listener: Listener,
+
     /// Where to forward externally received connections.
     pub private_forward: Option<Addr>,
 
@@ -137,6 +140,7 @@ const ENV_POD_NAME: &str = "CONDUIT_PROXY_POD_NAME";
 pub const ENV_POD_NAMESPACE: &str = "CONDUIT_PROXY_POD_NAMESPACE";
 
 pub const ENV_CONTROL_URL: &str = "CONDUIT_PROXY_CONTROL_URL";
+const ENV_METRICS_URL: &str = "CONDUIT_PROXY_METRICS_URL";
 const ENV_RESOLV_CONF: &str = "CONDUIT_RESOLV_CONF";
 
 // Default values for various configuration fields
@@ -146,6 +150,7 @@ const DEFAULT_REPORT_TIMEOUT_SECS: u64 = 10; // TODO: is this a reasonable defau
 const DEFAULT_PRIVATE_LISTENER: &str = "tcp://127.0.0.1:4140";
 const DEFAULT_PUBLIC_LISTENER: &str = "tcp://0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTENER: &str = "tcp://0.0.0.0:4190";
+const DEFAULT_METRICS_LISTENER: &str = "http://127.0.0.1:4191";
 const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
 const DEFAULT_PUBLIC_CONNECT_TIMEOUT_MS: u64 = 300;
 const DEFAULT_BIND_TIMEOUT_MS: u64 = 10_000; // ten seconds, as in Linkerd.
@@ -163,6 +168,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let private_listener_addr = parse(strings, ENV_PRIVATE_LISTENER, str::parse);
         let public_listener_addr = parse(strings, ENV_PUBLIC_LISTENER, str::parse);
         let control_listener_addr = parse(strings, ENV_CONTROL_LISTENER, str::parse);
+        let metrics_listener_addr = parse(strings, ENV_METRICS_LSITENER, str::parse);
         let private_forward = parse(strings, ENV_PRIVATE_FORWARD, str::parse);
         let public_connect_timeout = parse(strings, ENV_PUBLIC_CONNECT_TIMEOUT, parse_number);
         let private_connect_timeout = parse(strings, ENV_PRIVATE_CONNECT_TIMEOUT, parse_number);
@@ -205,6 +211,10 @@ impl<'a> TryFrom<&'a Strings> for Config {
             control_listener: Listener {
                 addr: control_listener_addr?
                     .unwrap_or_else(|| Addr::from_str(DEFAULT_CONTROL_LISTENER).unwrap()),
+            },
+            metrics_listener: Listener {
+                addr: metrics_listener_addr?
+                    .unwrap_or_else(|| Addr::from_str(DEFAULT_METRICS_LISTENER).unwrap()),
             },
             private_forward: private_forward?,
             public_connect_timeout: Duration::from_millis(

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -131,6 +131,7 @@ pub const ENV_PRIVATE_LISTENER: &str = "CONDUIT_PROXY_PRIVATE_LISTENER";
 pub const ENV_PRIVATE_FORWARD: &str = "CONDUIT_PROXY_PRIVATE_FORWARD";
 pub const ENV_PUBLIC_LISTENER: &str = "CONDUIT_PROXY_PUBLIC_LISTENER";
 pub const ENV_CONTROL_LISTENER: &str = "CONDUIT_PROXY_CONTROL_LISTENER";
+pub const ENV_METRICS_LISTENER: &str = "CONDUIT_PROXY_METRICS_LISTENER";
 const ENV_PRIVATE_CONNECT_TIMEOUT: &str = "CONDUIT_PROXY_PRIVATE_CONNECT_TIMEOUT";
 const ENV_PUBLIC_CONNECT_TIMEOUT: &str = "CONDUIT_PROXY_PUBLIC_CONNECT_TIMEOUT";
 pub const ENV_BIND_TIMEOUT: &str = "CONDUIT_PROXY_BIND_TIMEOUT";
@@ -140,7 +141,6 @@ const ENV_POD_NAME: &str = "CONDUIT_PROXY_POD_NAME";
 pub const ENV_POD_NAMESPACE: &str = "CONDUIT_PROXY_POD_NAMESPACE";
 
 pub const ENV_CONTROL_URL: &str = "CONDUIT_PROXY_CONTROL_URL";
-const ENV_METRICS_URL: &str = "CONDUIT_PROXY_METRICS_URL";
 const ENV_RESOLV_CONF: &str = "CONDUIT_RESOLV_CONF";
 
 // Default values for various configuration fields
@@ -150,7 +150,7 @@ const DEFAULT_REPORT_TIMEOUT_SECS: u64 = 10; // TODO: is this a reasonable defau
 const DEFAULT_PRIVATE_LISTENER: &str = "tcp://127.0.0.1:4140";
 const DEFAULT_PUBLIC_LISTENER: &str = "tcp://0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTENER: &str = "tcp://0.0.0.0:4190";
-const DEFAULT_METRICS_LISTENER: &str = "http://127.0.0.1:4191";
+const DEFAULT_METRICS_LISTENER: &str = "tcp://127.0.0.1:4191";
 const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
 const DEFAULT_PUBLIC_CONNECT_TIMEOUT_MS: u64 = 300;
 const DEFAULT_BIND_TIMEOUT_MS: u64 = 10_000; // ten seconds, as in Linkerd.
@@ -168,7 +168,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let private_listener_addr = parse(strings, ENV_PRIVATE_LISTENER, str::parse);
         let public_listener_addr = parse(strings, ENV_PUBLIC_LISTENER, str::parse);
         let control_listener_addr = parse(strings, ENV_CONTROL_LISTENER, str::parse);
-        let metrics_listener_addr = parse(strings, ENV_METRICS_LSITENER, str::parse);
+        let metrics_listener_addr = parse(strings, ENV_METRICS_LISTENER, str::parse);
         let private_forward = parse(strings, ENV_PRIVATE_FORWARD, str::parse);
         let public_connect_timeout = parse(strings, ENV_PUBLIC_CONNECT_TIMEOUT, parse_number);
         let private_connect_timeout = parse(strings, ENV_PRIVATE_CONNECT_TIMEOUT, parse_number);

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -27,6 +27,7 @@ use ctx;
 use telemetry::event::Event;
 
 mod latency;
+mod scrape;
 
 #[derive(Debug)]
 pub struct Metrics {

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -27,7 +27,7 @@ use ctx;
 use telemetry::event::Event;
 
 mod latency;
-mod scrape;
+pub mod scrape;
 
 #[derive(Debug)]
 pub struct Metrics {

--- a/proxy/src/telemetry/metrics/scrape.rs
+++ b/proxy/src/telemetry/metrics/scrape.rs
@@ -54,6 +54,6 @@ impl HyperService for Server {
 
         future::ok(HyperResponse::new()
             .with_status(StatusCode::Ok)
-            .with_body("Not yet implementted"))
+            .with_body("Not yet implemented"))
     }
 }

--- a/proxy/src/telemetry/metrics/scrape.rs
+++ b/proxy/src/telemetry/metrics/scrape.rs
@@ -1,0 +1,25 @@
+use std::io;
+
+use tower::Service;
+use http;
+use transparency::HttpBody;
+
+/// Serve scrapable metrics.
+#[derive(Debug, Clone)]
+pub struct Server {
+}
+
+impl Service for Server {
+    type Request = http::Request<HttpBody>;
+    type Response = http::Response<HttpBody>;
+    type Error = io::Error;
+    type Future = Box<Future<Item=Self::Response, Error=Self::Error>>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        unimplemented!()
+    }
+
+    fn call(&mut self, req: Self::Request) -> Self::Future {
+        unimplemented!()
+    }
+}

--- a/proxy/src/telemetry/metrics/scrape.rs
+++ b/proxy/src/telemetry/metrics/scrape.rs
@@ -54,6 +54,6 @@ impl HyperService for Server {
 
         future::ok(HyperResponse::new()
             .with_status(StatusCode::Ok)
-            .with_body("Not yet implemented"))
+            .with_body(""))
     }
 }

--- a/proxy/src/telemetry/mod.rs
+++ b/proxy/src/telemetry/mod.rs
@@ -16,6 +16,7 @@ pub mod tap;
 pub use self::control::{Control, MakeControl};
 pub use self::event::Event;
 pub use self::sensor::Sensors;
+pub use self::metrics::scrape::Metrics;
 
 /// Creates proxy-specific runtime telemetry.
 ///

--- a/proxy/tests/support/proxy.rs
+++ b/proxy/tests/support/proxy.rs
@@ -117,7 +117,7 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
     }
     env.put(config::ENV_PUBLIC_LISTENER, "tcp://127.0.0.1:0".to_owned());
     env.put(config::ENV_CONTROL_LISTENER, "tcp://127.0.0.1:0".to_owned());
-
+    env.put(config::ENV_METRICS_LISTENER, "tcp://127.0.0.1:0".to_owned());
     env.put(config::ENV_POD_NAMESPACE, "test".to_owned());
 
     let mut config = config::Config::try_from(&env).unwrap();


### PR DESCRIPTION
This PR adds a Hyper server that serves the proxy `/metrics` endpoint. It currently doesn't serve anything because no scrapable metrics are collected. The metrics server's address and port can be configured with the `CONDUIT_PROXY_METRICS_LISTENER` environment variable.

```
$ http get localhost:4191/metrics                   
HTTP/1.1 200 OK
Date: Thu, 08 Mar 2018 23:09:23 GMT
Transfer-Encoding: chunked


$ http get localhost:4191          
HTTP/1.1 404 Not Found
Content-Length: 0
Date: Thu, 08 Mar 2018 23:09:36 GMT


```

Closes #540