### PR TITLE
Modify simulate proxy to expose prometheus metrics

### DIFF
--- a/.prometheus.dev.yml
+++ b/.prometheus.dev.yml
@@ -8,26 +8,6 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name: 'web'
+  - job_name: 'conduit'
     static_configs:
-      - targets: ['web:9994']
-
-  - job_name: 'public-api'
-    static_configs:
-      - targets: ['public-api:9995']
-
-  - job_name: 'proxy-api'
-    static_configs:
-      - targets: ['proxy-api:9996']
-
-  - job_name: 'telemetry'
-    static_configs:
-      - targets: ['telemetry:9997']
-
-  - job_name: 'tap'
-    static_configs:
-      - targets: ['tap:9998']
-
-  - job_name: 'destination'
-    static_configs:
-      - targets: ['destination:9999']
+      - targets: ['localhost:9000', 'localhost:9001', 'localhost:9002']

--- a/.prometheus.dev.yml
+++ b/.prometheus.dev.yml
@@ -9,29 +9,33 @@ scrape_configs:
       - targets: ['localhost:9090']
 
   - job_name: 'web'
-      static_configs:
-        - targets: ['web:9994']
+    static_configs:
+      - targets: ['web:9994']
 
-    - job_name: 'public-api'
-      static_configs:
-        - targets: ['public-api:9995']
+  - job_name: 'public-api'
+    static_configs:
+      - targets: ['public-api:9995']
 
-    - job_name: 'proxy-api'
-      static_configs:
-        - targets: ['proxy-api:9996']
+  - job_name: 'proxy-api'
+    static_configs:
+      - targets: ['proxy-api:9996']
 
-    - job_name: 'telemetry'
-      static_configs:
-        - targets: ['telemetry:9997']
+  - job_name: 'telemetry'
+    static_configs:
+      - targets: ['telemetry:9997']
 
-    - job_name: 'tap'
-      static_configs:
-        - targets: ['tap:9998']
+  - job_name: 'tap'
+    static_configs:
+      - targets: ['tap:9998']
 
-    - job_name: 'destination'
-      static_configs:
-        - targets: ['destination:9999']
+  - job_name: 'destination'
+    static_configs:
+      - targets: ['destination:9999']
 
-    - job_name: 'conduit'
-      static_configs:
-        - targets: ['simulate-proxy:9000', 'simulate-proxy:9001', 'simulate-proxy:9002']
+  - job_name: 'conduit'
+    static_configs:
+      - targets: [
+      'simulate-proxy:9000',
+      'simulate-proxy:9001',
+      'simulate-proxy:9002'
+      ]

--- a/.prometheus.dev.yml
+++ b/.prometheus.dev.yml
@@ -8,6 +8,30 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name: 'conduit'
-    static_configs:
-      - targets: ['localhost:9000', 'localhost:9001', 'localhost:9002']
+  - job_name: 'web'
+      static_configs:
+        - targets: ['web:9994']
+
+    - job_name: 'public-api'
+      static_configs:
+        - targets: ['public-api:9995']
+
+    - job_name: 'proxy-api'
+      static_configs:
+        - targets: ['proxy-api:9996']
+
+    - job_name: 'telemetry'
+      static_configs:
+        - targets: ['telemetry:9997']
+
+    - job_name: 'tap'
+      static_configs:
+        - targets: ['tap:9998']
+
+    - job_name: 'destination'
+      static_configs:
+        - targets: ['destination:9999']
+
+    - job_name: 'conduit'
+      static_configs:
+        - targets: ['simulate-proxy:9000', 'simulate-proxy:9001', 'simulate-proxy:9002']

--- a/.prometheus.dev.yml
+++ b/.prometheus.dev.yml
@@ -34,8 +34,7 @@ scrape_configs:
 
   - job_name: 'conduit'
     static_configs:
-      - targets: [
-      'simulate-proxy:9000',
-      'simulate-proxy:9001',
-      'simulate-proxy:9002'
-      ]
+      - targets:
+        - 'simulate-proxy:9000'
+        - 'simulate-proxy:9001'
+        - 'simulate-proxy:9002'

--- a/BUILD.md
+++ b/BUILD.md
@@ -167,10 +167,8 @@ traffic to the docker-compose environment:
 ```bash
 # confirm you are connected to Kubernetes
 kubectl version
-
-# simulate traffic
-bin/go-run controller/script/simulate-proxy --kubeconfig ~/.kube/config --max-pods 10 --sleep 10ms
 ```
