### PR TITLE
Move StatSummary logic into grpc server

### DIFF
--- a/cli/cmd/stat_summary.go
+++ b/cli/cmd/stat_summary.go
@@ -32,10 +32,10 @@ Valid resource types include:
 This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases.
 If no resource name is specified, displays stats about all resources of the specified RESOURCETYPE`,
 	Example: `  # Get all deployments in the test namespace.
-  conduit statsummary deployments -a test
+  conduit statsummary deployments -n test
 
   # Get the hello1 deployment in the test namespace.
-  conduit statsummary deployments hello1 -a test`,
+  conduit statsummary deployments hello1 -n test`,
 	Args:      cobra.RangeArgs(1, 2),
 	ValidArgs: []string{"deployment"},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -13,6 +13,7 @@ import (
 	telemetry "github.com/runconduit/conduit/controller/gen/controller/telemetry"
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type mockTelemetry struct {
@@ -193,7 +194,13 @@ func TestStat(t *testing.T) {
 		}
 
 		for _, tr := range responses {
-			s := newGrpcServer(&mockTelemetry{test: t, tRes: tr.tRes, mReq: tr.mReq}, tap.NewTapClient(nil), "conduit")
+			s := newGrpcServer(
+				&mockTelemetry{test: t, tRes: tr.tRes, mReq: tr.mReq},
+				tap.NewTapClient(nil),
+				fake.NewSimpleClientset(),
+				&fakeProm{},
+				"conduit",
+			)
 
 			res, err := s.Stat(context.Background(), tr.mReq)
 			if err != nil {


### PR DESCRIPTION
The StatSummary logic was implemented as a method on http_server.

Move the StatSummary logic into grpc_server, for consistency with the
other endpoints.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>