### PR TITLE
Filter out conduit controller pods from Grafana

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -63,12 +63,11 @@ func validateAndBuildConfig() (*installConfig, error) {
 		return nil, err
 	}
 	return &installConfig{
-		Namespace:       controlPlaneNamespace,
-		ControllerImage: fmt.Sprintf("%s/controller:%s", dockerRegistry, conduitVersion),
-		WebImage:        fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
-		PrometheusImage: "prom/prometheus:v2.1.0",
-		GrafanaImage:    "grafana/grafana:5.0.4",
-		// TODO: these dashboards assume we're running in the "conduit" namespace
+		Namespace:                controlPlaneNamespace,
+		ControllerImage:          fmt.Sprintf("%s/controller:%s", dockerRegistry, conduitVersion),
+		WebImage:                 fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
+		PrometheusImage:          "prom/prometheus:v2.1.0",
+		GrafanaImage:             "grafana/grafana:5.0.4",
 		VizDashboard:             install.Viz,
 		DeploymentDashboard:      install.Deployment,
 		HealthDashboard:          install.Health,

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -820,7 +820,7 @@ data:
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1522201643834,
+      "iteration": 1522434948953,
       "links": [],
       "panels": [
         {
@@ -901,7 +901,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(count(request_total) by (deployment))",
+              "expr": "count(count(request_total{deployment=~\"$deployment\"}) by (deployment))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -983,7 +983,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\"}[20s]))) / sum(irate(response_total{}[20s]))",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=~\"$deployment\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\", deployment=~\"$deployment\"}[20s]))) / sum(irate(response_total{deployment=~\"$deployment\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",
@@ -1065,7 +1065,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(request_total{}[20s]))",
+              "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -1138,7 +1138,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\"}[20s])) by (deployment)) / sum(irate(response_total{}[20s])) by (deployment)",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=~\"$deployment\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\", deployment=~\"$deployment\"}[20s])) by (deployment)) / sum(irate(response_total{deployment=~\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{deployment}}",
@@ -1218,7 +1218,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{}[20s])) by (deployment)",
+              "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{deployment}}",
@@ -1298,21 +1298,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p95",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p99",
@@ -1675,7 +1675,7 @@ data:
             "multi": false,
             "name": "deployment",
             "options": [],
-            "query": "label_values(deployment)",
+            "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -3424,7 +3424,7 @@ data:
             "multi": false,
             "name": "deployment",
             "options": [],
-            "query": "label_values(deployment)",
+            "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,

--- a/cli/install/deployment.go
+++ b/cli/install/deployment.go
@@ -1701,7 +1701,7 @@ const Deployment = `{
             "multi": false,
             "name": "deployment",
             "options": [],
-            "query": "label_values(deployment)",
+            "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,

--- a/cli/install/viz.go
+++ b/cli/install/viz.go
@@ -19,7 +19,7 @@ const Viz = `{
       "gnetId": null,
       "graphTooltip": 1,
       "id": null,
-      "iteration": 1522201643834,
+      "iteration": 1522434948953,
       "links": [],
       "panels": [
         {
@@ -100,7 +100,7 @@ const Viz = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(count(request_total) by (deployment))",
+              "expr": "count(count(request_total{deployment=~\"$deployment\"}) by (deployment))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -182,7 +182,7 @@ const Viz = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\"}[20s]))) / sum(irate(response_total{}[20s]))",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=~\"$deployment\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\", deployment=~\"$deployment\"}[20s]))) / sum(irate(response_total{deployment=~\"$deployment\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",
@@ -264,7 +264,7 @@ const Viz = `{
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(request_total{}[20s]))",
+              "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[20s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -337,7 +337,7 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(sum(irate(response_total{status_code=\"200\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\"}[20s])) by (deployment)) / sum(irate(response_total{}[20s])) by (deployment)",
+              "expr": "(sum(irate(response_total{status_code=\"200\", deployment=~\"$deployment\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\", deployment=~\"$deployment\"}[20s])) by (deployment)) / sum(irate(response_total{deployment=~\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{deployment}}",
@@ -417,7 +417,7 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{}[20s])) by (deployment)",
+              "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[20s])) by (deployment)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{deployment}}",
@@ -497,21 +497,21 @@ const Viz = `{
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p95",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{}[20s])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p99",
@@ -874,7 +874,7 @@ const Viz = `{
             "multi": false,
             "name": "deployment",
             "options": [],
-            "query": "label_values(deployment)",
+            "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, deployment)",
             "refresh": 2,
             "regex": "",
             "sort": 1,


### PR DESCRIPTION
The Grafana dashboards were displaying all proxy-enabled pods, including
conduit controller pods. In the old telemetry pipeline filtering these
out required knowledge of the controller's namespace, which the
dashboards are agnostic to.

This change leverages the new `conduit_io_control_plane_component`
prometheus label to filter out proxy-enabled controller components.

Part of #420

Signed-off-by: Andrew Seigner <siggy@buoyant.io>