### PR TITLE
Improve CLI docker caching

### DIFF
--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -3,7 +3,9 @@ FROM gcr.io/runconduit/go-deps:5a44df7f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
-COPY controller controller
+COPY controller/api controller/api
+COPY controller/gen controller/gen
+COPY controller/util controller/util
 COPY pkg pkg
 RUN mkdir -p /out
 ENV GO_LDFLAGS="-s -w -X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}"


### PR DESCRIPTION
Currently, the CLI docker image copies the entire `controller`
directory, though the CLI only requires a few of its subdirectories.
This causes the CLI's docker cache to be needlessly invalidated when,
for instance, a service implementation changes.

By restricting the copied directories to `controller/{api,public,util}`,
build caching is improved.