### PR TITLE
Make `control::Cache` key-value in order to store discovery metadata

### DIFF
--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -1,6 +1,7 @@
-use indexmap::IndexMap;
+use indexmap::{map, IndexMap};
 use std::borrow::Borrow;
 use std::hash::Hash;
+use std::iter::IntoIterator;
 use std::mem;
 
 /// A key-value cache that supports incremental updates with lazy resetting
@@ -177,6 +178,18 @@ where
             }
         });
         self.reset_on_next_modification = false;
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a Cache<K, V>
+where
+    K: Hash + Eq,
+{
+    type IntoIter = map::Iter<'a, K, V>;
+    type Item = <map::Iter<'a, K, V> as Iterator>::Item;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
     }
 }
 

--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -75,7 +75,7 @@ where
                 F: FnMut((K, V), CacheChange)
         {
             for (key, value) in iter {
-                if values.insert(key, value.clone()).is_some() {
+                if values.insert(key, value.clone()).is_none() {
                     on_change((key, value), CacheChange::Insertion);
                 }
             }

--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -59,10 +59,6 @@ where
         }
     }
 
-    pub fn as_map(&self) -> &IndexMap<K, V> {
-        &self.values
-    }
-
     pub fn set_reset_on_next_modification(&mut self) {
         self.reset_on_next_modification = true;
     }
@@ -151,7 +147,7 @@ where
     /// match `to_update`.
     pub fn update_intersection<F, Q>(
         &mut self,
-        to_update: &IndexMap<K, V>,
+        to_update: &IndexMap<Q, V>,
         mut on_change: F
     )
     where

--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -58,7 +58,7 @@ where
         }
     }
 
-    pub fn values(&self) -> &IndexMap<K, V> {
+    pub fn as_map(&self) -> &IndexMap<K, V> {
         &self.values
     }
 

--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -162,8 +162,8 @@ where
                 // If the new value isn't equal to the old value, overwrite
                 // the old value.
                 Some(new_value) =>  {
-                    let old_value = mem::replace(value, new_value);
-                    on_change((*key, old_value), CacheChange::Modification);
+                    let _ = mem::replace(value, new_value.clone());
+                    on_change((*key, new_value), CacheChange::Modification);
                     true
                 },
                 // Key doesn't exist, remove it from the map.

--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -105,13 +105,13 @@ where
         if !self.reset_on_next_modification {
             update_inner(&mut self.inner, iter, on_change);
         } else {
-            let mut to_insert = iter.collect::<IndexMap<K, V>>();
+            let to_insert = iter.collect::<IndexMap<K, V>>();
             update_inner(
                 &mut self.inner,
                 to_insert.iter().map(|(k, v)| (*k, v.clone())),
                 on_change,
             );
-            self.update_intersection(&mut to_insert, on_change);
+            self.update_intersection(to_insert, on_change);
         }
         self.reset_on_next_modification = false;
     }
@@ -137,7 +137,7 @@ where
     where
         F: FnMut((K, V), CacheChange),
     {
-        self.update_intersection(&mut IndexMap::new(), on_change)
+        self.update_intersection(IndexMap::new(), on_change)
     }
 
     /// Update the cache to contain the intersection of its current contents
