### PR TITLE
 Add `eventually!` macro to help de-flake telemetry tests 

### DIFF
--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -39,7 +39,7 @@ macro_rules! eventually {
             } else if i == $retries {
                 panic!($($arg)+)
             } else {
-                ::std::thread::sleep(Duration::from_millis(5));
+                ::std::thread::sleep(Duration::from_millis(15));
             }
         }
     };

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate log;
 
+#[macro_use]
 mod support;
 use self::support::*;
 
@@ -262,13 +263,11 @@ fn telemetry_report_errors_are_ignored() {}
 
 macro_rules! assert_contains {
     ($scrape:expr, $contains:expr) => {
-        assert!($scrape.contains($contains), "metrics scrape:\n{:8}\ndid not contain:\n{:8}", $scrape, $contains)
+        eventually!($scrape.contains($contains), "metrics scrape:\n{:8}\ndid not contain:\n{:8}", $scrape, $contains)
     }
 }
 
-// https://github.com/runconduit/conduit/issues/613
 #[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_inbound_request_count() {
     let _ = env_logger::try_init();
 
@@ -297,9 +296,7 @@ fn metrics_endpoint_inbound_request_count() {
 
 }
 
-// https://github.com/runconduit/conduit/issues/613
 #[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_outbound_request_count() {
     let _ = env_logger::try_init();
 
@@ -385,9 +382,7 @@ mod response_classification {
             })
     }
 
-    // https://github.com/runconduit/conduit/issues/613
     #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn inbound_http() {
         let _ = env_logger::try_init();
         let srv = make_test_server().run();
@@ -417,9 +412,7 @@ mod response_classification {
         }
     }
 
-    // https://github.com/runconduit/conduit/issues/613
     #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn outbound_http() {
         let _ = env_logger::try_init();
         let srv = make_test_server().run();


### PR DESCRIPTION
Closes #615.

Based on @olix0r's suggestion in https://github.com/runconduit/conduit/issues/613#issuecomment-376024744, this PR adds an `eventually!` macro to retry an assertion a set number of times, waiting for 15 ms between retries. This is loosely based on ScalaTest's [eventually](http://doc.scalatest.org/1.8/org/scalatest/concurrent/Eventually.html).

I've rewritten the flaky telemetry tests to use the `eventually!` macro, to compensate for delays in the served metrics being updated between client requests and metrics scrapes.