### PR TITLE
Modify simulate-proxy to be more pod-centric

### DIFF
--- a/.prometheus.dev.yml
+++ b/.prometheus.dev.yml
@@ -25,14 +25,15 @@ scrape_configs:
 
   - job_name: 'conduit-proxy'
     static_configs:
+    # use this to generate: https://play.golang.org/p/e7uvgT5sUo9
     - targets:
-      - 'simulate-proxy:9000'
-      - 'simulate-proxy:9001'
-      - 'simulate-proxy:9002'
-      - 'simulate-proxy:9003'
-      - 'simulate-proxy:9004'
-      - 'simulate-proxy:9005'
-      - 'simulate-proxy:9006'
-      - 'simulate-proxy:9007'
-      - 'simulate-proxy:9008'
-      - 'simulate-proxy:9009'
+      - 'simulate-proxy:10000'
+      - 'simulate-proxy:10001'
+      - 'simulate-proxy:10002'
+      - 'simulate-proxy:10003'
+      - 'simulate-proxy:10004'
+      - 'simulate-proxy:10005'
+      - 'simulate-proxy:10006'
+      - 'simulate-proxy:10007'
+      - 'simulate-proxy:10008'
+      - 'simulate-proxy:10009'

--- a/controller/k8s/replicasets.go
+++ b/controller/k8s/replicasets.go
@@ -69,6 +69,9 @@ func (p *ReplicaSetStore) GetReplicaSet(key string) (*v1beta1.ReplicaSet, error)
 	return rs, nil
 }
 
+// GetDeploymentForPod returns pod owner information:
+// if the pod's replicaset belongs to a deployment: "namespace/deployment"
+// if the pod's replicaset does not belong to a deployment: "namespace/replicaset"
 func (p *ReplicaSetStore) GetDeploymentForPod(pod *v1.Pod) (string, error) {
 	namespace := pod.Namespace
 	if len(pod.GetOwnerReferences()) == 0 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
   simulate-proxy:
     image: golang:1.10.0-alpine3.7
     ports:
-    - 9000-9009:9000-9009
+    - 10000-10009:10000-10009
     volumes:
     - .:/go/src/github.com/runconduit/conduit
     - ~/.kube/config:/kubeconfig:ro
@@ -131,7 +131,6 @@ services:
     - go
     - run
     - /go/src/github.com/runconduit/conduit/controller/script/simulate-proxy/main.go
-    - --metric-addrs=0.0.0.0:9000,0.0.0.0:9001,0.0.0.0:9002,0.0.0.0:9003,0.0.0.0:9004,0.0.0.0:9005,0.0.0.0:9006,0.0.0.0:9007,0.0.0.0:9008,0.0.0.0:9009
+    - --metric-ports=10000-10009
     - --kubeconfig=/kubeconfig
-    - --max-pods=10
     - --sleep=3s


### PR DESCRIPTION
simulate-proxy uses a deployment object from kubernetes to simulate
each proxy metrics endpoint.

Modify simulate-proxy to instead use a pod to simulate each proxy
metrics endpoint. This ensures that each metrics endpoint consistently
represents a pod in kubernetes, including it's namespace, deployment,
and label information.

This change also adds support for:
- a new `metric-ports` flag, default is `10000-10009`.
- `classification`, `pod_name`, and `pod_template_hash` labels

Signed-off-by: Andrew Seigner <siggy@buoyant.io>