### PR TITLE
Reuse code for metrics serving in controller

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/destination"
+	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -47,11 +45,7 @@ func main() {
 		server.Serve(lis)
 	}()
 
-	go func() {
-		fmt.Println("serving scrapable metrics on", *metricsAddr)
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(*metricsAddr, nil)
-	}()
+	go util.NewMetricsServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"flag"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/api/proxy"
 	"github.com/runconduit/conduit/controller/destination"
+	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -57,11 +56,7 @@ func main() {
 		server.Serve(lis)
 	}()
 
-	go func() {
-		log.Infof("serving scrapable metrics on %s", *metricsAddr)
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(*metricsAddr, nil)
-	}()
+	go util.NewMetricsServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -3,15 +3,14 @@ package main
 import (
 	"context"
 	"flag"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/api/public"
 	"github.com/runconduit/conduit/controller/tap"
 	"github.com/runconduit/conduit/controller/telemetry"
+	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -57,11 +56,7 @@ func main() {
 		server.ListenAndServe()
 	}()
 
-	go func() {
-		log.Infof("serving scrapable metrics on %+v", *metricsAddr)
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(*metricsAddr, nil)
-	}()
+	go util.NewMetricsServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/tap"
+	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -45,11 +43,7 @@ func main() {
 		server.Serve(lis)
 	}()
 
-	go func() {
-		fmt.Println("serving scrapable metrics on", *metricsAddr)
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(*metricsAddr, nil)
-	}()
+	go util.NewMetricsServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/telemetry/main.go
+++ b/controller/cmd/telemetry/main.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"flag"
-	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/telemetry"
+	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -46,11 +45,7 @@ func main() {
 		server.Serve(lis)
 	}()
 
-	go func() {
-		log.Info("serving scrapable metrics on", *metricsAddr)
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(*metricsAddr, nil)
-	}()
+	go util.NewMetricsServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/util/prometheus.go
+++ b/controller/util/prometheus.go
@@ -6,6 +6,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 
@@ -70,4 +71,10 @@ func WithTelemetry(handler http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerDuration(duration,
 		promhttp.InstrumentHandlerResponseSize(responseSize,
 			promhttp.InstrumentHandlerCounter(counter, handler)))
+}
+
+func NewMetricsServer(metricsAddr string) {
+	log.Infof("serving scrapable metrics on %s", metricsAddr)
+	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(metricsAddr, nil)
 }


### PR DESCRIPTION
Starting a metrics endpoint code was duplicated on many places inside controller. This introduces util method unifying all usages.

fixes #228 

Signed-off-by: Alena Varkockova varkockova.a@gmail.com