+
 Note that the Kubernetes cluster your system is configured to talk to must not be referenced via 
 `localhost` in your Kubernetes config file, as `simulate-proxy` will not be able to connect to it.
  This includes Kubernetes on Docker For Mac.

--- a/BUILD.md
+++ b/BUILD.md
@@ -169,9 +169,11 @@ traffic to the docker-compose environment:
 kubectl version
 
 # simulate traffic
-bin/go-run controller/script/simulate-proxy --kubeconfig ~/.kube/config --addr $DOCKER_IP:8086 --max-pods 10 --sleep 10ms
+bin/go-run controller/script/simulate-proxy --kubeconfig ~/.kube/config --max-pods 10 --sleep 10ms
 ```
-
+Note that the Kubernetes cluster your system is configured to talk to must not be referenced via 
+`localhost` in your Kubernetes config file, as `simulate-proxy` will not be able to connect to it.
+ This includes Kubernetes on Docker For Mac.
 ### Testing
 
 ```bash

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -329,7 +329,7 @@ func getRandomNamespaceKey(podsByNamespace map[string][]*v1.Pod) string {
 func main() {
 	rand.Seed(time.Now().UnixNano())
 	sleep := flag.Duration("sleep", time.Second, "time to sleep between requests")
-	metricsAddr := flag.String("metrics-addr", ":9000", "port to server prometheus metrics")
+	metricsAddrs := flag.String("metrics-addrs", ":9000,:9001,:9002", "range of network addresses to serve prometheus metrics")
 	maxPods := flag.Int("max-pods", 0, "total number of pods to simulate (default unlimited)")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config - required")
 	flag.Parse()
@@ -371,7 +371,7 @@ func main() {
 	stopCh := make(chan os.Signal)
 	signal.Notify(stopCh, os.Interrupt, os.Kill)
 
-	for _, addr := range strings.Split(*metricsAddr, ",") {
+	for _, addr := range strings.Split(*metricsAddrs, ",") {
 		randomNamespace := getRandomNamespaceKey(podsByNamespace)
 		proxyPod := podList[rand.Intn(len(podList))]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     - go
     - run
     - /go/src/github.com/runconduit/conduit/controller/script/simulate-proxy/main.go
-    - --metrics-addr=0.0.0.0:9000
+    - --metrics-addrs=0.0.0.0:9000,0.0.0.0:9001,0.0.0.0:9002
     - --kubeconfig=/kubeconfig
     - --max-pods=10
     - --sleep=10ms

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,9 +114,7 @@ services:
   simulate-proxy:
     image: golang:1.10.0-alpine3.7
     ports:
-    - 9000:9000
-    - 9001:9001
-    - 9002:9002
+    - 9000-9002:9000-9002
     volumes:
     - .:/go/src/github.com/runconduit/conduit
     - ~/.kube/config:/kubeconfig:ro
@@ -124,7 +122,7 @@ services:
     - go
     - run
     - /go/src/github.com/runconduit/conduit/controller/script/simulate-proxy/main.go
-    - --metrics-addrs=0.0.0.0:9000,0.0.0.0:9001,0.0.0.0:9002
+    - --metric-addrs=0.0.0.0:9000,0.0.0.0:9001,0.0.0.0:9002
     - --kubeconfig=/kubeconfig
     - --max-pods=10
-    - --sleep=10ms
+    - --sleep=3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,3 +110,21 @@ services:
     command:
     - --config.file=/etc/prometheus/prometheus.yml
     - --storage.tsdb.retention=6h
+
+  simulate-proxy:
+    image: golang:1.10.0-alpine3.7
+    ports:
+    - 9000:9000
+    - 9001:9001
+    - 9002:9002
+    volumes:
+    - .:/go/src/github.com/runconduit/conduit
+    - ~/.kube/config:/kubeconfig:ro
+    command:
+    - go
+    - run
+    - /go/src/github.com/runconduit/conduit/controller/script/simulate-proxy/main.go
+    - --metrics-addr=0.0.0.0:9000
+    - --kubeconfig=/kubeconfig
+    - --max-pods=10
+    - --sleep=10ms


### PR DESCRIPTION
The simulate-proxy script pushes metrics to the telemetry service. This PR modifies the script to expose metrics to a prometheus endpoint. This functionality creates a server that randomly generates `response_total`, `request_totals`, `response_duration_ms` and `response_latency_ms`. The server reads pod information from a k8s cluster and picks a random namespace to use for all exposed metrics.

Tested out these changes with a locally running prometheus server. I also ran the `docker-compose.yml` to make sure metrics were being recorded by the prometheus docker container.

fixes #498

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>