### PR TITLE
Add support for CONDUIT_PROMETHEUS_LABELS to the proxy

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use http;
@@ -57,7 +58,7 @@ pub struct Config {
     pub bind_timeout: Duration,
 
     /// Labels to add to exported Prometheus metrics.
-    pub prometheus_labels: Option<String>,
+    pub prometheus_labels: Option<Arc<str>>,
 
     pub pod_name: Option<String>,
     pub pod_namespace: String,
@@ -246,7 +247,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
             pod_name: pod_name?,
             pod_namespace: pod_namespace?,
             node_name: node_name?,
-            prometheus_labels: prometheus_labels?,
+            prometheus_labels: prometheus_labels?
+                .map(Arc::from),
         })
     }
 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -56,6 +56,9 @@ pub struct Config {
     /// Timeout after which to cancel binding a request.
     pub bind_timeout: Duration,
 
+    /// Labels to add to exported Prometheus metrics.
+    pub prometheus_labels: Option<String>,
+
     pub pod_name: Option<String>,
     pub pod_namespace: String,
     pub node_name: Option<String>,
@@ -140,6 +143,8 @@ const ENV_NODE_NAME: &str = "CONDUIT_PROXY_NODE_NAME";
 const ENV_POD_NAME: &str = "CONDUIT_PROXY_POD_NAME";
 pub const ENV_POD_NAMESPACE: &str = "CONDUIT_PROXY_POD_NAMESPACE";
 
+pub const ENV_PROMETHEUS_LABELS: &str = "CONDUIT_PROMETHEUS_LABELS";
+
 pub const ENV_CONTROL_URL: &str = "CONDUIT_PROXY_CONTROL_URL";
 const ENV_RESOLV_CONF: &str = "CONDUIT_RESOLV_CONF";
 
@@ -187,6 +192,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
             })
         });
         let node_name = strings.get(ENV_NODE_NAME);
+        let prometheus_labels = strings.get(ENV_PROMETHEUS_LABELS);
 
         // There is no default controller URL because a default would make it
         // too easy to connect to the wrong controller, which would be dangerous.
@@ -240,6 +246,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
             pod_name: pod_name?,
             pod_namespace: pod_namespace?,
             node_name: node_name?,
+            prometheus_labels: prometheus_labels?,
         })
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -186,11 +186,11 @@ where
             "serving Prometheus metrics on {:?}",
             metrics_listener.local_addr(),
         );
-
         let (sensors, telemetry) = telemetry::new(
             &process_ctx,
             config.event_buffer_capacity,
             config.metrics_flush_interval,
+            config.prometheus_labels.clone(),
         );
 
         let (control, control_bg) = control::new();

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -24,6 +24,8 @@ pub struct MakeControl {
     flush_interval: Duration,
 
     process_ctx: Arc<ctx::Process>,
+
+    prometheus_labels: Option<Arc<str>>,
 }
 
 /// Handles the receipt of events.
@@ -77,11 +79,13 @@ impl MakeControl {
         rx: Receiver<Event>,
         flush_interval: Duration,
         process_ctx: &Arc<ctx::Process>,
+        prometheus_labels: Option<Arc<str>>,
     ) -> Self {
         Self {
             rx,
             flush_interval,
             process_ctx: Arc::clone(process_ctx),
+            prometheus_labels,
         }
     }
 
