### PR TITLE
Fix ci job failing when new Docker image added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,9 @@ jobs:
       before_script:
         - gcloud docker --authorize-only
         - bin/docker-pull-deps
-        - bin/docker-pull master
+         # Pulling master helps with docker build cache, but may fail if we're
+         # adding a new image to the mix.
+        - bin/docker-pull master || echo "docker pull failed" >&2
         - |
           export CONDUIT_TAG=$(. bin/_tag.sh ; clean_head_root_tag)
           echo "CONDUIT_TAG=${CONDUIT_TAG}"


### PR DESCRIPTION
The master ci job executes a `docker-pull master` prior to building, to
bootstrap the Docker image cache. This command fails if the PR being
merged to master introduces a new Docker image, for example:
https://travis-ci.org/runconduit/conduit/jobs/362841328

This changes the master ci job to handle a `docker-pull master` failure
gracefully.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>