### PR TITLE
Add process_start_time_seconds Prometheus metric

### DIFF
--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -9,6 +9,7 @@
 //! will be sent to a telemetry processing thread, we want to avoid excessive cloning.
 use config;
 use conduit_proxy_controller_grpc::telemetry as proto;
+use std::time::SystemTime;
 use std::sync::Arc;
 pub mod http;
 pub mod transport;
@@ -29,6 +30,8 @@ pub struct Process {
 
     /// Identifies the namespace for the `scheduled_instance`.
     pub scheduled_namespace: String,
+
+    pub start_time: SystemTime,
 }
 
 /// Indicates the orientation of traffic, relative to a sidecar proxy.
@@ -51,11 +54,13 @@ impl Process {
             node: node.into(),
             scheduled_instance: instance.into(),
             scheduled_namespace: ns.into(),
+            start_time: SystemTime::now(),
         })
     }
 
     /// Construct a new `Process` from environment variables.
     pub fn new(config: &config::Config) -> Arc<Self> {
+        let start_time = SystemTime::now();
         fn empty_if_missing(s: &Option<String>) -> String {
             match *s {
                 Some(ref s) => s.clone(),
@@ -67,6 +72,7 @@ impl Process {
             node: empty_if_missing(&config.node_name),
             scheduled_instance: empty_if_missing(&config.pod_name),
             scheduled_namespace: config.pod_namespace.clone(),
+            start_time,
         })
     }
 }

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -98,7 +98,8 @@ impl MakeControl {
         trace!("telemetry control flush_interval={:?}", self.flush_interval);
 
         let flush_timeout = Timeout::new(self.flush_interval, handle)?;
-        let (metrics_work, metrics_service) = prometheus::new();
+        let (metrics_work, metrics_service) =
+            prometheus::new(&self.process_ctx);
         let push_metrics = Some(PushMetrics::new(self.process_ctx));
 
         Ok(Control {


### PR DESCRIPTION
As described in #619. `process_start_time_seconds` is the idiomatic way of reporting to Prometheus the uptime of a process. It should contain the time in seconds since the beginning of the Unix epoch.

The proxy now exports this metric:
```
➜ http get localhost:4191/metrics
HTTP/1.1 200 OK
Content-Length: 902
Content-Type: text/plain; charset=utf-8
Date: Mon, 26 Mar 2018 22:09:55 GMT

# HELP request_total A counter of the number of requests the proxy has received.
# TYPE request_total counter

# HELP request_duration_ms A histogram of the duration of a request. This is measured from when the request headers are received to when the request stream has completed.
# TYPE request_duration_ms histogram

# HELP response_total A counter of the number of responses the proxy has received.
# TYPE response_total counter

# HELP response_duration_ms A histogram of the duration of a response. This is measured from when theresponse headers are received to when the response stream has completed.
# TYPE response_duration_ms histogram

# HELP response_latency_ms A histogram of the total latency of a response. This is measured from whenthe request headers are received to when the response stream has completed.
# TYPE response_latency_ms histogram

process_start_time_seconds 1522102089

```

Closes #619