### PR TITLE
Use Go 1.10.1 to build all Go code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ jobs:
         - (cd proxy && cargo test --locked --no-default-features)
 
     - language: go
-      # XXX; The "1.10" must be quoted or it will get intrepreted as 1.1. See
+      # Quote the version number to avoid parsing issues like
       # https://github.com/travis-ci/gimme/issues/132.
-      go: "1.10"
+      go: "1.10.1"
       go_import_path: github.com/runconduit/conduit
       cache:
         directories:

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,7 +5,7 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.10.0
+FROM golang:1.10.1
 ENV TEMP_GOPATH=/temp-gopath
 WORKDIR ${TEMP_GOPATH}/src/github.com/runconduit/conduit
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:cc2413fa as golang
+FROM gcr.io/runconduit/go-deps:7433a12f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:cc2413fa as golang
+FROM gcr.io/runconduit/go-deps:7433a12f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:cc2413fa as golang
+FROM gcr.io/runconduit/go-deps:7433a12f as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:cc2413fa as golang
+FROM gcr.io/runconduit/go-deps:7433a12f as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Go 1.10.1 is a security release.

Signed-off-by: Brian Smith <brian@briansmith.org>