### PR TITLE
Add Grafana support to conduit dashboard command

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -671,6 +671,9 @@ data:
   grafana.ini: |-
     instance_name = conduit-grafana
 
+    [server]
+    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/conduit/services/grafana:http/proxy/
+
     [auth]
     disable_login_form = true
 

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -675,6 +675,9 @@ data:
   grafana.ini: |-
     instance_name = conduit-grafana
 
+    [server]
+    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/Namespace/services/grafana:http/proxy/
+
     [auth]
     disable_login_form = true
 

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -445,6 +445,9 @@ data:
   grafana.ini: |-
     instance_name = conduit-grafana
 
+    [server]
+    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/{{.Namespace}}/services/grafana:http/proxy/
+
     [auth]
     disable_login_form = true
 


### PR DESCRIPTION
The existing `conduit dashboard` command supported opening the conduit
dashboard, or displaying the conduit dashboard URL, via a `url` boolean
flag.

Replace the `url` boolean flag with a `show` string flag, with three
modes:
`conduit dashboard --show conduit`: default, open conduit dashboard
`conduit dashboard --show grafana`: open grafana dashboard
`conduit dashboard --show url`: display dashboard URLs

Part of #420

Signed-off-by: Andrew Seigner <siggy@buoyant.io>