### PR TITLE
Fix mock controller in proxy tests after adding labels to destinations

### DIFF
--- a/proxy/tests/support/controller.rs
+++ b/proxy/tests/support/controller.rs
@@ -281,8 +281,10 @@ pub fn destination_update(addr: SocketAddr) -> pb::destination::Update {
                             port: u32::from(addr.port()),
                         }),
                         weight: 0,
+                        ..Default::default()
                     },
                 ],
+                ..Default::default()
             },
         )),
     }


### PR DESCRIPTION
This PR fixes the build errors in PR #654 by adding the `Default` initializer to the destination responses constructed by the mock controller in the proxy tests. This will stop the compiler from complaining that the new fields added to the destination protobuf in #654 are uninitialized.

I'm working on making more complete proxy changes based on the additions in #654 in another branch, so that the proxy actually _uses_ the labels it receives from the controller. This will include adding tests that actually set values for the added fields. However, this patch to #654 will allow us to merge that branch separately from the proxy changes needed to make use of the code added, without breaking the build on master.
