### PR TITLE
cli: reduce timeouts on API check requests

### DIFF
--- a/pkg/healthcheck/grpc.go
+++ b/pkg/healthcheck/grpc.go
@@ -3,6 +3,7 @@ package healthcheck
 import (
 	"context"
 	"fmt"
+	"time"
 
 	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
 	"google.golang.org/grpc"
@@ -24,7 +25,10 @@ func (proxy *statusCheckerProxy) SelfCheck() []*healthcheckPb.CheckResult {
 		CheckDescription: "can query the Conduit API",
 	}
 
-	selfCheckResponse, err := proxy.delegate.SelfCheck(context.Background(), &healthcheckPb.SelfCheckRequest{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	selfCheckResponse, err := proxy.delegate.SelfCheck(ctx, &healthcheckPb.SelfCheckRequest{})
 	if err != nil {
 		canConnectViaGrpcCheck.Status = healthcheckPb.CheckStatus_ERROR
 		canConnectViaGrpcCheck.FriendlyMessageToUser = err.Error()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -90,7 +90,10 @@ func (v versionStatusChecker) SelfCheck() []*healthcheckPb.CheckResult {
 }
 
 func (v versionStatusChecker) getServerVersion() (string, error) {
-	resp, err := v.publicApiClient.Version(context.Background(), &pb.Empty{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := v.publicApiClient.Version(ctx, &pb.Empty{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Applies timeout of 5s to check request contexts. This overrides
30s timeout applied at client transport level, and stops the
conduit check command from taking > 90s to complete.

Fixes #553

Signed-off-by: Andy Hume <andyhume@gmail.com>