@@ -147,7 +147,7 @@ where
     /// match `to_update`.
     pub fn update_intersection<F, Q>(
         &mut self,
-        to_update: &mut IndexMap<Q, V>,
+        mut to_update: IndexMap<Q, V>,
         mut on_change: F
     )
     where

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -446,18 +446,13 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
                  authority_for_logging: &FullyQualifiedAuthority,
                  addr: SocketAddr,
                  change: CacheChange) {
-        if let CacheChange::Modification = change {
-            // Skip `Modification` cache change events entirely until metadata
-            // changes occur, and are handled correctly.
-            return;
-        }
         let (update_str, update_constructor): (&'static str, fn(SocketAddr) -> Update) =
             match change {
                 CacheChange::Insertion => ("insert", Update::Insert),
                 CacheChange::Removal => ("remove", Update::Remove),
                 CacheChange::Modification => {
                     // TODO: generate `ChangeMetadata` events.
-                    unreachable!();
+                    return;
                 }
             };
         trace!("{} {:?} for {:?}", update_str, addr, authority_for_logging);

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -271,7 +271,7 @@ where
                             // them onto the new watch first
                             match set.addrs {
                                 Exists::Yes(ref cache) => {
-                                    for (&addr, _) in cache.as_map().iter() {
+                                    for (&addr, _) in cache {
                                         tx.unbounded_send(Update::Insert(addr))
                                             .expect("unbounded_send does not fail");
                                     }

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -189,25 +189,10 @@ where
 
                 Ok(Async::Ready(Change::Insert(addr, service)))
             },
-            Update::ChangeMetadata(addr) => {
-                // XXX: this is extremely wrong. we can't handle metadata
-                // changes by rebinding the service, for the following reasons:
-                //  1. rebinding the service will tear down any existing
-                //     connections, which we shouldn't have to do just to
-                //     change labels;
-                //  2. tower-balance won't honor the `Change::Insert` event for
-                //     a key that already exists; it will ignore that event
-                //     to avoid rebinding the service for the reasons discussed
-                //     above. so when metadata changes are actually meaningful,
-                //     they won't actually be reflected.
-                // TODO: we should solve the above issue by changing the
-                // labeling middleware to hold a `futures-watch::Watch` on the
-                // label value, so it can be updated without re-binding the
-                // underlying service.
-                let service = self.bind.bind(&addr).map_err(|_| ())?;
-
-                Ok(Async::Ready(Change::Insert(addr, service)))
-            },
+            // TODO: handle metadata changes by changing the labeling
+            // middleware to hold a `futures-watch::Watch` on the label value,
+            // so it can be updated.
+            Update::ChangeMetadata(_) => unimplemented!(),
             Update::Remove(addr) => Ok(Async::Ready(Change::Remove(addr))),
         }
     }

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -271,7 +271,7 @@ where
                             // them onto the new watch first
                             match set.addrs {
                                 Exists::Yes(ref cache) => {
-                                    for (&addr, _) in cache.values().iter() {
+                                    for (&addr, _) in cache.as_map().iter() {
                                         tx.unbounded_send(Update::Insert(addr))
                                             .expect("unbounded_send does not fail");
                                     }

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -398,7 +398,7 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
             Exists::Yes(mut cache) => cache,
             Exists::Unknown | Exists::No => Cache::new(),
         };
-        cache.extend(
+        cache.update_union(
             addrs_to_add.map(|a| (a, ())),
             &mut |(addr, _), change| Self::on_change(&mut self.txs, authority_for_logging, addr,
                                                 change));

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -21,6 +21,7 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate ns_dns_tokio;
+#[cfg_attr(test, macro_use)]
 extern crate indexmap;
 extern crate prost;
 extern crate prost_types;


### PR DESCRIPTION
This PR changes the proxy's `control::Cache` module from a set to a key-value map. 

This change is made in order to use the values in the map to store metadata from the Destination API, but allow evictions and insertions to be based only on the `SocketAddr` of the destination entry. This will make code in PR #661 much simpler, by removing the need to wrap `SocketAddr`s in the cache in a `Labeled` struct for storing metadata, and the need for custom `Borrow` implementations on that type.

Furthermore, I've changed from using a standard library `HashSet`/`HashMap` as the underlying collection to using `IndexMap`, as we suspect that this will result in performance improvements. 

Currently, as `master` has no additional metadata to associate with cache entries, the type of the values in the map is `()`. When #661 merges, the values will actually contain metadata.

If we suspect that there are many other use-cases for `control::Cache` where it will be treated as a set rather than a map, we may want to provide a separate set of impls for `Cache<T, ()>` (like `std::HashSet`) to make the API more ergonomic in this case. 