### PR TITLE
Update Grafana dashboards to use new proxy metrics

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -817,7 +817,7 @@ data:
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1520894444409,
+      "iteration": 1522201643834,
       "links": [],
       "panels": [
         {
@@ -898,7 +898,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(count(responses_total{target_deployment=~\"$target_deployment\"}) by (target_deployment))",
+              "expr": "count(count(request_total) by (deployment))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -980,9 +980,9 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\", classification=\"success\"}[20s])) / sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s]))",
+              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\"}[20s]))) / sum(irate(response_total{}[20s]))",
               "format": "time_series",
-              "intervalFactor": 2,
+              "intervalFactor": 1,
               "legendFormat": "",
               "refId": "A"
             }
@@ -1062,7 +1062,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s]))",
+              "expr": "sum(irate(request_total{}[20s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -1135,10 +1135,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\", classification=\"success\"}[20s])) by (target_deployment) / sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s])) by (target_deployment)",
+              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\"}[20s])) by (deployment)) / sum(irate(response_total{}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1211,14 +1211,14 @@ data:
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s])) by (target_deployment)",
+              "expr": "sum(irate(request_total{}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1228,7 +1228,7 @@ data:
           "title": "Request Volume",
           "tooltip": {
             "shared": true,
-            "sort": 2,
+            "sort": 1,
             "value_type": "individual"
           },
           "type": "graph",
@@ -1295,21 +1295,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{target_deployment=~\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{target_deployment=~\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p95",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{target_deployment=~\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p99",
@@ -1378,12 +1378,12 @@ data:
           },
           "id": 40,
           "panels": [],
-          "repeat": "target_deployment",
+          "repeat": "deployment",
           "title": "",
           "type": "row"
         },
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-target_deployment=$target_deployment\">\n    <span style=\"font-size: 15px; border-image:none\">$target_deployment</span>\n  </a>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$deployment\">\n    <span style=\"font-size: 15px; border-image:none\">$deployment</span>\n  </a>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -1435,10 +1435,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", target_deployment=\"$target_deployment\"}[20s])) by (target) / sum(irate(responses_total{target_deployment=\"$target_deployment\"}[20s])) by (target)",
+              "expr": "(sum(irate(response_total{status_code=\"200\", dst_deployment=\"$deployment\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\", dst_deployment=\"$deployment\"}[20s])) by (deployment))/ sum(irate(response_total{dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1515,10 +1515,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=\"$target_deployment\"}[20s])) by (target)",
+              "expr": "sum(irate(request_total{dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1595,7 +1595,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1603,7 +1603,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1611,7 +1611,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1664,18 +1664,15 @@ data:
         "list": [
           {
             "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 2,
             "includeAll": true,
             "label": null,
             "multi": false,
-            "name": "target_deployment",
+            "name": "deployment",
             "options": [],
-            "query": "label_values(requests_total{target_deployment!~\"conduit/.*\"}, target_deployment)",
+            "query": "label_values(deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -1742,11 +1739,11 @@ data:
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1520894520976,
+      "iteration": 1522197746099,
       "links": [],
       "panels": [
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:40px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">$target_deployment</span>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:40px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">$deployment</span>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -1822,7 +1819,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(requests_total{target_deployment=\"$target_deployment\"}[20s]))",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\"}[20s]))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1906,7 +1903,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", target_deployment=\"$target_deployment\"}[20s])) / sum(irate(responses_total{target_deployment=\"$target_deployment\"}[20s]))",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=\"$deployment\"}[20s])) + sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$deployment\"}[20s]))) / sum(irate(response_total{deployment=\"$deployment\"}[20s]))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1990,7 +1987,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -2074,7 +2071,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -2158,7 +2155,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -2242,7 +2239,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(requests_total{target_deployment=\"$target_deployment\"})",
+              "expr": "count(request_total{dst_deployment=\"$deployment\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",
@@ -2324,7 +2321,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(requests_total{source_deployment=\"$target_deployment\", target_deployment=~\"$outbound\"})",
+              "expr": "count(request_total{deployment=\"$deployment\", dst_deployment=~\"$outbound\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",
@@ -2382,7 +2379,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{target_deployment=\"$target_deployment\"}[20s]))",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "inbound",
@@ -2462,7 +2459,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{source_deployment=\"$target_deployment\", target_deployment=~\"$outbound\"}[20s]))",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"outbound\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "outbound",
@@ -2535,7 +2532,7 @@ data:
           "type": "row"
         },
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-target_deployment=$inbound\">\n    <span style=\"font-size: 15px; border-image:none\">$inbound</span>\n  </a>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$inbound\">\n    <span style=\"font-size: 15px; border-image:none\">$inbound</span>\n  </a>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -2586,10 +2583,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (source_deployment)",
+              "expr": "sum(irate(request_total{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -2666,10 +2663,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (source_deployment) / sum(irate(responses_total{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (source_deployment)",
+              "expr": "(sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment) +sum(irate(response_total{status_code=\"200\", deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)) / sum(irate(response_total{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -2746,10 +2743,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (le, source_deployment))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}} P50",
+              "legendFormat": "{{deployment}} P50",
               "refId": "A"
             }
           ],
@@ -2826,10 +2823,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (le, source_deployment))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}} P95",
+              "legendFormat": "{{deployment}} P95",
               "refId": "A"
             }
           ],
@@ -2906,10 +2903,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (le, source_deployment))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}} P99",
+              "legendFormat": "{{deployment}} P99",
               "refId": "A"
             }
           ],
