### PR TITLE
cli: ensure check command has 80-character output

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -17,6 +17,9 @@ import (
 
 const (
 	lineWidth       = 80
+	okStatus        = "[ok]"
+	failStatus      = "[FAIL]"
+	errorStatus     = "[ERROR]"
 	versionCheckURL = "https://versioncheck.conduit.io/version.json"
 )
 
@@ -65,17 +68,18 @@ func checkStatus(w io.Writer, checkers ...healthcheck.StatusChecker) error {
 		checkLabel := fmt.Sprintf("%s: %s", result.SubsystemName, result.CheckDescription)
 
 		filler := ""
-		for i := 0; i < lineWidth-len(checkLabel); i++ {
+		lineBreak := "\n"
+		for i := 0; i < lineWidth-len(checkLabel)-len(okStatus)-len(lineBreak); i++ {
 			filler = filler + "."
 		}
 
 		switch result.Status {
 		case healthcheckPb.CheckStatus_OK:
-			fmt.Fprintf(w, "%s%s[ok]\n", checkLabel, filler)
+			fmt.Fprintf(w, "%s%s%s%s", checkLabel, filler, okStatus, lineBreak)
 		case healthcheckPb.CheckStatus_FAIL:
-			fmt.Fprintf(w, "%s%s[FAIL]  -- %s\n", checkLabel, filler, result.FriendlyMessageToUser)
+			fmt.Fprintf(w, "%s%s%s  -- %s%s", checkLabel, filler, failStatus, result.FriendlyMessageToUser, lineBreak)
 		case healthcheckPb.CheckStatus_ERROR:
-			fmt.Fprintf(w, "%s%s[ERROR] -- %s\n", checkLabel, filler, result.FriendlyMessageToUser)
+			fmt.Fprintf(w, "%s%s%s -- %s%s", checkLabel, filler, errorStatus, result.FriendlyMessageToUser, lineBreak)
 		}
 	}
 

--- a/cli/cmd/testdata/status_busy_output.golden
+++ b/cli/cmd/testdata/status_busy_output.golden
@@ -1,5 +1,5 @@
-kubernetes-api: can initialize the client.......................................[FAIL]  -- This should contain instructions for fail
-kubernetes-api: can query the Kubernetes API....................................[ok]
-kubernetes-api: is running the minimum Kubernetes API version...................[ERROR] -- This should contain instructions for err
+kubernetes-api: can initialize the client..................................[FAIL]  -- This should contain instructions for fail
+kubernetes-api: can query the Kubernetes API...............................[ok]
+kubernetes-api: is running the minimum Kubernetes API version..............[ERROR] -- This should contain instructions for err
 
 Status check results are [ERROR]


### PR DESCRIPTION
Successful `conduit check` commands now take into account `[ok]`
and `\n` tokens when constraining line length.

Fixes #554 

---

It's a bit blunt this fix, and the filler/string printing approach in `checkStatus` is looking somewhat clunky with these additions. Happy to take a steer on better approaches, and work on a smarter refactor if you have ideas.