### PR TITLE
fix pod status and count in control plane dashboard

### DIFF
--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -179,7 +179,7 @@ export default class ServiceMesh extends React.Component {
     return _(componentNames)
       .map((name, id) => {
         let componentPods = _.get(podIndex, _.get(componentDeploys, id), []);
-        return { name: name, pods: _.sortBy(getComponentPods(componentPods), "name") };
+        return { name: name, pods: getComponentPods(componentPods) };
       })
       .sortBy("name")
       .value();

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -11,6 +11,7 @@ import { rowGutter } from './util/Utils.js';
 import StatusTable from './StatusTable.jsx';
 import { Col, Row, Table } from 'antd';
 import {
+  getComponentPods,
   getPodsByDeployment,
   processRollupMetrics,
   processTimeseriesMetrics
@@ -178,10 +179,7 @@ export default class ServiceMesh extends React.Component {
     return _(componentNames)
       .map((name, id) => {
         let componentPods = _.get(podIndex, _.get(componentDeploys, id), []);
-        let podStatuses = _.map(componentPods, p => {
-          return { name: p.name, value: p.status === "Running" ? "good" : "bad" };
-        });
-        return { name: name, pods: _.sortBy(podStatuses, "name") };
+        return { name: name, pods: _.sortBy(getComponentPods(componentPods), "name") };
       })
       .sortBy("name")
       .value();

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -60,6 +60,16 @@ export const getPodsByDeployment = pods => {
     .value();
 };
 
+export const getComponentPods = componentPods => {
+  return _.chain(componentPods)
+    .map( p => {
+      return { name: p.name, value: getPodCategorization(p) };
+    })
+    .reject(p => _.isEmpty(p.value))
+    .sortBy("name")
+    .value();
+};
+
 export const processTimeseriesMetrics = (rawTs, targetEntity) => {
   let tsbyEntity = _.groupBy(rawTs, "metadata." + targetEntity);
   return _.reduce(tsbyEntity, (mem, metrics, entity) => {


### PR DESCRIPTION
- the control plane would show terminated and stale deployments in the UI, this is confusing behavior and might indicate errors that aren't there/
- this PR filters out terminated and failed component deploys from the UI
- it is to note that pending deploys will still be counted and represented with a greyed out status dot
- Fixes: #606

Signed-off-by: Franziska von der Goltz <franziska@vdgoltz.eu>