### PR TITLE
Stop collapsing Cargo.lock in GitHub PR reviews.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 # By default, collapse for these files in in GitHub reviews.
-Cargo.lock linguist-generated=true
 Gopkg.lock linguist-generated=true
 controller/gen/**/*.pb.go linguist-generated=true


### PR DESCRIPTION
We should review changes to Cargo.lock to ensure we're not adding
unexpected and/or unnecessary dependencies. (Maybe we should do the
same for Gopkg.lock, but I'm not in a position to say for sure.)

Signed-off-by: Brian Smith <brian@briansmith.org>