### PR TITLE
Fix missing comma in gRPC status code labels

### DIFF
--- a/proxy/src/telemetry/metrics/prometheus.rs
+++ b/proxy/src/telemetry/metrics/prometheus.rs
@@ -605,7 +605,7 @@ impl fmt::Display for ResponseLabels {
             self.status_code
         )?;
         if let Some(ref status) = self.grpc_status_code {
-            write!(f, "grpc_status_code=\"{}\"", status)?;
+            write!(f, ",grpc_status_code=\"{}\"", status)?;
         }
 
         Ok(())


### PR DESCRIPTION
Fixes the issue caught by @olix0r in https://github.com/runconduit/conduit/pull/661#issuecomment-378431155