### PR TITLE
Use a larger default h2 connection window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.3.0",
- "h2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.3 (git+https://github.com/carllerche/h2)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -143,7 +143,7 @@ dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "convert 0.3.0",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.3 (git+https://github.com/carllerche/h2)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.3.2 (git+https://github.com/danburkert/prost)",
@@ -249,8 +249,8 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.3"
+source = "git+https://github.com/carllerche/h2#01d81b46c20d85b30a0abeb6d62138f8cc8f87ba"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -786,7 +786,7 @@ source = "git+https://github.com/tower-rs/tower-grpc#57d976aca89c13838b946dca9b6
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.3 (git+https://github.com/carllerche/h2)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -812,7 +812,7 @@ source = "git+https://github.com/tower-rs/tower-h2#59f344f02d37a9e8596805f159bdc
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.3 (git+https://github.com/carllerche/h2)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
@@ -957,7 +957,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum h2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "39d9ebc6de5a56567932d30d1364fc69bf6435d2d705f033f4e722e41703d3b0"
+"checksum h2 0.1.3 (git+https://github.com/carllerche/h2)" = "<none>"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ members = [
 
 [patch.crates-io]
 prost-derive = { git = "https://github.com/danburkert/prost" }
+h2 = { git = "https://github.com/carllerche/h2" }

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use futures::{future, Async, Future, Poll, Stream};
-use h2;
 use http;
 use tokio_core::reactor::{
     Handle,
@@ -90,7 +89,7 @@ impl Background {
 
             let h2_client = tower_h2::client::Connect::new(
                 connect,
-                h2::client::Builder::default(),
+                ::default_h2_client_builder(),
                 ::logging::context_executor(ctx, executor.clone()),
             );
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -384,8 +384,7 @@ where
     B: tower_h2::Body + 'static,
     N: NewService<Request = http::Request<tower_h2::RecvBody>, Response = http::Response<B>> + 'static,
 {
-    let h2_builder = h2::server::Builder::default();
-    let server = tower_h2::Server::new(new_service, h2_builder, executor.clone());
+    let server = tower_h2::Server::new(new_service, default_h2_server_builder(), executor.clone());
     bound_port.listen_and_fold(
         executor,
         (server, executor.clone()),
@@ -398,4 +397,19 @@ where
             future::ok((server, executor))
         },
     )
+}
+
+fn default_h2_client_builder() -> h2::client::Builder {
+    let mut b = h2::client::Builder::new();
+    // Cargo-culted from gRPC.
+    b.initial_connection_window_size(1048560);
+    b.enable_push(false);
+    b
+}
+
+fn default_h2_server_builder() -> h2::server::Builder {
+    let mut b = h2::server::Builder::new();
+    // Cargo-culted from gRPC.
+    b.initial_connection_window_size(1048560);
+    b
 }

--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -97,10 +97,7 @@ where
                 }
             },
             bind::Protocol::Http2 => {
-                let mut h2_builder = h2::client::Builder::default();
-                // h2 currently doesn't handle PUSH_PROMISE that well, so we just
-                // disable it for now.
-                h2_builder.enable_push(false);
+                let h2_builder = ::default_h2_client_builder();
                 let h2 = tower_h2::client::Connect::new(connect, h2_builder, executor);
 
                 Client {

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -64,11 +64,12 @@ where
     ) -> Self {
         let recv_body_svc = HttpBodyNewSvc::new(stack.clone());
         let tcp = tcp::Proxy::new(tcp_connect_timeout, sensors.clone(), &executor);
+        let h2_builder = ::default_h2_server_builder();
         Server {
             executor: executor.clone(),
             get_orig_dst,
             h1: hyper::server::Http::new(),
-            h2: tower_h2::Server::new(recv_body_svc, Default::default(), executor),
+            h2: tower_h2::Server::new(recv_body_svc, h2_builder, executor),
             listen_addr,
             new_service: stack,
             proxy_ctx,


### PR DESCRIPTION
The default connection window (65535) is fairly small and limited in the
context of many applications.

grpc-go, for instance, uses a larger default value of 1048560 (slightly
less than 1MB). We now use this same default.

Fixes #638