@@ -2993,7 +2990,7 @@ data:
           "type": "row"
         },
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-target_deployment=$outbound\">\n    <span style=\"font-size: 15px; border-image:none\">$outbound</span>\n  </a>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$outbound\">\n    <span style=\"font-size: 15px; border-image:none\">$outbound</span>\n  </a>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -3044,10 +3041,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (target_deployment)",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{dst_deployment}}",
               "refId": "A"
             }
           ],
@@ -3124,10 +3121,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (target_deployment) / sum(irate(responses_total{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (target_deployment)",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment) + sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)) / sum(irate(response_total{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{dst_deployment}}",
               "refId": "A"
             }
           ],
@@ -3204,10 +3201,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (le, target_deployment))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}} P50",
+              "legendFormat": "{{dst_deployment}} P50",
               "refId": "A"
             }
           ],
@@ -3284,10 +3281,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (le, target_deployment))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}} P95",
+              "legendFormat": "{{dst_deployment}} P95",
               "refId": "A"
             }
           ],
@@ -3364,10 +3361,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (le, target_deployment))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}} P99",
+              "legendFormat": "{{dst_deployment}} P99",
               "refId": "A"
             }
           ],
@@ -3416,19 +3413,15 @@ data:
         "list": [
           {
             "allValue": null,
-            "current": {
-              "isNone": true,
-              "text": "None",
-              "value": ""
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Deployment",
             "multi": false,
-            "name": "target_deployment",
+            "name": "deployment",
             "options": [],
-            "query": "label_values(requests_total{target_deployment!~\"conduit/.*\"}, target_deployment)",
+            "query": "label_values(deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -3440,10 +3433,7 @@ data:
           },
           {
             "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 2,
             "includeAll": true,
@@ -3451,7 +3441,7 @@ data:
             "multi": false,
             "name": "inbound",
             "options": [],
-            "query": "label_values(requests_total{target_deployment=\"$target_deployment\"}, source_deployment)",
+            "query": "label_values(request_total{dst_deployment=\"$deployment\"}, deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -3463,10 +3453,7 @@ data:
           },
           {
             "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 2,
             "includeAll": true,
@@ -3474,7 +3461,7 @@ data:
             "multi": false,
             "name": "outbound",
             "options": [],
-            "query": "label_values(requests_total{source_deployment=\"$target_deployment\", target_deployment!~\"conduit/.*\"}, target_deployment)",
+            "query": "label_values(request_total{deployment=\"$deployment\"}, dst_deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -3517,7 +3504,7 @@ data:
       },
       "timezone": "",
       "title": "Conduit Deployment",
-      "uid": "m9JcBBekk",
+      "uid": "6svnwykmk",
       "version": 1
     }
 
@@ -4697,7 +4684,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "conduit-health",
+      "title": "Conduit Health",
       "uid": "Og9nanzmk",
       "version": 3
     }

