### PR TITLE
Fix public-api config in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,12 +78,16 @@ services:
     ports:
     - "8085:8085"
     - "9995:9995"
+    volumes:
+    - ~/.kube/config:/kubeconfig:ro
     command:
     - public-api
     - -addr=:8085
     - -metrics-addr=:9995
     - -telemetry-addr=telemetry:8087
     - -tap-addr=tap:8088
+    - -prometheus-url=http://prometheus:9090
+    - -kubeconfig=/kubeconfig
 
   web:
     build:


### PR DESCRIPTION
The public-api in the docker-compose environment is not configured to
talk to Prometheus or Kubernetes, which is now required with the new
telemetry pipeline.

Modify the public-api config in docker-compose to connect to k8s and
prom.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>