### PR TITLE
fix grafana CrashLoopBackoff on image 5.0.3

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -67,7 +67,7 @@ func validateAndBuildConfig() (*installConfig, error) {
 		ControllerImage: fmt.Sprintf("%s/controller:%s", dockerRegistry, conduitVersion),
 		WebImage:        fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
 		PrometheusImage: "prom/prometheus:v2.1.0",
-		GrafanaImage:    "grafana/grafana:5.0.3",
+		GrafanaImage:    "grafana/grafana:5.0.4",
 		// TODO: these dashboards assume we're running in the "conduit" namespace
 		VizDashboard:             install.Viz,
 		DeploymentDashboard:      install.Deployment,

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -633,7 +633,7 @@ spec:
         conduit.io/proxy-deployment: grafana
     spec:
       containers:
-      - image: grafana/grafana:5.0.3
+      - image: grafana/grafana:5.0.4
         imagePullPolicy: IfNotPresent
         name: grafana
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     - --storage.tsdb.retention=6h
 
   grafana:
-    image: grafana/grafana:5.0.3
+    image: grafana/grafana:5.0.4
     ports:
     - 3000:3000
     volumes:


### PR DESCRIPTION
this is a known issue with grafana in k8s. `grafana/grafana:5.0.4` was just released today. update the repo from `5.0.3` to `5.0.4`
fixed issues #582