### PR TITLE
Remove report-checking from ListPods

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -195,6 +195,7 @@ spec:
         resources: {}
       - args:
         - telemetry
+        - -controller-namespace=conduit
         - -ignore-namespaces=kube-system
         - -prometheus-url=http://prometheus.conduit.svc.cluster.local:9090
         - -log-level=info

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -196,6 +196,7 @@ spec:
         resources: {}
       - args:
         - telemetry
+        - -controller-namespace=Namespace
         - -ignore-namespaces=kube-system
         - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
         - -log-level=ControllerLogLevel

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -197,6 +197,7 @@ spec:
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - "telemetry"
+        - "-controller-namespace={{.Namespace}}"
         - "-ignore-namespaces=kube-system"
         - "-prometheus-url=http://prometheus.{{.Namespace}}.svc.cluster.local:9090"
         - "-log-level={{.ControllerLogLevel}}"

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -88,8 +88,18 @@ var (
 	controlPlaneComponents = []string{"web", "controller", "prometheus", "grafana"}
 )
 
-func newGrpcServer(telemetryClient telemPb.TelemetryClient, tapClient tapPb.TapClient, controllerNamespace string) *grpcServer {
-	return &grpcServer{telemetryClient: telemetryClient, tapClient: tapClient, controllerNamespace: controllerNamespace}
+func newGrpcServer(
+	telemetryClient telemPb.TelemetryClient,
+	tapClient tapPb.TapClient,
+	controllerNamespace string,
+	ignoreNamespaces []string,
+) *grpcServer {
+	return &grpcServer{
+		telemetryClient:     telemetryClient,
+		tapClient:           tapClient,
+		controllerNamespace: controllerNamespace,
+		ignoreNamespaces:    ignoreNamespaces,
+	}
 }
 
 func (s *grpcServer) Stat(ctx context.Context, req *pb.MetricRequest) (*pb.MetricResponse, error) {

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -92,13 +92,11 @@ func newGrpcServer(
 	telemetryClient telemPb.TelemetryClient,
 	tapClient tapPb.TapClient,
 	controllerNamespace string,
-	ignoreNamespaces []string,
 ) *grpcServer {
 	return &grpcServer{
 		telemetryClient:     telemetryClient,
 		tapClient:           tapClient,
 		controllerNamespace: controllerNamespace,
-		ignoreNamespaces:    ignoreNamespaces,
 	}
 }
 

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -192,15 +192,17 @@ func fullUrlPathFor(method string) string {
 	return ApiRoot + ApiPrefix + method
 }
 
-func NewServer(addr string, telemetryClient telemPb.TelemetryClient, tapClient tapPb.TapClient, controllerNamespace string) *http.Server {
-	baseHandler := &handler{
-		grpcServer: newGrpcServer(telemetryClient, tapClient, controllerNamespace),
-	}
-
-	instrumentedHandler := util.WithTelemetry(baseHandler)
+func NewServer(
+	addr, controllerNamespace string,
+	telemetryClient telemPb.TelemetryClient,
+	tapClient tapPb.TapClient,
+	ignoreNamespaces []string,
+) *http.Server {
+	grpcServer := newGrpcServer(telemetryClient, tapClient, controllerNamespace, ignoreNamespaces)
+	httpServer := &handler{grpcServer}
 
 	return &http.Server{
 		Addr:    addr,
-		Handler: instrumentedHandler,
+		Handler: util.WithTelemetry(httpServer),
 	}
 }

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -196,9 +196,8 @@ func NewServer(
 	addr, controllerNamespace string,
 	telemetryClient telemPb.TelemetryClient,
 	tapClient tapPb.TapClient,
-	ignoreNamespaces []string,
 ) *http.Server {
-	grpcServer := newGrpcServer(telemetryClient, tapClient, controllerNamespace, ignoreNamespaces)
+	grpcServer := newGrpcServer(telemetryClient, tapClient, controllerNamespace)
 	httpServer := &handler{grpcServer}
 
 	return &http.Server{

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 	defer tapConn.Close()
 
-	server := public.NewServer(*addr, telemetryClient, tapClient, *controllerNamespace)
+	server := public.NewServer(*addr, *controllerNamespace, telemetryClient, tapClient)
 
 	go func() {
 		log.Infof("starting HTTP server on %+v", *addr)

--- a/controller/cmd/telemetry/main.go
+++ b/controller/cmd/telemetry/main.go
@@ -17,6 +17,7 @@ func main() {
 	addr := flag.String("addr", "127.0.0.1:8087", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9997", "address to serve scrapable metrics on")
 	prometheusUrl := flag.String("prometheus-url", "http://127.0.0.1:9090", "prometheus url")
+	controllerNamespace := flag.String("controller-namespace", "conduit", "namespace in which Conduit is installed")
 	ignoredNamespaces := flag.String("ignore-namespaces", "", "comma separated list of namespaces to not list pods from")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
@@ -35,7 +36,8 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	server, lis, err := telemetry.NewServer(*addr, *prometheusUrl, strings.Split(*ignoredNamespaces, ","), *kubeConfigPath)
+	server, lis, err := telemetry.NewServer(*addr, *controllerNamespace, *prometheusUrl,
+		strings.Split(*ignoredNamespaces, ","), *kubeConfigPath)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
Currently, the `ListPods` implementation uses prometheus to see if the
instance has sent a telemetry report to the controller.

In preparation of removing the telemetry push functionality, the
`ListPods` endpoint should be changed to not rely on push telemetry.

While doing this, it seems that we don't actually need to talk to
prometheus to determine whether a pod is `added`. Instead, we check that
the pod is configured with the correct controller namespace.