### PR TITLE
Plumb scrapable metrics into event pipeline

### DIFF
--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -214,6 +214,8 @@ impl Stream for Control {
                         }
                     }
 
+                    self.scrape_metrics.record_event(&ev);
+
                     self.flush_report()
                 }
                 Async::Ready(None) => {

--- a/proxy/src/telemetry/metrics/scrape.rs
+++ b/proxy/src/telemetry/metrics/scrape.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+
+use telemetry::event::Event;
 use futures::future::{self, FutureResult};
 use hyper;
 use hyper::StatusCode;
@@ -34,10 +36,15 @@ impl Metrics {
         Metrics { }
     }
 
-    // /// Observe the given event.
-    // pub fn observe(&mut self, _event: &Event) {
-    //     unimplemented!()
-    // }
+    /// Observe the given event.
+    ///
+    /// This borrows self immutably, so that individual metric fields
+    /// can implement their own mutual exclusion strategy (i.e. counters
+    /// can just use atomic integers).
+    pub fn record_event(&self, event: &Event) {
+        trace!("Metrics::record({:?})", event);
+        // TODO: record the event.
+    }
 }
 
 impl HyperService for Server {


### PR DESCRIPTION
Follow-up from #540. 

I've wired up the scrapable metrics server from #540 to the rest of the telemetry pipeline, so that it's notified on every event generated. Right now, it doesn't do anything with those events, so [I made it log them at the trace level](https://github.com/runconduit/conduit/commit/621618914b5e6297118b8cbae913097c261ef142#diff-ac42548a2265998a61c9b4680829c0fbR45) to validate that it's working:

```
$ RUST_LOG=conduit_proxy=warn,conduit_proxy::telemetry::metrics::scrape=trace cargo test -- inbound_sends_telemetry
    Finished dev [unoptimized + debuginfo] target(s) in 0.1 secs
     Running target/debug/deps/telemetry-ab4056cac5f3c6e1

running 2 tests
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(TransportOpen(Server(Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52462), local: V4(127.0.0.1:52457), orig_dst: Some(V4(127.0.0.1:52450)), protocol: Http })))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(TransportOpen(Server(Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52463), local: V4(127.0.0.1:52452), orig_dst: Some(V4(127.0.0.1:52448)), protocol: Http })))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(StreamRequestOpen(Request { id: 0, uri: http://tele.test.svc.cluster.local/hey, method: GET, server: Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52463), local: V4(127.0.0.1:52452), orig_dst: Some(V4(127.0.0.1:52448)), protocol: Http }, client: Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52448), protocol: Http } }))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(TransportOpen(Client(Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52448), protocol: Http })))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(TransportOpen(Client(Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52450), protocol: Http })))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(StreamRequestOpen(Request { id: 0, uri: http://tele.test.svc.cluster.local/hey, method: GET, server: Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52462), local: V4(127.0.0.1:52457), orig_dst: Some(V4(127.0.0.1:52450)), protocol: Http }, client: Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52450), protocol: Http } }))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(StreamResponseOpen(Response { request: Request { id: 0, uri: http://tele.test.svc.cluster.local/hey, method: GET, server: Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52462), local: V4(127.0.0.1:52457), orig_dst: Some(V4(127.0.0.1:52450)), protocol: Http }, client: Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52450), protocol: Http } }, status: 200 }, StreamResponseOpen { since_request_open: Duration { secs: 0, nanos: 3865677 } }))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(StreamResponseOpen(Response { request: Request { id: 0, uri: http://tele.test.svc.cluster.local/hey, method: GET, server: Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52463), local: V4(127.0.0.1:52452), orig_dst: Some(V4(127.0.0.1:52448)), protocol: Http }, client: Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52448), protocol: Http } }, status: 200 }, StreamResponseOpen { since_request_open: Duration { secs: 0, nanos: 5988748 } }))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(StreamResponseEnd(Response { request: Request { id: 0, uri: http://tele.test.svc.cluster.local/hey, method: GET, server: Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52462), local: V4(127.0.0.1:52457), orig_dst: Some(V4(127.0.0.1:52450)), protocol: Http }, client: Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52450), protocol: Http } }, status: 200 }, StreamResponseEnd { grpc_status: None, since_request_open: Duration { secs: 0, nanos: 4016320 }, since_response_open: Duration { secs: 0, nanos: 126275 }, bytes_sent: 5, frames_sent: 1 }))
TRACE 2018-03-08T23:40:19Z: conduit_proxy::telemetry::metrics::scrape: Metrics::record(StreamResponseEnd(Response { request: Request { id: 0, uri: http://tele.test.svc.cluster.local/hey, method: GET, server: Server { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52463), local: V4(127.0.0.1:52452), orig_dst: Some(V4(127.0.0.1:52448)), protocol: Http }, client: Client { proxy: Inbound(Process { node: "", scheduled_instance: "", scheduled_namespace: "test" }), remote: V4(127.0.0.1:52448), protocol: Http } }, status: 200 }, StreamResponseEnd { grpc_status: None, since_request_open: Duration { secs: 0, nanos: 6550963 }, since_response_open: Duration { secs: 0, nanos: 540425 }, bytes_sent: 5, frames_sent: 1 }))
test http1_inbound_sends_telemetry ... ok
test inbound_sends_telemetry ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out
```

Closes #542 