### PR TITLE
Revert "Proxy: Refactor DNS name parsing and normalization (#673)"

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -349,7 +349,7 @@ fn parse_url(s: &str) -> Result<HostAndPort, ParseError> {
     // https://github.com/hyperium/http/issues/127. For now just ignore any
     // fragment that is there.
 
-    HostAndPort::normalize(authority, None)
+    HostAndPort::try_from(authority)
         .map_err(|e| ParseError::UrlError(UrlError::AuthorityError(e)))
 }
 
@@ -366,7 +366,7 @@ fn parse<T, Parse>(strings: &Strings, name: &str, parse: Parse) -> Result<Option
     match strings.get(name)? {
         Some(ref s) => {
             let r = parse(s).map_err(|parse_error| {
-                error!("{}={:?} is not valid: {:?}", name, s, parse_error);
+                error!("{} is not valid: {:?}", name, parse_error);
                 Error::InvalidEnvVar
             })?;
             Ok(Some(r))

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -17,7 +17,8 @@ use tower_h2;
 use tower_reconnect::{Error as ReconnectError, Reconnect};
 
 use dns;
-use transport::{DnsNameAndPort, HostAndPort, LookupAddressAndConnect};
+use fully_qualified_authority::FullyQualifiedAuthority;
+use transport::{HostAndPort, LookupAddressAndConnect};
 use timeout::{Timeout, TimeoutError};
 
 mod cache;
@@ -40,9 +41,8 @@ pub struct Background {
     disco: DiscoBg,
 }
 
-pub fn new(default_destination_namespace: String) -> (Control, Background)
-{
-    let (tx, rx) = self::discovery::new(default_destination_namespace);
+pub fn new() -> (Control, Background) {
+    let (tx, rx) = self::discovery::new();
 
     let c = Control {
         disco: tx,
@@ -58,7 +58,7 @@ pub fn new(default_destination_namespace: String) -> (Control, Background)
 // ===== impl Control =====
 
 impl Control {
-    pub fn resolve<B>(&self, auth: &DnsNameAndPort, bind: B) -> Watch<B> {
+    pub fn resolve<B>(&self, auth: &FullyQualifiedAuthority, bind: B) -> Watch<B> {
         self.disco.resolve(auth, bind)
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -202,10 +202,11 @@ where
             config.metrics_flush_interval,
         );
 
-        let (control, control_bg) = control::new(config.pod_namespace.clone());
+        let (control, control_bg) = control::new();
+
+        let executor = core.handle();
 
         let dns_config = dns::Config::from_file(&config.resolv_conf_path);
-        let executor = core.handle();
 
         let bind = Bind::new(executor.clone()).with_sensors(sensors.clone());
 

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -18,10 +18,9 @@ use bind::{self, Bind, Protocol};
 use control::{self, discovery};
 use control::discovery::Bind as BindTrait;
 use ctx;
-use fully_qualified_authority::FullyQualifiedAuthority;
+use fully_qualified_authority::{FullyQualifiedAuthority, NamedAddress};
 use timeout::Timeout;
 use transparency::h1;
-use transport::{DnsNameAndPort, Host, HostAndPort};
 
 type BindProtocol<B> = bind::BindProtocol<Arc<ctx::Proxy>, B>;
 
@@ -53,10 +52,24 @@ impl<B> Outbound<B> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Destination {
-    Hostname(DnsNameAndPort),
-    ExplicitIp(SocketAddr),
-    ImplicitOriginalDst(SocketAddr),
+    LocalSvc(FullyQualifiedAuthority),
+    External(SocketAddr),
 }
+
+impl From<FullyQualifiedAuthority> for Destination {
+    #[inline]
+    fn from(authority: FullyQualifiedAuthority) -> Self {
+        Destination::LocalSvc(authority)
+    }
+}
+
+impl From<SocketAddr> for Destination {
+    #[inline]
+    fn from(addr: SocketAddr) -> Self {
+        Destination::External(addr)
+    }
+}
+
 
 impl<B> Recognize for Outbound<B>
 where
@@ -79,46 +92,38 @@ where
         // by `NormalizeUri`, as we need to know whether the request will
         // be routed by Host/authority or by SO_ORIGINAL_DST, in order to
         // determine whether the service is reusable.
-        let authority = req.uri().authority_part()
+        let local = req.uri().authority_part()
             .cloned()
         // Therefore, we need to check the host header as well as the URI
         // for a valid authority, before we fall back to SO_ORIGINAL_DST.
-            .or_else(|| h1::authority_from_host(req));
+            .or_else(|| h1::authority_from_host(req))
+            .map(|authority| {
+                FullyQualifiedAuthority::normalize(
+                    &authority,
+                    &self.default_namespace)
+            });
 
-
-        // TODO: Return error when `HostAndPort::normalize()` fails.
-        let mut dest = match authority.as_ref()
-            .and_then(|auth| HostAndPort::normalize(auth, Some(80)).ok()) {
-            Some(HostAndPort { host: Host::DnsName(dns_name), port }) => {
-                let authority = DnsNameAndPort { host: dns_name, port };
-                // Work around the inability of control/discovery.rs to handle unnormalized names.
-                // TODO: Remove this use of `FullyQualifiedAuthority::normalize()` and use
-                // `Destination::Hostname` for all `Host::DnsName` values once DNS machinery is
-                // added to control/discovery.rs.
-                FullyQualifiedAuthority::normalize(&authority, &self.default_namespace)
-                    .map(|_| Destination::Hostname(authority))
-            },
-            Some(HostAndPort { host: Host::Ip(ip), port }) =>
-                Some(Destination::ExplicitIp(SocketAddr::from((ip, port)))),
-            None => None
-        };
-
-        if dest.is_none() {
-            dest = req.extensions()
+        // If we can't fully qualify the authority as a local service,
+        // and there is no original dst, then we have nothing! In that
+        // case, we return `None`, which results an "unrecognized" error.
+        //
+        // In practice, this shouldn't ever happen, since we expect the proxy
+        // to be run on Linux servers, with iptables setup, so there should
+        // always be an original destination.
+        let dest = if let Some(NamedAddress {
+            name,
+            use_destination_service: true
+        }) = local {
+            Destination::LocalSvc(name)
+        } else {
+            let orig_dst = req.extensions()
                 .get::<Arc<ctx::transport::Server>>()
                 .and_then(|ctx| {
                     ctx.orig_dst_if_not_local()
-                })
-                .map(Destination::ImplicitOriginalDst)
+                });
+            Destination::External(orig_dst?)
         };
 
-        // If there is no authority in the request URI or in the Host header,
-        // and there is no original dst, then we have nothing! In that case,
-        // return `None`, which results an "unrecognized" error. In practice,
-        // this shouldn't ever happen, since we expect the proxy to be run on
-        // Linux servers, with iptables setup, so there should always be an
-        // original destination.
-        let dest = dest?;
 
         Some(proto.into_key(dest))
     }
@@ -140,15 +145,16 @@ where
         debug!("building outbound {:?} client to {:?}", protocol, dest);
 
         let resolve = match *dest {
-            Destination::Hostname(ref authority) =>
-                Discovery::NamedSvc(self.discovery.resolve(
+            Destination::LocalSvc(ref authority) => {
+                Discovery::LocalSvc(self.discovery.resolve(
                     authority,
                     self.bind.clone().with_protocol(protocol.clone()),
-                )),
-            Destination::ExplicitIp(addr) =>
-                Discovery::ExplicitIp((addr, self.bind.clone().with_protocol(protocol.clone()))),
-            Destination::ImplicitOriginalDst(addr) =>
-                Discovery::External(Some((addr, self.bind.clone().with_protocol(protocol.clone())))),
+                ))
+            },
+            Destination::External(addr) => {
+                Discovery::External(Some((addr, self.bind.clone()
+                    .with_protocol(protocol.clone()))))
+            }
         };
 
         let loaded = tower_balance::load::WithPendingRequests::new(resolve);
@@ -170,8 +176,7 @@ where
 }
 
 pub enum Discovery<B> {
-    NamedSvc(discovery::Watch<BindProtocol<B>>),
-    ExplicitIp((SocketAddr, BindProtocol<B>)),
+    LocalSvc(discovery::Watch<BindProtocol<B>>),
     External(Option<(SocketAddr, BindProtocol<B>)>),
 }
 
@@ -188,18 +193,8 @@ where
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {
         match *self {
-            Discovery::NamedSvc(ref mut w) => w.poll()
+            Discovery::LocalSvc(ref mut w) => w.poll()
                 .map_err(|_| BindError::Internal),
-            Discovery::ExplicitIp((addr, ref bind)) => {
-                // This "discovers" a single address for a fixed IP address
-                // that never has another change. This can mean it floats
-                // in the Balancer forever. However, when we finally add
-                // circuit-breaking, this should be able to take care of itself,
-                // closing down when the connection is no longer usable.
-                let svc = bind.bind(&addr)
-                    .map_err(|_| BindError::External{ addr })?;
-                Ok(Async::Ready(Change::Insert(addr, svc)))
-            },
             Discovery::External(ref mut opt) => {
                 // This "discovers" a single address for an external service
                 // that never has another change. This can mean it floats

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use http;
 
 use connection;
+use convert;
 use dns;
 
 #[derive(Debug, Clone)]
@@ -23,24 +24,14 @@ pub struct HostAndPort {
     pub port: u16,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DnsNameAndPort {
-    pub host: dns::Name,
-    pub port: u16,
-}
-
-
 #[derive(Clone, Debug)]
 pub enum Host {
-    DnsName(dns::Name),
+    DnsName(String),
     Ip(IpAddr),
 }
 
 #[derive(Clone, Copy, Debug)]
 pub enum HostAndPortError {
-    /// The host is not a valid DNS name or IP address.
-    InvalidHost,
-
     /// The port is missing.
     MissingPort,
 }
@@ -54,23 +45,17 @@ pub struct LookupAddressAndConnect {
 
 // ===== impl HostAndPort =====
 
-impl HostAndPort {
-    pub fn normalize(a: &http::uri::Authority, default_port: Option<u16>)
-        -> Result<Self, HostAndPortError>
-    {
+impl<'a> convert::TryFrom<&'a http::uri::Authority> for HostAndPort {
+    type Err = HostAndPortError;
+    fn try_from(a: &http::uri::Authority) -> Result<Self, Self::Err> {
         let host = {
-            match dns::Name::normalize(a.host()) {
-                Ok(host) => Host::DnsName(host),
-                Err(_) => {
-                    let ip: IpAddr = IpAddr::from_str(a.host())
-                        .map_err(|_| HostAndPortError::InvalidHost)?;
-                    Host::Ip(ip)
-                },
+            let host = a.host();
+            match IpAddr::from_str(host) {
+                Err(_) => Host::DnsName(host.to_owned()),
+                Ok(ip) => Host::Ip(ip),
             }
         };
-        let port = a.port()
-            .or(default_port)
-            .ok_or_else(|| HostAndPortError::MissingPort)?;
+        let port = a.port().ok_or_else(|| HostAndPortError::MissingPort)?;
         Ok(HostAndPort {
             host,
             port

--- a/proxy/src/transport/mod.rs
+++ b/proxy/src/transport/mod.rs
@@ -3,7 +3,7 @@ mod so_original_dst;
 
 pub use self::connect::{
     Connect,
-    DnsNameAndPort, Host, HostAndPort, HostAndPortError,
+    Host, HostAndPort, HostAndPortError,
     LookupAddressAndConnect,
 };
 pub use self::so_original_dst::{GetOriginalDst, SoOriginalDst};


### PR DESCRIPTION
This reverts commit 311ef41 due to integration test failure.

Signed-off-by: Brian Smith <brian@briansmith.org>