### PR TITLE
Update codegen and tower-balance to remove indexmap dep.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 [[package]]
 name = "codegen"
 version = "0.1.0"
-source = "git+https://github.com/carllerche/codegen#f8f294fd56197b67f19917d4f67bc13e938f80c1"
+source = "git+https://github.com/carllerche/codegen#9b2f81859e91931871456ad06437643585d35866"
 dependencies = [
- "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -309,11 +309,6 @@ dependencies = [
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "indexmap"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "indexmap"
@@ -749,7 +744,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -757,10 +752,10 @@ dependencies = [
 [[package]]
 name = "tower-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -770,7 +765,7 @@ dependencies = [
 [[package]]
 name = "tower-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -779,7 +774,7 @@ dependencies = [
 [[package]]
 name = "tower-discover"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -830,7 +825,7 @@ dependencies = [
 [[package]]
 name = "tower-in-flight-limit"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -840,7 +835,7 @@ dependencies = [
 [[package]]
 name = "tower-ready-service"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -849,7 +844,7 @@ dependencies = [
 [[package]]
 name = "tower-reconnect"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -859,7 +854,7 @@ dependencies = [
 [[package]]
 name = "tower-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#7b6cd0355dae2aed0fdf8c486d04372e1c988cd4"
+source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -968,7 +963,6 @@ dependencies = [
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.11.22 (registry+https://github.com/rust-lang/crates.io-index)" = "d595f999e90624f64d2c4bc74c72adb0f3e0f773dc5692ca91338363b3568fa0"
-"checksum indexmap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7164c96d6e18ccc3ce43f3dedac996c21a220670a106c275b96ad92110401362"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"


### PR DESCRIPTION
```sh
$ cargo update -p codegen -p tower-balance
    [...]
    Removing indexmap v0.4.1
```

Signed-off-by: Brian Smith <brian@briansmith.org>