### PR TITLE
Rename grafana viz to top-line

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -21,7 +21,7 @@ type installConfig struct {
 	WebImage                 string
 	PrometheusImage          string
 	GrafanaImage             string
-	VizDashboard             string
+	TopLineDashboard         string
 	DeploymentDashboard      string
 	HealthDashboard          string
 	ControllerReplicas       uint
@@ -68,7 +68,7 @@ func validateAndBuildConfig() (*installConfig, error) {
 		WebImage:                 fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
 		PrometheusImage:          "prom/prometheus:v2.1.0",
 		GrafanaImage:             "grafana/grafana:5.0.4",
-		VizDashboard:             install.Viz,
+		TopLineDashboard:         install.TopLine,
 		DeploymentDashboard:      install.Deployment,
 		HealthDashboard:          install.Health,
 		ControllerReplicas:       controllerReplicas,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -26,7 +26,7 @@ func TestRender(t *testing.T) {
 		WebImage:                 "WebImage",
 		PrometheusImage:          "PrometheusImage",
 		GrafanaImage:             "GrafanaImage",
-		VizDashboard:             "VizDashboard",
+		TopLineDashboard:         "TopLineDashboard",
 		DeploymentDashboard:      "DeploymentDashboard",
 		HealthDashboard:          "HealthDashboard",
 		ControllerReplicas:       1,

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -723,7 +723,7 @@ spec:
         name: grafana-dashboards
       - configMap:
           items:
-          - key: conduit-viz.json
+          - key: conduit-top-line.json
             path: home.json
           name: grafana-dashboards
         name: grafana-dashboard-home
@@ -783,7 +783,7 @@ data:
       editable: true
       options:
         path: /var/lib/grafana/dashboards
-        homeDashboardId: conduit-viz
+        homeDashboardId: conduit-top-line
 
 ### Grafana ConfigMap ###
 # The ConfigMap below contains Grafana dashboards in the form of JSON files.
@@ -801,7 +801,7 @@ metadata:
   annotations:
     conduit.io/created-by: conduit/cli undefined
 data:
-  conduit-viz.json: |-
+  conduit-top-line.json: |-
     {
       "annotations": {
         "list": [

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -727,7 +727,7 @@ spec:
         name: grafana-dashboards
       - configMap:
           items:
-          - key: conduit-viz.json
+          - key: conduit-top-line.json
             path: home.json
           name: grafana-dashboards
         name: grafana-dashboard-home
@@ -787,7 +787,7 @@ data:
       editable: true
       options:
         path: /var/lib/grafana/dashboards
-        homeDashboardId: conduit-viz
+        homeDashboardId: conduit-top-line
 
 ### Grafana ConfigMap ###
 # The ConfigMap below contains Grafana dashboards in the form of JSON files.
@@ -805,8 +805,8 @@ metadata:
   annotations:
     CreatedByAnnotation: CliVersion
 data:
-  conduit-viz.json: |-
-    VizDashboard
+  conduit-top-line.json: |-
+    TopLineDashboard
 
   conduit-deployment.json: |-
     DeploymentDashboard

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -462,7 +462,7 @@ spec:
         configMap:
           name: grafana-dashboards
           items:
-          - key: conduit-viz.json
+          - key: conduit-top-line.json
             path: home.json
       containers:
       - name: grafana
@@ -537,7 +537,7 @@ data:
       editable: true
       options:
         path: /var/lib/grafana/dashboards
-        homeDashboardId: conduit-viz
+        homeDashboardId: conduit-top-line
 
 ### Grafana ConfigMap ###
 # The ConfigMap below contains Grafana dashboards in the form of JSON files.
@@ -555,8 +555,8 @@ metadata:
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:
-  conduit-viz.json: |-
-    {{.VizDashboard}}
+  conduit-top-line.json: |-
+    {{.TopLineDashboard}}
 
   conduit-deployment.json: |-
     {{.DeploymentDashboard}}

--- a/cli/install/top-line.go
+++ b/cli/install/top-line.go
@@ -1,7 +1,7 @@
 package install
 
-// Viz defines the primary Conduit Grafana dashboard, installed via the `conduit install` command.
-const Viz = `{
+// TopLine defines the primary Conduit Grafana dashboard, installed via the `conduit install` command.
+const TopLine = `{
       "annotations": {
         "list": [
           {


### PR DESCRIPTION
The primary Grafana dashboard was named 'viz' from a prototype.

Rename 'viz' to 'Top Line'.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>