@@ -99,7 +103,7 @@ impl MakeControl {
 
         let flush_timeout = Timeout::new(self.flush_interval, handle)?;
         let (metrics_work, metrics_service) =
-            prometheus::new(&self.process_ctx);
+            prometheus::new(&self.process_ctx, self.prometheus_labels);
         let push_metrics = Some(PushMetrics::new(self.process_ctx));
 
         Ok(Control {

--- a/proxy/src/telemetry/metrics/prometheus.rs
+++ b/proxy/src/telemetry/metrics/prometheus.rs
@@ -36,6 +36,16 @@ struct Metrics {
 struct Metric<M, L: Hash + Eq> {
     name: &'static str,
     help: &'static str,
+
+    /// Labels from the `CONDUIT_PROMETHEUS_LABELS` environment variable.
+    ///
+    /// Since this should be applied to all metrics and never changes
+    /// over the lifetime of the process, we can store it at the `Metric` level
+    /// rather than in the `Labels` of each individual value. This should keep
+    /// the ref count much smaller, and means we don't have to factor it into
+    /// labels hashing.
+    env_labels: Option<Arc<str>>,
+
     values: IndexMap<L, M>
 }
 
@@ -79,8 +89,11 @@ pub struct Serve {
 /// is a Hyper service which can be used to create the server for the
 /// scrape endpoint, while the `Aggregate` side can receive updates to the
 /// metrics by calling `record_event`.
-pub fn new(process: &Arc<ctx::Process>) -> (Aggregate, Serve) {
-    let metrics = Arc::new(Mutex::new(Metrics::new(process)));
+pub fn new(process: &Arc<ctx::Process>,
+           env_labels: Option<Arc<str>>)
+           -> (Aggregate, Serve)
+{
+    let metrics = Arc::new(Mutex::new(Metrics::new(process, env_labels)));
     (Aggregate::new(&metrics), Serve::new(&metrics))
 }
 
@@ -139,7 +152,10 @@ struct OutboundLabels {
 
 impl Metrics {
 
-    pub fn new(process: &Arc<ctx::Process>) -> Self {
+    pub fn new(process: &Arc<ctx::Process>,
+               env_labels: Option<Arc<str>>)
+               -> Self
+    {
 
         let start_time = process.start_time
             .duration_since(time::UNIX_EPOCH)
@@ -152,6 +168,7 @@ impl Metrics {
         let request_total = Metric::<Counter, Arc<RequestLabels>>::new(
             "request_total",
             "A counter of the number of requests the proxy has received.",
+            env_labels.clone(),
         );
 
         let request_duration = Metric::<Histogram, Arc<RequestLabels>>::new(
@@ -159,11 +176,13 @@ impl Metrics {
             "A histogram of the duration of a request. This is measured from \
              when the request headers are received to when the request \
              stream has completed.",
+            env_labels.clone(),
         );
 
         let response_total = Metric::<Counter, Arc<ResponseLabels>>::new(
             "response_total",
             "A counter of the number of responses the proxy has received.",
+            env_labels.clone(),
         );
 
         let response_duration = Metric::<Histogram, Arc<ResponseLabels>>::new(
@@ -171,6 +190,8 @@ impl Metrics {
             "A histogram of the duration of a response. This is measured from \
              when the response headers are received to when the response \
              stream has completed.",
+
+            env_labels.clone(),
         );
 
         let response_latency = Metric::<Histogram, Arc<ResponseLabels>>::new(
@@ -178,6 +199,7 @@ impl Metrics {
             "A histogram of the total latency of a response. This is measured \
             from when the request headers are received to when the response \
             stream has completed.",
+            env_labels.clone(),
         );
 
         Metrics {
@@ -282,10 +304,14 @@ impl Counter {
 
 impl<M, L: Hash + Eq> Metric<M, L> {
 
-    pub fn new(name: &'static str, help: &'static str) -> Self {
+    pub fn new(name: &'static str,
+               help: &'static str,
+               env_labels: Option<Arc<str>>)
+               -> Self {
         Metric {
             name,
             help,
+            env_labels,
             values: IndexMap::new(),
         }
     }
@@ -304,9 +330,20 @@ where
             help = self.help,
         )?;
 
+        let comma = if self.env_labels.is_some() {
+            ","
+        } else {
+            ""
+        };
+
+        let env_labels = self.env_labels.as_ref()
+            .map_or("", AsRef::as_ref);
+
         for (labels, value) in &self.values {
-            write!(f, "{name}{{{labels}}} {value}\n",
+            write!(f, "{name}{{{env_labels}{comma}{labels}}} {value}\n",
                 name = self.name,
+                env_labels = env_labels,
+                comma = comma,
                 labels = labels,
                 value = value,
             )?;
@@ -327,7 +364,18 @@ impl<L> fmt::Display for Metric<Histogram, L> where
             help = self.help,
         )?;
 
+        // determine whether or not to place a comma after the labels from
+        // the environment variable.
+        let env_comma = if self.env_labels.is_some() {
+            ","
+        } else {
+            ""
+        };
+        let env_labels = self.env_labels.as_ref()
+            .map_or("", AsRef::as_ref);
+
         for (labels, histogram) in &self.values {
+
             // Look up the bucket numbers against the BUCKET_BOUNDS array
             // to turn them into upper bounds.
             let bounds_and_counts = histogram.into_iter()
@@ -341,8 +389,11 @@ impl<L> fmt::Display for Metric<Histogram, L> where
             for (le, count) in bounds_and_counts {
                 // Add this bucket's count to the total count.
                 total_count += count;
-                write!(f, "{name}_bucket{{{labels},le=\"{le}\"}} {count}\n",
+                write!(f,
+                    "{name}_bucket{{{env_labels}{comma}{labels},le=\"{le}\"}} {count}\n",
                     name = self.name,
+                    env_labels = env_labels,
+                    comma = env_comma,
                     labels = labels,
                     le = le,
                     // Print the total count *as of this iteration*.
@@ -352,9 +403,11 @@ impl<L> fmt::Display for Metric<Histogram, L> where
 
             // Print the total count and histogram sum stats.
             write!(f,
-                "{name}_count{{{labels}}} {count}\n\
-                 {name}_sum{{{labels}}} {sum}\n",
+                "{name}_count{{{env_labels}{comma}{labels}}} {count}\n\
+                 {name}_sum{{{env_labels}{comma}{labels}}} {sum}\n",
                 name = self.name,
+                env_labels = env_labels,
+                comma = env_comma,
                 labels = labels,
                 count = total_count,
                 sum = histogram.sum_in_ms(),

--- a/proxy/src/telemetry/mod.rs
+++ b/proxy/src/telemetry/mod.rs
@@ -27,8 +27,10 @@ pub use self::sensor::Sensors;
 ///
 /// # Arguments
 /// - `capacity`: the number of events to aggregate.
-/// - `flush_interval`: the length of time after which a metrics report should be sent,
-///   regardless of how many events have been aggregated.
+/// - `flush_interval`: the length of time after which a metrics report should
+///    be sent, regardless of how many events have been aggregated.
+/// - `prometheus_labels`: the value of the `CONDUIT_PROMETHEUS_LABELS`
+///    environment variable.
 ///
 /// [`Sensors`]: struct.Sensors.html
 /// [`Control`]: struct.Control.html
@@ -36,9 +38,10 @@ pub fn new(
     process: &Arc<ctx::Process>,
     capacity: usize,
     flush_interval: Duration,
+    prometheus_labels: Option<Arc<str>>
 ) -> (Sensors, MakeControl) {
     let (tx, rx) = futures_mpsc_lossy::channel(capacity);
     let s = Sensors::new(tx);
-    let c = MakeControl::new(rx, flush_interval, process);
+    let c = MakeControl::new(rx, flush_interval, process, prometheus_labels);
     (s, c)
 }


### PR DESCRIPTION
This PR adds support for the `CONDUIT_PROMETHEUS_LABELS` environment variable in the proxy. I've added a unit test asserting that the labels in the env var are correctly added to metrics.

Closes ##618.