### PR TITLE
Add pretty durations to panics from `eventually!`

### DIFF
--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -75,8 +75,10 @@ macro_rules! assert_eventually {
                     break;
                 } else if i == $retries {
                     panic!(
-                        "assertion failed after {:?} (retried {} times): {}",
-                        start_t.elapsed(), i, format_args!($($arg)+)
+                        "assertion failed after {} (retried {} times): {}",
+                        timeout::HumanDuration(start_t.elapsed()),
+                        i,
+                        format_args!($($arg)+)
                     )
                 } else {
                     ::std::thread::sleep(patience);


### PR DESCRIPTION
This PR adds the pretty-printing for durations I added in #676 to the panic message from the `eventually!` macro added in #669. 

Should merge after #676.