### PR TITLE
Pretty-print durations in log messages

### DIFF
--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -34,7 +34,7 @@ pub struct TimeoutFuture<F> {
     timeout: ReactorTimeout,
 }
 
-/// Pretty-print durations as fractional seconds.
+/// A duration which pretty-prints as fractional seconds.
 ///
 /// This may not be the ideal display format for _all_ duration values,
 /// but should be sufficient for most timeouts.
@@ -158,10 +158,8 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            TimeoutError::Timeout(ref duration) =>
-                write!(f, "operation timed out after {}",
-                    HumanDuration(*duration)
-                ),
+            TimeoutError::Timeout(ref d) =>
+                write!(f, "operation timed out after {}", HumanDuration(*d)),
             TimeoutError::Error(ref err) => fmt::Display::fmt(err, f),
         }
     }
@@ -224,8 +222,8 @@ where
 
 impl fmt::Display for HumanDuration {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let secs = self.as_secs();
-        let subsec_ms = self.subsec_nanos() as f64 / 1_000_000f64;
+        let secs = self.0.as_secs();
+        let subsec_ms = self.0.subsec_nanos() as f64 / 1_000_000f64;
         if secs == 0 {
             write!(fmt, "{}ms", subsec_ms)
         } else {

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -224,7 +224,6 @@ where
 
 impl fmt::Display for HumanDuration {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        // let precision = fmt.precision().unwrap_or(3);
         let secs = self.as_secs();
         let subsec_ms = self.subsec_nanos() as f64 / 1_000_000f64;
         if secs == 0 {

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -227,9 +227,9 @@ impl fmt::Display for HumanDuration {
         let secs = self.as_secs();
         let subsec_ms = self.subsec_nanos() as f64 / 1_000_000f64;
         if secs == 0 {
-            write!(fmt, "{} ms", subsec_ms)
+            write!(fmt, "{}ms", subsec_ms)
         } else {
-            write!(fmt, "{} s", secs as f64 + subsec_ms)
+            write!(fmt, "{}s", secs as f64 + subsec_ms)
         }
     }
 }

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -2,7 +2,7 @@
 use futures::{Async, Future, Poll};
 
 use std::error::Error;
-use std::{fmt, io, ops};
+use std::{fmt, io};
 use std::time::Duration;
 
 use tokio_connect::Connect;
@@ -231,23 +231,6 @@ impl fmt::Display for HumanDuration {
         } else {
             write!(fmt, "{}s", secs as f64 + subsec_ms)
         }
-    }
-}
-
-impl ops::Deref for HumanDuration {
-    type Target = Duration;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl ops::DerefMut for HumanDuration {
-
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
This branch adds simple pretty-printing to duration in log timeout messages. If the duration is >= 1 second, it's printed in seconds with a fractional part. If the duration is less than 1 second, it is printed in milliseconds. This simple formatting may not be sufficient as a formatting rule for all cases, but should be sufficient for printing our relatively small timeouts.

Log messages now look something like this:
```
ERROR 2018-04-04T20:05:49Z: conduit_proxy: turning operation timed out after 100 ms into 500
```

Previously, they looked like this:
```
ERROR 2018-04-04T20:07:26Z: conduit_proxy: turning operation timed out after Duration { secs: 0, nanos: 100000000 } into 500
```

I made this change partially because I wanted to make the panics from the `eventually!` macro added in #669 more readable.