### PR TITLE
Proxy: Download fewer crates in Travis CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,8 @@ jobs:
       language: rust
       rust: stable
       cache: cargo
-      install:
-        - cargo fetch --locked
       script:
-        - cargo test --frozen --no-default-features
+        - cargo test --locked --no-default-features
 
     - language: go
       # XXX; The "1.10" must be quoted or it will get intrepreted as 1.1. See


### PR DESCRIPTION
Follow up
https://github.com/runconduit/conduit/pull/593 by avoiding
`cargo fetch` in favor of the implicit fetch done in `cargo build`
to work around the lack of a `--target` flag in `cargo fetch`. This
should at least slightly improve the speed and reliability of Travis
CI runs.

Signed-off-by: Brian Smith <brian@briansmith.org>