--- a/cli/install/deployment.go
+++ b/cli/install/deployment.go
@@ -19,11 +19,11 @@ const Deployment = `{
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1520894520976,
+      "iteration": 1522197746099,
       "links": [],
       "panels": [
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:40px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">$target_deployment</span>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:40px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">$deployment</span>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -99,7 +99,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(requests_total{target_deployment=\"$target_deployment\"}[20s]))",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\"}[20s]))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -183,7 +183,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", target_deployment=\"$target_deployment\"}[20s])) / sum(irate(responses_total{target_deployment=\"$target_deployment\"}[20s]))",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=\"$deployment\"}[20s])) + sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$deployment\"}[20s]))) / sum(irate(response_total{deployment=\"$deployment\"}[20s]))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -267,7 +267,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -351,7 +351,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -435,7 +435,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -519,7 +519,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(requests_total{target_deployment=\"$target_deployment\"})",
+              "expr": "count(request_total{dst_deployment=\"$deployment\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",
@@ -601,7 +601,7 @@ const Deployment = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(requests_total{source_deployment=\"$target_deployment\", target_deployment=~\"$outbound\"})",
+              "expr": "count(request_total{deployment=\"$deployment\", dst_deployment=~\"$outbound\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",
@@ -659,7 +659,7 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{target_deployment=\"$target_deployment\"}[20s]))",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "inbound",
@@ -739,7 +739,7 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{source_deployment=\"$target_deployment\", target_deployment=~\"$outbound\"}[20s]))",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"outbound\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "outbound",
@@ -812,7 +812,7 @@ const Deployment = `{
           "type": "row"
         },
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-target_deployment=$inbound\">\n    <span style=\"font-size: 15px; border-image:none\">$inbound</span>\n  </a>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$inbound\">\n    <span style=\"font-size: 15px; border-image:none\">$inbound</span>\n  </a>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -863,10 +863,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (source_deployment)",
+              "expr": "sum(irate(request_total{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -943,10 +943,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (source_deployment) / sum(irate(responses_total{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (source_deployment)",
+              "expr": "(sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment) +sum(irate(response_total{status_code=\"200\", deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)) / sum(irate(response_total{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -1023,10 +1023,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (le, source_deployment))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}} P50",
+              "legendFormat": "{{deployment}} P50",
               "refId": "A"
             }
           ],
@@ -1103,10 +1103,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (le, source_deployment))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}} P95",
+              "legendFormat": "{{deployment}} P95",
               "refId": "A"
             }
           ],
@@ -1183,10 +1183,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{source_deployment=\"$inbound\", target_deployment=\"$target_deployment\"}[20s])) by (le, source_deployment))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{source_deployment}} P99",
+              "legendFormat": "{{deployment}} P99",
               "refId": "A"
             }
           ],
