### PR TITLE
Fix success rate calculation in public api

### DIFF
--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -198,7 +198,7 @@ func TestStat(t *testing.T) {
 				&mockTelemetry{test: t, tRes: tr.tRes, mReq: tr.mReq},
 				tap.NewTapClient(nil),
 				fake.NewSimpleClientset(),
-				&fakeProm{},
+				&MockProm{},
 				"conduit",
 			)
 

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -190,7 +190,7 @@ func processRequests(vec model.Vector, labelSelector string) map[string]*pb.Basi
 		switch string(sample.Metric[model.LabelName("classification")]) {
 		case "success":
 			result[label].SuccessCount = uint64(sample.Value)
-		case "fail":
+		case "failure":
 			result[label].FailureCount = uint64(sample.Value)
 		}
 	}

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -3,7 +3,10 @@ package public
 import (
 	"context"
 	"io"
+	"time"
 
+	"github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 	common "github.com/runconduit/conduit/controller/gen/common"
 	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
 	pb "github.com/runconduit/conduit/controller/gen/public"
@@ -64,4 +67,23 @@ func (a *MockApi_TapClient) Recv() (*common.TapEvent, error) {
 	}
 
 	return &eventPopped, errorPopped
+}
+
+type MockProm struct {
+	api v1.API
+	Res model.Value
+}
+
+// satisfies v1.API
+func (m *MockProm) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	return m.Res, nil
+}
+func (m *MockProm) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
+	return m.Res, nil
+}
+func (m *MockProm) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
+	return nil, nil
+}
+func (m *MockProm) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	return nil, nil
 }

--- a/controller/telemetry/server_test.go
+++ b/controller/telemetry/server_test.go
@@ -5,31 +5,11 @@ import (
 	"errors"
 	"reflect"
 	"testing"
-	"time"
 
-	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"github.com/runconduit/conduit/controller/api/public"
 	read "github.com/runconduit/conduit/controller/gen/controller/telemetry"
 )
-
-type mockProm struct {
-	api v1.API
-	res model.Value
-}
-
-// satisfies v1.API
-func (m *mockProm) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
-	return m.res, nil
-}
-func (m *mockProm) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
-	return m.res, nil
-}
-func (m *mockProm) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
-	return nil, nil
-}
-func (m *mockProm) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
-	return nil, nil
-}
 
 type testResponse struct {
 	err      error
@@ -157,7 +137,7 @@ func TestServerResponses(t *testing.T) {
 	t.Run("Queries return the expected responses", func(t *testing.T) {
 		for _, tr := range responses {
 			s := server{
-				prometheusAPI: &mockProm{res: tr.promRes},
+				prometheusAPI: &public.MockProm{Res: tr.promRes},
 			}
 			res, err := s.Query(context.Background(), tr.queryReq)
 			if err != nil || tr.err != nil {


### PR DESCRIPTION
The success rate calculation relies on the `classification` label, but
was incorrectly specifying `fail` rather than `failure`.

Fix public api to specify `failure`. Also re-org public api tests for
easier Kubernetes and Prometheus mocking.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>