### PR TITLE
Add request_duration_ms metric and increment request_total on request end

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -79,6 +79,8 @@ pub type NewHttp<B> = sensor::NewHttp<Client<B>, B, HttpBody>;
 
 pub type HttpResponse = http::Response<sensor::http::ResponseBody<HttpBody>>;
 
+pub type HttpRequest<B> = http::Request<sensor::http::RequestBody<B>>;
+
 pub type Client<B> = transparency::Client<
     sensor::Connect<transport::Connect>,
     B,
@@ -253,11 +255,11 @@ impl<S> NormalizeUri<S> {
 impl<S, B> tower::NewService for NormalizeUri<S>
 where
     S: tower::NewService<
-        Request=http::Request<B>,
+        Request=HttpRequest<B>,
         Response=HttpResponse,
     >,
     S::Service: tower::Service<
-        Request=http::Request<B>,
+        Request=HttpRequest<B>,
         Response=HttpResponse,
     >,
     NormalizeUri<S::Service>: tower::Service,
@@ -280,7 +282,7 @@ where
 impl<S, B> tower::Service for NormalizeUri<S>
 where
     S: tower::Service<
-        Request=http::Request<B>,
+        Request=HttpRequest<B>,
         Response=HttpResponse,
     >,
     B: tower_h2::Body,

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -255,11 +255,11 @@ impl<S> NormalizeUri<S> {
 impl<S, B> tower::NewService for NormalizeUri<S>
 where
     S: tower::NewService<
-        Request=HttpRequest<B>,
+        Request=http::Request<B>,
         Response=HttpResponse,
     >,
     S::Service: tower::Service<
-        Request=HttpRequest<B>,
+        Request=http::Request<B>,
         Response=HttpResponse,
     >,
     NormalizeUri<S::Service>: tower::Service,
@@ -282,7 +282,7 @@ where
 impl<S, B> tower::Service for NormalizeUri<S>
 where
     S: tower::Service<
-        Request=HttpRequest<B>,
+        Request=http::Request<B>,
         Response=HttpResponse,
     >,
     B: tower_h2::Body,

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -3,8 +3,8 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use std::sync::Arc;
 
-use futures::{Async, Poll};
 use http;
+use futures::{Async, Poll};
 use rand;
 use tower;
 use tower_balance::{self, choose, load, Balance};

--- a/proxy/src/telemetry/event.rs
+++ b/proxy/src/telemetry/event.rs
@@ -12,6 +12,7 @@ pub enum Event {
 
     StreamRequestOpen(Arc<ctx::http::Request>),
     StreamRequestFail(Arc<ctx::http::Request>, StreamRequestFail),
+    StreamRequestEnd(Arc<ctx::http::Request>, StreamRequestEnd),
 
     StreamResponseOpen(Arc<ctx::http::Response>, StreamResponseOpen),
     StreamResponseFail(Arc<ctx::http::Response>, StreamResponseFail),
@@ -35,6 +36,12 @@ pub struct TransportClose {
 pub struct StreamRequestFail {
     pub since_request_open: Duration,
     pub error: h2::Reason,
+}
+
+#[derive(Clone, Debug)]
+pub struct StreamRequestEnd {
+    pub since_request_open: Duration,
+    pub grpc_status: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -67,6 +74,7 @@ impl Event {
         match *self {
             Event::StreamRequestOpen(_) |
             Event::StreamRequestFail(_, _) |
+            Event::StreamRequestEnd(_, _) |
             Event::StreamResponseOpen(_, _) |
             Event::StreamResponseFail(_, _) |
             Event::StreamResponseEnd(_, _) => true,
@@ -84,9 +92,9 @@ impl Event {
     pub fn proxy(&self) -> &Arc<ctx::Proxy> {
         match *self {
             Event::TransportOpen(ref ctx) | Event::TransportClose(ref ctx, _) => ctx.proxy(),
-            Event::StreamRequestOpen(ref req) | Event::StreamRequestFail(ref req, _) => {
-                &req.server.proxy
-            }
+            Event::StreamRequestOpen(ref req) |
+            Event::StreamRequestFail(ref req, _) |
+            Event::StreamRequestEnd(ref req, _) => &req.server.proxy,
             Event::StreamResponseOpen(ref rsp, _) |
             Event::StreamResponseFail(ref rsp, _) |
             Event::StreamResponseEnd(ref rsp, _) => &rsp.request.server.proxy,

--- a/proxy/src/telemetry/event.rs
+++ b/proxy/src/telemetry/event.rs
@@ -41,7 +41,6 @@ pub struct StreamRequestFail {
 #[derive(Clone, Debug)]
 pub struct StreamRequestEnd {
     pub since_request_open: Duration,
-    pub grpc_status: Option<u32>,
 }
 
 #[derive(Clone, Debug)]

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -127,7 +127,10 @@ impl Metrics {
                 stats.latencies += fail.since_request_open;
                 *ends += 1;
             }
-
+            Event::StreamRequestEnd(_, _) => {
+                // Do nothing, as the push metrics are slated for removal and
+                // we don't need to support this event.
+            }
             Event::StreamResponseOpen(ref res, ref open) => {
                 self.response(res).latencies += open.since_request_open;
             },

--- a/proxy/src/telemetry/metrics/prometheus.rs
+++ b/proxy/src/telemetry/metrics/prometheus.rs
@@ -22,6 +22,8 @@ use super::latency::{BUCKET_BOUNDS, Histogram};
 #[derive(Debug, Clone)]
 struct Metrics {
     request_total: Metric<Counter, Arc<RequestLabels>>,
+    request_duration: Metric<Histogram, Arc<RequestLabels>>,
+
     response_total: Metric<Counter, Arc<ResponseLabels>>,
     response_duration: Metric<Histogram, Arc<ResponseLabels>>,
     response_latency: Metric<Histogram, Arc<ResponseLabels>>,
@@ -122,6 +124,13 @@ impl Metrics {
             "A counter of the number of requests the proxy has received.",
         );
 
+        let request_duration = Metric::<Histogram, Arc<RequestLabels>>::new(
+            "request_duration_ms",
+            "A histogram of the duration of a request. This is measured from \
+             when the request headers are received to when the request \
+             stream has completed.",
+        );
+
         let response_total = Metric::<Counter, Arc<ResponseLabels>>::new(
             "response_total",
             "A counter of the number of responses the proxy has received.",
@@ -133,14 +142,17 @@ impl Metrics {
              when the response headers are received to when the response \
              stream has completed.",
         );
+
         let response_latency = Metric::<Histogram, Arc<ResponseLabels>>::new(
             "response_latency_ms",
             "A histogram of the total latency of a response. This is measured \
             from when the request headers are received to when the response \
             stream has completed.",
         );
+
         Metrics {
             request_total,
+            request_duration,
             response_total,
             response_duration,
             response_latency,
@@ -151,6 +163,14 @@ impl Metrics {
         &mut self.request_total.values
             .entry(labels.clone())
             .or_insert_with(Default::default).0
+    }
+
+    fn request_duration(&mut self,
+                        labels: &Arc<RequestLabels>)
+                        -> &mut Histogram {
+        self.request_duration.values
+            .entry(labels.clone())
+            .or_insert_with(Default::default)
     }
 
     fn response_duration(&mut self,
@@ -179,8 +199,9 @@ impl Metrics {
 
 impl fmt::Display for Metrics {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}\n{}\n{}\n{}",
+        write!(f, "{}\n{}\n{}\n{}\n{}",
             self.request_total,
+            self.request_duration,
             self.response_total,
             self.response_duration,
             self.response_latency,
@@ -309,10 +330,20 @@ impl Aggregate {
                 })
             },
 
-            Event::StreamRequestFail(_, _) => {
-                // The request total was already incremented by the
-                // StreamRequestOpen event; when we count requests on
-                // stream ends, we'll care about this event.
+            Event::StreamRequestFail(ref req, ref fail) => {
+                let labels = Arc::new(RequestLabels::new(req));
+                self.update(|metrics| {
+                    *metrics.request_duration(&labels) +=
+                        fail.since_request_open;
+                })
+            },
+
+            Event::StreamRequestEnd(ref req, ref end) => {
+                let labels = Arc::new(RequestLabels::new(req));
+                self.update(|metrics| {
+                    *metrics.request_duration(&labels) +=
+                        end.since_request_open;
+                })
             },
 
             Event::StreamResponseOpen(_, _) =>  {

--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -65,6 +65,8 @@ pub struct MeasuredBody<B, I: BodySensor> {
     _p: PhantomData<(B)>,
 }
 
+/// The `inner` portion of a `MeasuredBody`, with differing implementations
+/// for request and response streams.
 pub trait BodySensor: Sized {
     fn fail(self, reason: h2::Reason);
     fn end(self, grpc_status: Option<u32>);
@@ -545,7 +547,6 @@ impl BodySensor for RequestBodyInner {
             event::Event::StreamRequestEnd(
                 Arc::clone(&ctx),
                 event::StreamRequestEnd {
-                    grpc_status,
                     since_request_open: request_open.elapsed(),
                 },
             )

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -84,7 +84,11 @@ impl Sensors {
     where
         A: Body + 'static,
         B: Body + 'static,
-        N: NewService<Request = Request<A>, Response = Response<B>, Error = client::Error>
+        N: NewService<
+            Request = Request<http::RequestBody<A>>,
+            Response = Response<B>,
+            Error = client::Error
+        >
             + 'static,
     {
         NewHttp::new(next_id, new_service, &self.0, client_ctx)

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -27,7 +27,7 @@ use super::tcp;
 /// service.
 pub struct Server<S: NewService, B: tower_h2::Body, G>
 where
-    S: NewService<Request=http:: Request<HttpBody>>,
+    S: NewService<Request=http::Request<HttpBody>>,
     S::Future: 'static,
 {
     executor: Handle,

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -27,7 +27,7 @@ use super::tcp;
 /// service.
 pub struct Server<S: NewService, B: tower_h2::Body, G>
 where
-    S: NewService<Request=http::Request<HttpBody>>,
+    S: NewService<Request=http:: Request<HttpBody>>,
     S::Future: 'static,
 {
     executor: Handle,

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -326,7 +326,12 @@ fn metrics_endpoint_outbound_request_count() {
 
 }
 
+// Ignore this test on CI, because our method of adding latency to requests
+// (calling `thread::sleep`) is likely to be flakey on Travis.
+// Eventually, we can add some kind of mock timer system for simulating latency
+// more reliably, and re-enable this test.
 #[test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_inbound_response_latency() {
     let _ = env_logger::try_init();
 
@@ -409,7 +414,12 @@ fn metrics_endpoint_inbound_response_latency() {
 }
 
 
+// Ignore this test on CI, because our method of adding latency to requests
+// (calling `thread::sleep`) is likely to be flakey on Travis.
+// Eventually, we can add some kind of mock timer system for simulating latency
+// more reliably, and re-enable this test.
 #[test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_outbound_response_latency() {
     let _ = env_logger::try_init();
 

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -413,7 +413,6 @@ fn metrics_endpoint_inbound_response_latency() {
         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",status_code=\"200\"} 4");
 }
 
-
 // Ignore this test on CI, because our method of adding latency to requests
 // (calling `thread::sleep`) is likely to be flakey on Travis.
 // Eventually, we can add some kind of mock timer system for simulating latency
@@ -501,6 +500,75 @@ fn metrics_endpoint_outbound_response_latency() {
     // the histogram's total count should be 4.
     assert_contains!(scrape,
         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",status_code=\"200\"} 4");
+}
+
+#[test]
+fn metrics_endpoint_inbound_request_duration() {
+    let _ = env_logger::try_init();
+
+    info!("running test server");
+    let srv = server::new()
+        .route("/hey", "hello")
+        .run();
+
+    let ctrl = controller::new();
+    let proxy = proxy::new()
+        .controller(ctrl.run())
+        .inbound(srv)
+        .metrics_flush_interval(Duration::from_millis(500))
+        .run();
+    let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+    let metrics = client::http1(proxy.metrics, "localhost");
+
+    // request with body should increment request_duration
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey"), "hello");
+
+    let scrape = metrics.get("/metrics");
+    assert_contains!(scrape,
+        "request_duration_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\"} 1");
+
+    // request without body should also increment request_duration
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey"), "hello");
+
+    let scrape = metrics.get("/metrics");
+    assert_contains!(scrape,
+        "request_duration_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\"} 2");
+}
+
+#[test]
+fn metrics_endpoint_outbound_request_duration() {
+    let _ = env_logger::try_init();
+
+    info!("running test server");
+    let srv = server::new()
+        .route("/hey", "hello")
+        .run();
+    let ctrl = controller::new()
+        .destination("tele.test.svc.cluster.local", srv.addr)
+        .run();
+    let proxy = proxy::new()
+        .controller(ctrl)
+        .outbound(srv)
+        .metrics_flush_interval(Duration::from_millis(500))
+        .run();
+    let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+    let metrics = client::http1(proxy.metrics, "localhost");
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey"), "hello");
+
+    let scrape = metrics.get("/metrics");
+    assert_contains!(scrape,
+        "request_duration_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\"} 1");
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey"), "hello");
+
+    let scrape = metrics.get("/metrics");
+    assert_contains!(scrape,
+        "request_duration_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\"} 2");
 }
 
 #[test]

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -553,7 +553,7 @@ fn metrics_endpoint_outbound_request_duration() {
         .outbound(srv)
         .metrics_flush_interval(Duration::from_millis(500))
         .run();
-    let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+    let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
     let metrics = client::http1(proxy.metrics, "localhost");
 
     info!("client.get(/hey)");


### PR DESCRIPTION
This PR adds the `request_duration_ms` metric to the Prometheus metrics exported by the proxy. It also modifies the `request_total` metric so that it is incremented when a request stream finishes, rather than when it opens, for consistency with how the `response_total` metric is generated.

Making this change required modifying `telemetry::sensors::http` to generate a `StreamRequestEnd` event similar to the `StreamResponseEnd` event. This is done similarly to how sensors are added to response bodies, by generalizing the `ResponseBody` type into a `MeasuredBody` type that can wrap a request or response body. Since this changed the type of request bodies, it necessitated changing request types pretty much everywhere else in the proxy codebase in order to fix the resulting type errors, which is why the diff for this PR is so large.

Closes #570 