### PR TITLE
Namespace-aware Grafana dashboards

### DIFF
--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1522197746099,
+  "iteration": 1523047156373,
   "links": [],
   "panels": [
     {
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$deployment\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum(irate(response_total{status_code=\"200\", deployment=\"$deployment\"}[20s])) + sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$deployment\"}[20s]))) / sum(irate(response_total{deployment=\"$deployment\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -264,7 +264,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -348,7 +348,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -432,7 +432,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -516,7 +516,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(request_total{dst_deployment=\"$deployment\"})",
+          "expr": "count(request_total{dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -598,7 +598,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(request_total{deployment=\"$deployment\", dst_deployment=~\"$outbound\"})",
+          "expr": "count(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=~\"$outbound\", direction=\"outbound\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -656,7 +656,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "inbound",
@@ -736,7 +736,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"outbound\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[20s]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "outbound",
@@ -809,7 +809,7 @@
       "type": "row"
     },
     {
-      "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$inbound\">\n    <span style=\"font-size: 15px; border-image:none\">$inbound</span>\n  </a>\n</div>",
+      "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">$inbound</span>\n</div>",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -860,7 +860,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)",
+          "expr": "sum(irate(request_total{deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}}",
@@ -940,7 +940,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment) +sum(irate(response_total{status_code=\"200\", deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)) / sum(irate(response_total{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (deployment) / sum(irate(response_total{deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}}",
@@ -1020,7 +1020,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}} P50",
@@ -1100,7 +1100,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}} P95",
@@ -1180,7 +1180,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_deployment=\"$deployment\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}} P99",
@@ -1267,7 +1267,7 @@
       "type": "row"
     },
     {
-      "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$outbound\">\n    <span style=\"font-size: 15px; border-image:none\">$outbound</span>\n  </a>\n</div>",
+      "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">$outbound</span>\n</div>",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -1318,7 +1318,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{dst_deployment}}",
@@ -1398,7 +1398,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(response_total{status_code=\"200\", deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment) + sum(irate(response_total{grpc_status_code=\"0\", deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)) / sum(irate(response_total{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (dst_deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{dst_deployment}}",
@@ -1478,7 +1478,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
+          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{dst_deployment}} P50",
@@ -1558,7 +1558,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{dst_deployment}} P95",
@@ -1638,7 +1638,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", dst_deployment=\"$outbound\"}[20s])) by (le, dst_deployment))",
+          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{dst_deployment}} P99",
@@ -1694,11 +1694,31 @@
         "datasource": "prometheus",
         "hide": 0,
         "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, namespace)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": false,
         "label": "Deployment",
         "multi": false,
         "name": "deployment",
         "options": [],
-        "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, deployment)",
+        "query": "label_values(request_total{namespace=\"$namespace\", conduit_io_control_plane_component=\"\"}, deployment)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1718,7 +1738,7 @@
         "multi": false,
         "name": "inbound",
         "options": [],
-        "query": "label_values(request_total{dst_deployment=\"$deployment\"}, deployment)",
+        "query": "label_values(request_total{dst_namespace=\"$namespace\", dst_deployment=\"$deployment\"}, deployment)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1738,7 +1758,7 @@
         "multi": false,
         "name": "outbound",
         "options": [],
-        "query": "label_values(request_total{deployment=\"$deployment\"}, dst_deployment)",
+        "query": "label_values(request_total{namespace=\"$namespace\", deployment=\"$deployment\"}, dst_deployment)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1522434948953,
+  "iteration": 1523048893004,
   "links": [],
   "panels": [
     {
@@ -55,7 +55,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 3
       },
@@ -97,7 +97,89 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(count(request_total{deployment=~\"$deployment\"}) by (deployment))",
+          "expr": "count(count(request_total{namespace=~\"$namespace\"}) by (namespace))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Namespaces Monitored",
+      "type": "singlestat",
+      "valueFontSize": "200%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 1,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 3
+      },
+      "height": "",
+      "id": 86,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(count(request_total{namespace=~\"$namespace\"}) by (namespace, deployment))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -137,8 +219,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 12,
         "y": 3
       },
       "height": "",
@@ -179,7 +261,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum(irate(response_total{status_code=\"200\", deployment=~\"$deployment\"}[20s]))+sum(irate(response_total{grpc_status_code=\"0\", deployment=~\"$deployment\"}[20s]))) / sum(irate(response_total{deployment=~\"$deployment\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", deployment=~\"$deployment\"}[20s])) / sum(irate(response_total{deployment=~\"$deployment\"}[20s]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -219,8 +301,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 18,
         "y": 3
       },
       "height": "",
@@ -334,10 +416,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(response_total{status_code=\"200\", deployment=~\"$deployment\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\", deployment=~\"$deployment\"}[20s])) by (deployment)) / sum(irate(response_total{deployment=~\"$deployment\"}[20s])) by (deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (namespace) / sum(irate(response_total{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{deployment}}",
+          "legendFormat": "{{namespace}}",
           "refId": "A"
         }
       ],
@@ -414,10 +496,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[20s])) by (deployment)",
+          "expr": "sum(irate(request_total{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{deployment}}",
+          "legendFormat": "{{namespace}}",
           "refId": "A"
         }
       ],
@@ -494,24 +576,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (le, namespace))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50",
+          "legendFormat": "p50 {{namespace}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (le, namespace))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p95",
+          "legendFormat": "p95 {{namespace}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{deployment=~\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (le, namespace))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99",
+          "legendFormat": "p99 {{namespace}}",
           "refId": "C"
         }
       ],
@@ -577,12 +659,12 @@
       },
       "id": 40,
       "panels": [],
-      "repeat": "deployment",
+      "repeat": "namespace",
       "title": "",
       "type": "row"
     },
     {
-      "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-deployment=$deployment\">\n    <span style=\"font-size: 15px; border-image:none\">$deployment</span>\n  </a>\n</div>",
+      "content": "<div>\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <a href=\"./dashboard/db/conduit-deployment?var-namespace=$namespace\">\n    <span style=\"font-size: 15px; border-image:none\">$namespace</span>\n  </a>\n</div>",
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -634,7 +716,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(irate(response_total{status_code=\"200\", dst_deployment=\"$deployment\"}[20s])) by (deployment) + sum(irate(response_total{grpc_status_code=\"0\", dst_deployment=\"$deployment\"}[20s])) by (deployment))/ sum(irate(response_total{dst_deployment=\"$deployment\"}[20s])) by (deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (deployment) / sum(irate(response_total{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}}",
@@ -714,7 +796,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{dst_deployment=\"$deployment\"}[20s])) by (deployment)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{deployment}}",
@@ -794,27 +876,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (le, deployment))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "p50",
+          "legendFormat": "p50 {{deployment}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (le, deployment))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "p95",
+          "legendFormat": "p95 {{deployment}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{dst_deployment=\"$deployment\"}[20s])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (le, deployment))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "p99",
+          "legendFormat": "p99 {{deployment}}",
           "refId": "C"
         }
       ],
@@ -861,6 +943,26 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, namespace)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
       {
         "allValue": null,
         "current": {},

--- a/web/app/js/components/GrafanaLink.jsx
+++ b/web/app/js/components/GrafanaLink.jsx
@@ -3,20 +3,20 @@ import React from 'react';
 
 export default class GrafanaLink extends React.Component {
   render() {
-    // TODO: pass along namespace information as well, once grafana supports it, part of:
-    // https://github.com/runconduit/conduit/issues/420
-    let deployment = this.props.name.split("/")[1];
+    let ownerInfo = this.props.name.split("/");
+    let namespace = ownerInfo[0];
+    let deployment = ownerInfo[1];
     return (
       <this.props.conduitLink
-        to={`/dashboard/db/conduit-deployment?var-deployment=${deployment}`}
+        to={`/dashboard/db/conduit-deployment?var-namespace=${namespace}&var-deployment=${deployment}`}
         deployment={"grafana"}
         targetBlank={true}>
         <img
           src={grafanaicon}
           width={this.props.size}
           height={this.props.size}
-          title={`${deployment} grafana dashboard`}
-          alt={`link to ${deployment} grafana dashboard`} />
+          title={`${namespace}/${deployment} grafana dashboard`}
+          alt={`link to ${namespace}/${deployment} grafana dashboard`} />
       </this.props.conduitLink>
     );
   }


### PR DESCRIPTION
The Grafana dashboards key off of deployment, but had no awareness of
namespaces, causing incorrect metrics aggregation and display.

This change makes the Grafana dashboards key off of namespaces, and also
modifies the Grafana links in the Conduit dashboard to link to
namespace+deployment.

Fixes #704
Part of #420

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Note this is almost entirely dashboard json changes, with the exception of a code change in `GrafanaLink.jsx`.

![screen shot 2018-04-06 at 2 30 42 pm](https://user-images.githubusercontent.com/236915/38445233-84bc7740-39a7-11e8-8e6b-e383796f2fc9.png)
