### PR TITLE
Harmonize Prometheus label usage

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -571,7 +571,7 @@ data:
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: pod_name
+        target_label: pod
       # special case k8s' "job" label, to not interfere with prometheus' "job"
       # label
       # __meta_kubernetes_pod_label_conduit_io_proxy_job=foo =>

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -574,7 +574,7 @@ data:
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: pod_name
+        target_label: pod
       # special case k8s' "job" label, to not interfere with prometheus' "job"
       # label
       # __meta_kubernetes_pod_label_conduit_io_proxy_job=foo =>

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -386,7 +386,7 @@ data:
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: pod_name
+        target_label: pod
       # special case k8s' "job" label, to not interfere with prometheus' "job"
       # label
       # __meta_kubernetes_pod_label_conduit_io_proxy_job=foo =>

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -77,7 +77,7 @@ func (l *endpointListener) toWeightedAddrSet(endpoints []common.TcpAddress) *pb.
 			} else {
 				pod := resultingPods[0]
 				metricLabelsForPod = map[string]string{
-					"k8s_pod": pod.Name,
+					"pod": pod.Name,
 				}
 
 				namespace = pod.Namespace
@@ -92,8 +92,8 @@ func (l *endpointListener) toWeightedAddrSet(endpoints []common.TcpAddress) *pb.
 	}
 
 	globalMetricLabels := map[string]string{
-		"k8s_service":   l.serviceName,
-		"k8s_namespace": namespace,
+		"service":   l.serviceName,
+		"namespace": namespace,
 	}
 
 	return &pb.WeightedAddrSet{

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -113,13 +113,13 @@ func TestEndpointListener(t *testing.T) {
 		listener.Update([]common.TcpAddress{addedAddress1, addedAddress2}, nil)
 
 		actualGlobalMetricLabels := mockGetServer.updatesReceived[0].GetAdd().MetricLabels
-		expectedGlobalMetricLabels := map[string]string{"k8s_namespace": expectedNamespace, "k8s_service": expectedServiceName}
+		expectedGlobalMetricLabels := map[string]string{"namespace": expectedNamespace, "service": expectedServiceName}
 		if !reflect.DeepEqual(actualGlobalMetricLabels, expectedGlobalMetricLabels) {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedGlobalMetricLabels, actualGlobalMetricLabels)
 		}
 
 		actualAddedAddress1MetricLabels := mockGetServer.updatesReceived[0].GetAdd().Addrs[0].MetricLabels
-		expectedAddedAddress1MetricLabels := map[string]string{"k8s_pod": expectedPodName}
+		expectedAddedAddress1MetricLabels := map[string]string{"pod": expectedPodName}
 		if !reflect.DeepEqual(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels) {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedAddedAddress1MetricLabels, actualAddedAddress1MetricLabels)
 		}

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -271,7 +271,7 @@ func newSimulatedProxy(pod v1.Pod, deployments []string, replicaSets *k8s.Replic
 		"namespace":         pod.GetNamespace(),
 		"deployment":        deploymentName,
 		"pod_template_hash": pod.GetLabels()["pod-template-hash"],
-		"pod_name":          pod.GetName(),
+		"pod":               pod.GetName(),
 
 		// TODO: support other k8s objects
 		// "daemon_set",

--- a/doc/prometheus.md
+++ b/doc/prometheus.md
@@ -40,7 +40,7 @@ rich telemetry data to your cluster.  Simply add the following item to your
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
-        target_label: pod_name
+        target_label: pod
       # special case k8s' "job" label, to not interfere with prometheus' "job"
       # label
       # __meta_kubernetes_pod_label_conduit_io_proxy_job=foo =>

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -38,52 +38,69 @@ request headers are received to when the response stream has completed.
 
 Each of these metrics has the following labels:
 
+* `authority`: The value of the `:authority` (HTTP/2) or `Host` (HTTP/1.1)
+               header of the request.
+* `direction`: `inbound` if the request originated from outside of the pod,
+               `outbound` if the request originated from inside of the pod.
+
+### Response Labels
+
+The following labels are only applicable on `response_*` metrics.
+
 * `classification`: `success` if the response was successful, or `failure` if
                     a server error occurred. This classification is based on
                     the gRPC status code if one is present, and on the HTTP
                     status code otherwise. Only applicable to response metrics.
-* `direction`: `inbound` if the request originated from outside of the pod,
-               `outbound` if the request originated from inside of the pod.
-* `authority`: The value of the `:authority` (HTTP/2) or `Host` (HTTP/1.1)
-               header of the request.
-* `dst_deployment`: The deployment to which this request is being sent.  Only
-                    applicable if `direction=outbound`.
-* `dst_job`: The job to which this request is being sent.  Only applicable if
-             `direction=outbound`.
-* `dst_replica_set`: The replica set to which this request is being sent.  Only
-                     applicable if `direction=outbound`.
-* `dst_daemon_set`: The daemon set to which this request is being sent.  Only
-                    applicable if `direction=outbound`.
-* `dst_replication_controller`: The replication controller to which this request
-                                is being sent.  Only applicable if
-                                `direction=outbound`.
-* `dst_namespace`: The namespace to which this request is being sent.  Only
-                   applicable if `direction=outbound`.
-* `status_code`: The HTTP status code of the response.  Only applicable to
-                 response metrics.
 * `grpc_status_code`: The value of the `grpc-status` trailer.  Only applicable
-                      to response metrics for gRPC responses.
+                      for gRPC responses.
+* `status_code`: The HTTP status code of the response.
 
-The following labels are added by the Prometheus collector. All Kubernetes
-labels are mapped to corresponding `k8s_*` Prometheus labels. Kubernetes labels
-prefixed with `conduit.io/` are added to your application at `conduit inject`
-time. More specifically, Kubernetes labels prefixed with `conduit.io/proxy-*`
-will correspond to `k8s_*` Prometheus labels:
+### Outbound labels
+
+The following labels are only applicable if `direction=outbound`.
+
+* `dst_deployment`: The deployment to which this request is being sent.
+* `dst_job`: The job to which this request is being sent.
+* `dst_replica_set`: The replica set to which this request is being sent.
+* `dst_daemon_set`: The daemon set to which this request is being sent.
+* `dst_replication_controller`: The replication controller to which this request
+                                is being sent.
+* `dst_namespace`: The namespace to which this request is being sent.
+* `dst_service`: The service to which this request is being sent.
+
+### Prometheus Collector labels
+
+The following labels are added by the Prometheus collector.
 
 * `instance`: ip:port of the pod.
 * `job`: The Prometheus job responsible for the collection, typically
          `conduit-proxy`.
+
+#### Kubernetes labels added at collection time
+
+Kubernetes namespace, pod name, and all labels are mapped to corresponding
+Prometheus labels.
+
 * `namespace`: Kubernetes namespace that the pod belongs to.
-* `deployment`: The deployment that the pod belongs to (if applicable).
-* `k8s_job`: The job that the pod belongs to (if applicable).
-* `replica_set`: The replica set that the pod belongs to (if applicable).
-* `daemon_set`: The daemon set that the pod belongs to (if applicable).
-* `replication_controller`: The replication controller that the pod belongs to
-                            (if applicable).
-* `pod_name`: Kubernetes pod name.
+* `pod`: Kubernetes pod name.
 * `pod_template_hash`: Corresponds to the [pod-template-hash][pod-template-hash]
                        Kubernetes label. This value changes during redeploys and
                        rolling restarts.
+
+#### Conduit labels added at collection time
+
+Kubernetes labels prefixed with `conduit.io/` are added to your application at
+`conduit inject` time. More specifically, Kubernetes labels prefixed with
+`conduit.io/proxy-*` will correspond to these Prometheus labels:
+
+* `daemon_set`: The daemon set that the pod belongs to (if applicable).
+* `deployment`: The deployment that the pod belongs to (if applicable).
+* `k8s_job`: The job that the pod belongs to (if applicable).
+* `replica_set`: The replica set that the pod belongs to (if applicable).
+* `replication_controller`: The replication controller that the pod belongs to
+                            (if applicable).
+
+### Example
 
 Here's a concrete example, given the following pod snippet:
 
@@ -102,11 +119,11 @@ The resulting Prometheus labels will look like this:
 
 ```
 request_total{
+  pod="vote-bot-5b7f5657f6-xbjjw",
   namespace="emojivoto",
   app="vote-bot",
   conduit_io_control_plane_ns="conduit",
   deployment="vote-bot",
-  pod_name="vote-bot-5b7f5657f6-xbjjw",
   pod_template_hash="3957278789",
   test="vote-bot-test",
   instance="10.1.3.93:4191",


### PR DESCRIPTION
The Destination service used slightly different labels than the
telemetry pipeline expected, specifically, prefixed with `k8s_*`.

Make all Prometheus labels consistent by dropping `k8s_*`. Also rename
`pod_name` to `pod` for consistency with `deployement`, etc. Also update
and reorganize `proxy-metrics.md` to reflect new labelling.

Fixes #655

Signed-off-by: Andrew Seigner <siggy@buoyant.io>