### PR TITLE
Update docker-compose environment to match prod

### DIFF
--- a/.prometheus.dev.yml
+++ b/.prometheus.dev.yml
@@ -4,37 +4,28 @@ global:
   scrape_interval:     10s
 
 scrape_configs:
-  - job_name: 'prometheus'
+  - job_name: 'conduit-controller'
     static_configs:
-      - targets: ['localhost:9090']
+    - targets:
+      - 'destination:9999'
+      - 'prometheus:9090'
+      - 'proxy-api:9996'
+      - 'public-api:9995'
+      - 'tap:9998'
+      - 'telemetry:9997'
+      - 'web:9994'
+    relabel_configs:
+    - action: labelmap
+      regex: __address__
+      replacement: component
+    - action: replace
+      source_labels: [component]
+      regex: ^(.*):.*$
+      target_label: component
 
-  - job_name: 'web'
+  - job_name: 'conduit-proxy'
     static_configs:
-      - targets: ['web:9994']
-
-  - job_name: 'public-api'
-    static_configs:
-      - targets: ['public-api:9995']
-
-  - job_name: 'proxy-api'
-    static_configs:
-      - targets: ['proxy-api:9996']
-
-  - job_name: 'telemetry'
-    static_configs:
-      - targets: ['telemetry:9997']
-
-  - job_name: 'tap'
-    static_configs:
-      - targets: ['tap:9998']
-
-  - job_name: 'destination'
-    static_configs:
-      - targets: ['destination:9999']
-
-  - job_name: 'conduit'
-    static_configs:
-      - targets:
-        - 'simulate-proxy:9000'
-        - 'simulate-proxy:9001'
-        - 'simulate-proxy:9002'
+    - targets:
+      - 'simulate-proxy:9000'
+      - 'simulate-proxy:9001'
+      - 'simulate-proxy:9002'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,15 @@ services:
     - --config.file=/etc/prometheus/prometheus.yml
     - --storage.tsdb.retention=6h
 
+  grafana:
+    image: grafana/grafana:5.0.3
+    ports:
+    - 3000:3000
+    volumes:
+    # TODO: find a way to share the dashboard json files, currently in cli/install/*.go
+    - ./grafana/dev.grafana.ini:/etc/grafana/grafana.ini:ro
+    - ./grafana/dev.datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
+
   simulate-proxy:
     image: golang:1.10.0-alpine3.7
     ports:

--- a/grafana/dev.datasources.yaml
+++ b/grafana/dev.datasources.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+- name: prometheus
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  isDefault: true
+  jsonData:
+    timeInterval: "5s"
+  version: 1
+  editable: true

--- a/grafana/dev.grafana.ini
+++ b/grafana/dev.grafana.ini
@@ -1,0 +1,14 @@
+instance_name = conduit-grafana
+
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+org_role = Editor
+
+[auth.basic]
+enabled = false
+
+[analytics]
+check_for_updates = false


### PR DESCRIPTION
The Prometheus config in the docker-compose environment had fallen
behind the prod setup.

This change updates the docker-compose environment in the following
ways:
- Prometheus config more closely matches prod, based on #583
- simulate-proxy labels matches prod, based on #605
- add Grafana container

Signed-off-by: Andrew Seigner <siggy@buoyant.io>