### PR TITLE
Clarify routing logic

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -15,7 +15,6 @@ use tower_h2;
 use tower_reconnect::Reconnect;
 
 use conduit_proxy_controller_grpc;
-use conduit_proxy_router::Reuse;
 use control;
 use ctx;
 use telemetry::{self, sensor};
@@ -321,20 +320,5 @@ impl Protocol {
             .unwrap_or_else(|| Host::NoAuthority);
 
         Protocol::Http1(host)
-    }
-
-    pub fn is_cachable(&self) -> bool {
-        match *self {
-            Protocol::Http2 | Protocol::Http1(Host::Authority(_)) => true,
-            _ => false,
-        }
-    }
-
-    pub fn into_key<T>(self, key: T) -> Reuse<(T, Protocol)> {
-        if self.is_cachable() {
-            Reuse::Reusable((key, self))
-        } else {
-            Reuse::SingleUse((key, self))
-        }
     }
 }


### PR DESCRIPTION
The relationship between protocol & authority was subtle.

This change mostly adds documentation, though the `Destination` enum has
been renamed to `Dst` with `Bound` and `Unbound` variants, replacing
`LocalSvc` and `External`, which had misleading connotations.

Protocol::into_key has been removed so that the reuse logic is explicit
and readable.

Based on #555 