@@ -1270,7 +1270,7 @@ const Deployment = `{
           "type": "row"
         },
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-target_deployment=$outbound\">\n    <span style=\"font-size: 15px; border-image:none\">$outbound</span>\n  </a>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$outbound\">\n    <span style=\"font-size: 15px; border-image:none\">$outbound</span>\n  </a>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -1321,10 +1321,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(requests_total{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (target_deployment)",
+              "expr": "sum(irate(request_total{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{dst_deployment}}",
               "refId": "A"
             }
           ],
@@ -1401,10 +1401,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (target_deployment) / sum(irate(responses_total{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (target_deployment)",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment) + sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)) / sum(irate(response_total{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{dst_deployment}}",
               "refId": "A"
             }
           ],
@@ -1481,10 +1481,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (le, target_deployment))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}} P50",
+              "legendFormat": "{{dst_deployment}} P50",
               "refId": "A"
             }
           ],
@@ -1561,10 +1561,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (le, target_deployment))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}} P95",
+              "legendFormat": "{{dst_deployment}} P95",
               "refId": "A"
             }
           ],
@@ -1641,10 +1641,10 @@ const Deployment = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{source_deployment=\"$target_deployment\", target_deployment=\"$outbound\"}[20s])) by (le, target_deployment))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}} P99",
+              "legendFormat": "{{dst_deployment}} P99",
               "refId": "A"
             }
           ],
@@ -1693,19 +1693,15 @@ const Deployment = `{
         "list": [
           {
             "allValue": null,
-            "current": {
-              "isNone": true,
-              "text": "None",
-              "value": ""
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 0,
             "includeAll": false,
             "label": "Deployment",
             "multi": false,
-            "name": "target_deployment",
+            "name": "deployment",
             "options": [],
-            "query": "label_values(requests_total{target_deployment!~\"conduit/.*\"}, target_deployment)",
+            "query": "label_values(deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -1717,10 +1713,7 @@ const Deployment = `{
           },
           {
             "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 2,
             "includeAll": true,
@@ -1728,7 +1721,7 @@ const Deployment = `{
             "multi": false,
             "name": "inbound",
             "options": [],
-            "query": "label_values(requests_total{target_deployment=\"$target_deployment\"}, source_deployment)",
+            "query": "label_values(request_total{dst_deployment=\"$deployment\"}, deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -1740,10 +1733,7 @@ const Deployment = `{
           },
           {
             "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 2,
             "includeAll": true,
@@ -1751,7 +1741,7 @@ const Deployment = `{
             "multi": false,
             "name": "outbound",
             "options": [],
-            "query": "label_values(requests_total{source_deployment=\"$target_deployment\", target_deployment!~\"conduit/.*\"}, target_deployment)",
+            "query": "label_values(request_total{deployment=\"$deployment\"}, dst_deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -1794,7 +1784,7 @@ const Deployment = `{
       },
       "timezone": "",
       "title": "Conduit Deployment",
-      "uid": "m9JcBBekk",
+      "uid": "6svnwykmk",
       "version": 1
     }
 `

--- a/cli/install/health.go
+++ b/cli/install/health.go
@@ -1175,7 +1175,7 @@ const Health = `{
         ]
       },
       "timezone": "",
-      "title": "conduit-health",
+      "title": "Conduit Health",
       "uid": "Og9nanzmk",
       "version": 3
     }

--- a/cli/install/viz.go
+++ b/cli/install/viz.go
@@ -19,7 +19,7 @@ const Viz = `{
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1520894444409,
+      "iteration": 1522201643834,
       "links": [],
       "panels": [
         {
@@ -100,7 +100,7 @@ const Viz = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(count(responses_total{target_deployment=~\"$target_deployment\"}) by (target_deployment))",
+              "expr": "count(count(request_total) by (deployment))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -182,9 +182,9 @@ const Viz = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\", classification=\"success\"}[20s])) / sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s]))",
+              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\"}[20s]))) / sum(irate(response_total{}[20s]))",
               "format": "time_series",
-              "intervalFactor": 2,
+              "intervalFactor": 1,
               "legendFormat": "",
               "refId": "A"
             }
@@ -264,7 +264,7 @@ const Viz = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s]))",
+              "expr": "sum(irate(request_total{}[20s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -337,10 +337,10 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\", classification=\"success\"}[20s])) by (target_deployment) / sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s])) by (target_deployment)",
+              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\"}[20s])) by (deployment)) / sum(irate(response_total{}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -413,14 +413,14 @@ const Viz = `{
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=~\"$target_deployment\"}[20s])) by (target_deployment)",
+              "expr": "sum(irate(request_total{}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target_deployment}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -430,7 +430,7 @@ const Viz = `{
           "title": "Request Volume",
           "tooltip": {
             "shared": true,
-            "sort": 2,
+            "sort": 1,
             "value_type": "individual"
           },
           "type": "graph",
@@ -497,21 +497,21 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{target_deployment=~\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{target_deployment=~\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p95",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{target_deployment=~\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p99",
@@ -580,12 +580,12 @@ const Viz = `{
           },
           "id": 40,
           "panels": [],
-          "repeat": "target_deployment",
+          "repeat": "deployment",
           "title": "",
           "type": "row"
         },
         {
-          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-target_deployment=$target_deployment\">\n    <span style=\"font-size: 15px; border-image:none\">$target_deployment</span>\n  </a>\n</div>",
+          "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$deployment\">\n    <span style=\"font-size: 15px; border-image:none\">$deployment</span>\n  </a>\n</div>",
           "gridPos": {
             "h": 2,
             "w": 24,
@@ -637,10 +637,10 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{classification=\"success\", target_deployment=\"$target_deployment\"}[20s])) by (target) / sum(irate(responses_total{target_deployment=\"$target_deployment\"}[20s])) by (target)",
+              "expr": "(sum(irate(response_total{status_code=\"200\", dst_deployment=\"$deployment\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\", dst_deployment=\"$deployment\"}[20s])) by (deployment))/ sum(irate(response_total{dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -717,10 +717,10 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(responses_total{target_deployment=\"$target_deployment\"}[20s])) by (target)",
+              "expr": "sum(irate(request_total{dst_deployment=\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{target}}",
+              "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
@@ -797,7 +797,7 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -805,7 +805,7 @@ const Viz = `{
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -813,7 +813,7 @@ const Viz = `{
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{target_deployment=\"$target_deployment\"}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -866,18 +866,15 @@ const Viz = `{
         "list": [
           {
             "allValue": null,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            },
+            "current": {},
             "datasource": "prometheus",
             "hide": 2,
             "includeAll": true,
             "label": null,
             "multi": false,
-            "name": "target_deployment",
+            "name": "deployment",
             "options": [],
-            "query": "label_values(requests_total{target_deployment!~\"conduit/.*\"}, target_deployment)",
+            "query": "label_values(deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,


### PR DESCRIPTION
The Top-line and Deployment Grafana dashboards relied on the
soon-to-be-removed telemetry pipeline metrics.

Update the Grafana dashboards to query for the new, proxy-based metrics.
Grafana dashboard layouts have not changed.

Depends on #635 to render metrics.

Part of #420.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>