### PR TITLE
Remove references to `cli` images

### DIFF
--- a/bin/docker-images
+++ b/bin/docker-images
@@ -16,11 +16,8 @@ docker_image() {
 
 tag=$(head_root_tag)
 
-docker_image controller   "${tag}"
-docker_image proxy        "${tag}"
-docker_image proxy-init   "${tag}"
-docker_image web          "${tag}"
-docker_image cli          "${tag}"
-docker_image cli-bin      "${tag}"
+for img in proxy proxy-init controller web cli-bin ; do
+    docker_image "$img" "$tag"
+done
 
 docker_image go-deps      "$(go_deps_sha)"

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -13,9 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-docker_pull proxy        "${tag}"  || true
-docker_pull proxy-init   "${tag}"  || true
-docker_pull controller   "${tag}"  || true
-docker_pull web          "${tag}"  || true
-docker_pull cli          "${tag}"  || true
-docker_pull cli-bin      "${tag}"  || true
+for img in proxy proxy-init controller web cli-bin ; do
+    docker_pull "$img" "$tag"
+done

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -13,9 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-docker_push proxy        "${tag}"
-docker_push proxy-init   "${tag}"
-docker_push controller   "${tag}"
-docker_push web          "${tag}"
-docker_push cli          "${tag}"
-docker_push cli-bin      "${tag}"
+for img in proxy proxy-init controller web cli-bin ; do
+    docker_push "$img" "$tag"
+done

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -13,9 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-docker_retag proxy        "$from" "$to"
-docker_retag proxy-init   "$from" "$to"
-docker_retag controller   "$from" "$to"
-docker_retag web          "$from" "$to"
-docker_retag cli          "$from" "$to"
-docker_retag cli-bin      "$from" "$to"
+for img in proxy proxy-init controller web cli-bin ; do
+    docker_retag "$img" "$from" "$to"
+done


### PR DESCRIPTION
CI builds on master have been failing to publish `cli-bin` images because the
`bin/docker-push` script still refers to the `cli` image, though it was removed in
e7c4a9d4b91fda34446fbe3e74b63643a6665c03.

This change removes references to the `cli` image from all scripts.

Note that `bin/docker-pull` now fails when an image doesn't exist.