### PR TITLE
Move injected data from env var to k8s labels

### DIFF
--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: web-svc
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: web
     spec:
       containers:
       - env:
@@ -61,8 +62,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=web
         image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: web-svc
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: controller
     spec:
       containers:
       - env:
@@ -61,8 +62,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=controller
         image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -116,6 +115,7 @@ spec:
       labels:
         app: web-svc
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: not-controller
     spec:
       containers:
       - env:
@@ -158,8 +158,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=not-controller
         image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: web-svc
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: web
     spec:
       containers:
       - env:
@@ -62,8 +63,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=web
         image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: get-test
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: get-test-deploy-injected-1
     spec:
       containers:
       - args:
@@ -63,8 +64,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=get-test-deploy-injected-1
         image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -113,6 +112,7 @@ spec:
       labels:
         app: get-test
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: get-test-deploy-injected-2
     spec:
       containers:
       - args:
@@ -162,8 +162,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=get-test-deploy-injected-2
         image: gcr.io/runconduit/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -137,6 +137,7 @@ spec:
       labels:
         conduit.io/control-plane-component: controller
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: controller
     spec:
       containers:
       - args:
@@ -232,8 +233,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=controller
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -311,6 +310,7 @@ spec:
       labels:
         conduit.io/control-plane-component: web
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: web
     spec:
       containers:
       - args:
@@ -354,8 +354,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=web
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -429,6 +427,7 @@ spec:
       labels:
         conduit.io/control-plane-component: prometheus
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: prometheus
     spec:
       containers:
       - args:
@@ -470,8 +469,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=prometheus
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -572,8 +569,18 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
+      # __meta_kubernetes_pod_label_conduit_io_proxy_deployment=foo =>
+      # k8s_deployment=foo
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_conduit_io_proxy_(.+)
+        replacement: k8s_$1
+      # drop all labels that we just made copies of in the previous labelmap
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_conduit_io_proxy_(.+)
+      # __meta_kubernetes_pod_label_foo=bar => k8s_foo=bar
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+        replacement: k8s_$1
 
 ### Grafana ###
 ---
@@ -618,6 +625,7 @@ spec:
       labels:
         conduit.io/control-plane-component: grafana
         conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: grafana
     spec:
       containers:
       - image: grafana/grafana:5.0.3
@@ -661,8 +669,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=grafana
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -138,6 +138,7 @@ spec:
       labels:
         ControllerComponentLabel: controller
         conduit.io/control-plane-ns: Namespace
+        conduit.io/proxy-deployment: controller
     spec:
       containers:
       - args:
@@ -233,8 +234,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=controller
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -313,6 +312,7 @@ spec:
       labels:
         ControllerComponentLabel: web
         conduit.io/control-plane-ns: Namespace
+        conduit.io/proxy-deployment: web
     spec:
       containers:
       - args:
@@ -356,8 +356,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=web
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -432,6 +430,7 @@ spec:
       labels:
         ControllerComponentLabel: prometheus
         conduit.io/control-plane-ns: Namespace
+        conduit.io/proxy-deployment: prometheus
     spec:
       containers:
       - args:
@@ -473,8 +472,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=prometheus
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy
@@ -575,8 +572,18 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
+      # __meta_kubernetes_pod_label_conduit_io_proxy_deployment=foo =>
+      # k8s_deployment=foo
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_conduit_io_proxy_(.+)
+        replacement: k8s_$1
+      # drop all labels that we just made copies of in the previous labelmap
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_conduit_io_proxy_(.+)
+      # __meta_kubernetes_pod_label_foo=bar => k8s_foo=bar
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+        replacement: k8s_$1
 
 ### Grafana ###
 ---
@@ -622,6 +629,7 @@ spec:
       labels:
         ControllerComponentLabel: grafana
         conduit.io/control-plane-ns: Namespace
+        conduit.io/proxy-deployment: grafana
     spec:
       containers:
       - image: GrafanaImage
@@ -665,8 +673,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROMETHEUS_LABELS
-          value: deployment=grafana
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -384,8 +384,18 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
+      # __meta_kubernetes_pod_label_conduit_io_proxy_deployment=foo =>
+      # k8s_deployment=foo
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_conduit_io_proxy_(.+)
+        replacement: k8s_$1
+      # drop all labels that we just made copies of in the previous labelmap
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_conduit_io_proxy_(.+)
+      # __meta_kubernetes_pod_label_foo=bar => k8s_foo=bar
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+        replacement: k8s_$1
 
 ### Grafana ###
 ---

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -24,6 +24,26 @@ const (
 	// namespace of the Conduit control plane.
 	ControllerNSLabel = "conduit.io/control-plane-ns"
 
+	// ProxyDeploymentLabel is injected into mesh-enabled apps, identifying the
+	// deployment that this proxy belongs to.
+	ProxyDeploymentLabel = "conduit.io/proxy-deployment"
+
+	// ProxyReplicationControllerLabel is injected into mesh-enabled apps,
+	// identifying the ReplicationController that this proxy belongs to.
+	ProxyReplicationControllerLabel = "conduit.io/proxy-replication-controller"
+
+	// ProxyReplicaSetLabel is injected into mesh-enabled apps, identifying the
+	// ReplicaSet that this proxy belongs to.
+	ProxyReplicaSetLabel = "conduit.io/proxy-replica-set"
+
+	// ProxyJobLabel is injected into mesh-enabled apps, identifying the Job that
+	// this proxy belongs to.
+	ProxyJobLabel = "conduit.io/proxy-job"
+
+	// ProxyDaemonSetLabel is injected into mesh-enabled apps, identifying the
+	// DaemonSet that this proxy belongs to.
+	ProxyDaemonSetLabel = "conduit.io/proxy-daemon-set"
+
 	/*
 	 * Annotations
 	 */

--- a/proxy/src/telemetry/metrics/prometheus.rs
+++ b/proxy/src/telemetry/metrics/prometheus.rs
@@ -448,8 +448,6 @@ impl fmt::Display for RequestLabels {
         } else {
             write!(f, "direction=\"inbound\"")?;
         }
-        // TODO: when PR #448 lands, use CONDUIT_PROMETHEUS_LABELS
-        // to add the appropriate labels for the owner of this pod.
 
         Ok(())
     }


### PR DESCRIPTION
The inject code detects the object it is being injected into, and writes
self-identifying information into the CONDUIT_PROMETHEUS_LABELS
environment variable, so that conduit-proxy may read this information
and report it to Prometheus at collection time.

This change puts the self-identifying information directly into
Kubernetes labels, which Prometheus already collects, removing the need
for conduit-proxy to be aware of this information. The resulting label
in Prometheus is recorded in the form `conduit_io_proxy_deployment`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

This change is a follow up to #448.

![screen shot 2018-03-22 at 4 42 07 pm](https://user-images.githubusercontent.com/236915/37804373-2c7135e2-2df1-11e8-8206-694b44eecc2e.png)

![screen shot 2018-03-22 at 4 43 27 pm](https://user-images.githubusercontent.com/236915/37804374-2ebf11fc-2df1-11e8-8055-90bc4b8c706c.png)
