### PR TITLE
Added IPv6 Parser in /controller/destination/util.go 

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -34,7 +34,6 @@ func main() {
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	done := make(chan struct{})
-	
 
 	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, *k8sDNSZone, done)
 	if err != nil {

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -34,6 +34,7 @@ func main() {
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	done := make(chan struct{})
+	
 
 	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, *k8sDNSZone, done)
 	if err != nil {

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/runconduit/conduit/controller/destination"
-	"github.com/runconduit/conduit/controller/util"
+	"github.com/xabxx/conduit/controller/destination"
+	"github.com/xabxx/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/xabxx/conduit/controller/destination"
-	"github.com/xabxx/conduit/controller/util"
+	"github.com/runconduit/conduit/controller/destination"
+	"github.com/runconduit/conduit/controller/util"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )

--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 	s "strings"
+
 	common "github.com/runconduit/conduit/controller/gen/common"
 	"github.com/xabxx/conduit/controller/util"
 	log "github.com/sirupsen/logrus"

--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -8,7 +8,7 @@ import (
 	s "strings"
 
 	common "github.com/runconduit/conduit/controller/gen/common"
-	"github.com/xabxx/conduit/controller/util"
+	"github.com/runconduit/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -5,9 +5,9 @@ import (
 	"net"
 	"sync"
 	"time"
-
+	s "strings"
 	common "github.com/runconduit/conduit/controller/gen/common"
-	"github.com/runconduit/conduit/controller/util"
+	"github.com/xabxx/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -112,12 +112,22 @@ func (i *informer) run() {
 		} else {
 			addresses := make([]common.TcpAddress, 0)
 			for _, addr := range addrs {
-				ip, err := util.ParseIPV4(addr)
-				if err != nil {
-					log.Printf("[%s] is not a valid IP address: %v", addr, err)
+				if (s.Contains(addr, ".")) {
+					ip, err := util.ParseIPV4(addr)
+					if err != nil {
+						log.Printf("[%s] is not valid IPv4 address %v", addr, err)
+					} else {
+						address := common.TcpAddress{Ip: ip, Port: 80}
+						addresses = append(addresses, address)
+					}
 				} else {
-					address := common.TcpAddress{Ip: ip, Port: 80}
-					addresses = append(addresses, address)
+					ip, err := util.ParseIPV6(addr)
+					if err != nil {
+						log.Printf("[%s] is not valid IPv6 address %v", addr, err)
+					} else {
+						address := common.TcpAddress{Ip: ip, Port: 80}
+						addresses = append(addresses, address)
+					}
 				}
 			}
 			i.update(addresses)

--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -11,7 +11,6 @@ import (
 	"github.com/runconduit/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
 )
-
 var refreshInterval = 10 * time.Second
 
 type DnsListener interface {

--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -130,6 +130,7 @@ func (i *informer) run() {
 					}
 				}
 			}
+
 			i.update(addresses)
 		}
 

--- a/controller/util/util.go
+++ b/controller/util/util.go
@@ -51,6 +51,48 @@ func ParseIPV4(ip string) (*pb.IPAddress, error) {
 	return IPV4(octets[0], octets[1], octets[2], octets[3]), nil
 }
 
+//1. check if :: occurs twice, if yes, invalid IPV6 addr.
+//2. check if has 8 segments (including 0000s, or ::)
+//3. check if in between 0000 - FFFF
+func ParseIPV6(ip string) (*pb.IPAddress, error) {
+	segments := strings.Split(ip, ":")
+	zeros := false
+	hextets := [8]uint64{0, 0, 0, 0, 0, 0, 0, 0}
+	zerosIndex := 0
+	lastIndex := 0
+	for i, segment := range segments {
+		if segment == "" && !zeros{
+			zeros = true
+			hextets[i] = 0000
+			zerosIndex = i
+			continue
+		} else if segment == "" && zeros {
+			return nil, fmt.Errorf("Invalid IP6 addr")
+		}
+		hextet, err := strconv.ParseUint(segment, 16, 16)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid IP6 segment: %v", err)
+		}
+		lastIndex = i
+		hextets[i] = hextet
+	}
+	hextets = formatIPV6(hextets, zerosIndex, lastIndex)
+	return nil, nil
+}
+
+func formatIPV6(hextets [8]uint64, zerosIndex int, lastIndex int) [8]uint64{
+	last := len(hextets) - 1
+	for lastIndex > zerosIndex {
+		hextets[last] = hextets[lastIndex]
+		last--
+		lastIndex--
+	}
+	for zerosIndex <= last {
+		hextets[zerosIndex] = 0000
+		zerosIndex++
+	}
+	return hextets
+}
 func decodeIPToOctets(ip uint32) [4]uint8 {
 	return [4]uint8{
 		uint8(ip >> 24 & 255),

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -2,14 +2,17 @@ use std::collections::VecDeque;
 use std::collections::hash_map::{Entry, HashMap};
 use std::net::SocketAddr;
 use std::fmt;
+use std::time::Duration;
 
 use futures::{Async, Future, Poll, Stream};
 use futures::sync::mpsc;
+use tokio_core::reactor::Handle;
 use tower::Service;
 use tower_h2::{HttpService, BoxBody, RecvBody};
 use tower_discover::{Change, Discover};
 use tower_grpc as grpc;
 
+use dns::{self, IpAddrListFuture};
 use fully_qualified_authority::FullyQualifiedAuthority;
 
 use conduit_proxy_controller_grpc::common::{Destination, TcpAddress};
@@ -37,6 +40,7 @@ pub struct Watch<B> {
 #[derive(Debug)]
 pub struct Background {
     rx: mpsc::UnboundedReceiver<(DnsNameAndPort, mpsc::UnboundedSender<Update>)>,
+    dns_config: dns::Config,
     default_destination_namespace: String,
 }
 
@@ -44,6 +48,7 @@ pub struct Background {
 /// the controller destination API.
 // TODO: debug impl
 pub struct DiscoveryWork<T: HttpService<ResponseBody = RecvBody>> {
+    dns_resolver: dns::Resolver,
     default_destination_namespace: String,
     destinations: HashMap<DnsNameAndPort, DestinationSet<T>>,
     /// A queue of authorities that need to be reconnected.
@@ -58,6 +63,7 @@ pub struct DiscoveryWork<T: HttpService<ResponseBody = RecvBody>> {
 struct DestinationSet<T: HttpService<ResponseBody = RecvBody>> {
     addrs: Exists<Cache<SocketAddr, ()>>,
     query: Option<DestinationServiceQuery<T>>,
+    dns_query: Option<IpAddrListFuture>,
     txs: Vec<mpsc::UnboundedSender<Update>>,
 }
 
@@ -129,7 +135,7 @@ pub trait Bind {
 ///
 /// The `Discovery` is used by a listener, the `Background` is consumed
 /// on the controller thread.
-pub fn new(default_destination_namespace: String) -> (Discovery, Background) {
+pub fn new(dns_config: dns::Config, default_destination_namespace: String) -> (Discovery, Background) {
     let (tx, rx) = mpsc::unbounded();
     (
         Discovery {
@@ -137,6 +143,7 @@ pub fn new(default_destination_namespace: String) -> (Discovery, Background) {
         },
         Background {
             rx,
+            dns_config,
             default_destination_namespace,
         },
     )
@@ -201,11 +208,12 @@ where
 
 impl Background {
     /// Bind this handle to start talking to the controller API.
-    pub fn work<T>(self) -> DiscoveryWork<T>
+    pub fn work<T>(self, executor: &Handle) -> DiscoveryWork<T>
     where T: HttpService<RequestBody = BoxBody, ResponseBody = RecvBody>,
           T::Error: fmt::Debug,
     {
         DiscoveryWork {
+            dns_resolver: dns::Resolver::new(self.dns_config, executor),
             default_destination_namespace: self.default_destination_namespace,
             destinations: HashMap::new(),
             reconnects: VecDeque::new(),
@@ -286,11 +294,22 @@ where
                                     client,
                                     vac.key(),
                                     "connect");
-                            vac.insert(DestinationSet {
+                            let mut set = DestinationSet {
                                 addrs: Exists::Unknown,
                                 query,
+                                dns_query: None,
                                 txs: vec![tx],
-                            });
+                            };
+                            // If the authority is one for which the Destination service is never
+                            // relevant (e.g. an absolute name that doesn't end in ".svc.$zone." in
+                            // Kubernetes), then immediately start polling DNS.
+                            if set.query.is_none() {
+                                set.reset_dns_query(
+                                    &self.dns_resolver,
+                                    Duration::from_secs(0),
+                                    vac.key());
+                            }
+                            vac.insert(set);
                         }
                     }
                 }
@@ -325,17 +344,44 @@ where
 
     fn poll_destinations(&mut self) {
         for (auth, set) in &mut self.destinations {
-            set.query = match set.query.take() {
+            // Query the Destination service first.
+            let (new_query, found_by_destination_service) = match set.query.take() {
                 Some(DestinationServiceQuery::ConnectedOrConnecting{ rx }) => {
-                    let new_query = set.poll_destination(auth, rx);
+                    let (new_query, found_by_destination_service) =
+                        set.poll_destination_service(auth, rx);
                     if let DestinationServiceQuery::NeedsReconnect = new_query {
                         set.reset_on_next_modification();
                         self.reconnects.push_back(auth.clone());
                     }
-                    Some(new_query)
+                    (Some(new_query), found_by_destination_service)
                 },
-                query => query,
+                query => (query, Exists::Unknown),
             };
+            set.query = new_query;
+
+            // Any active response from the Destination service cancels the DNS query except for a
+            // positive assertion that the service doesn't exist.
+            //
+            // Any disconnection from the Destination service has no effect on the DNS query; we
+            // assume that if we were querying DNS before, we should continue to do so, and if we
+            // weren't querying DNS then we shouldn't start now. In particular, temporary
+            // disruptions of connectivity to the Destination service do not cause a fallback to
+            // DNS.
+            match found_by_destination_service {
+                Exists::Yes(()) => {
+                    // Stop polling DNS on any active update from the Destination service.
+                    set.dns_query = None;
+                },
+                Exists::No => {
+                    // Fall back to DNS.
+                    set.reset_dns_query(&self.dns_resolver, Duration::from_secs(0), auth);
+                },
+                Exists::Unknown => (), // No change from Destination service's perspective.
+            }
+
+            // Poll DNS after polling the Destination service. This may reset the DNS query but it
+            // won't affect the Destination Service query.
+            set.poll_dns(&self.dns_resolver, auth);
         }
     }
 }
@@ -375,23 +421,53 @@ impl<T> DestinationSet<T>
     where T: HttpService<RequestBody = BoxBody, ResponseBody = RecvBody>,
           T::Error: fmt::Debug
 {
-    fn poll_destination(&mut self, auth: &DnsNameAndPort, mut rx: UpdateRx<T>)
-                        -> DestinationServiceQuery<T>
+    fn reset_dns_query(
+        &mut self,
+        dns_resolver: &dns::Resolver,
+        delay: Duration,
+        authority: &DnsNameAndPort)
     {
+        trace!("resetting DNS query for {} with delay {:?}", authority.host, delay);
+        self.reset_on_next_modification();
+        self.dns_query = Some(dns_resolver.resolve_all_ips(delay, &authority.host));
+    }
+
+    // Processes Destination service updates from `rx`, returning the new query an an indication of
+    // any *change* to whether the service exists as far as the Destination service is concerned,
+    // where `Exists::Unknown` is to be interpreted as "no change in existence" instead of
+    // "unknown".
+    fn poll_destination_service(
+        &mut self,
+        auth: &DnsNameAndPort,
+        mut rx: UpdateRx<T>)
+        -> (DestinationServiceQuery<T>, Exists<()>)
+    {
+        let mut exists = Exists::Unknown;
+
         loop {
             match rx.poll() {
                 Ok(Async::Ready(Some(update))) => match update.update {
-                    Some(PbUpdate2::Add(a_set)) =>
+                    Some(PbUpdate2::Add(a_set)) => {
+                        exists = Exists::Yes(());
                         self.add(
                             auth,
                             a_set.addrs.iter().filter_map(
-                                |addr| addr.addr.clone().and_then(pb_to_sock_addr))),
-                    Some(PbUpdate2::Remove(r_set)) =>
+                                |addr| addr.addr.clone().and_then(pb_to_sock_addr)));
+                    },
+                    Some(PbUpdate2::Remove(r_set)) => {
+                        exists = Exists::Yes(());
                         self.remove(
                             auth,
-                            r_set.addrs.iter().filter_map(|addr| pb_to_sock_addr(addr.clone()))),
-                    Some(PbUpdate2::NoEndpoints(no_endpoints)) =>
-                        self.no_endpoints(auth, no_endpoints.exists),
+                            r_set.addrs.iter().filter_map(|addr| pb_to_sock_addr(addr.clone())));
+                    },
+                    Some(PbUpdate2::NoEndpoints(ref no_endpoints)) if no_endpoints.exists => {
+                        exists = Exists::Yes(());
+                        self.no_endpoints(auth, no_endpoints.exists);
+                    },
+                    Some(PbUpdate2::NoEndpoints(no_endpoints)) => {
+                        debug_assert!(!no_endpoints.exists);
+                        exists = Exists::No;
+                    },
                     None => (),
                 },
                 Ok(Async::Ready(None)) => {
@@ -399,16 +475,48 @@ impl<T> DestinationSet<T>
                         "Destination.Get stream ended for {:?}, must reconnect",
                         auth
                     );
-                    return DestinationServiceQuery::NeedsReconnect;
+                    return (DestinationServiceQuery::NeedsReconnect, exists);
                 },
                 Ok(Async::NotReady) => {
-                    return DestinationServiceQuery::ConnectedOrConnecting { rx };
+                    return (DestinationServiceQuery::ConnectedOrConnecting { rx }, exists);
                 },
                 Err(err) => {
                     warn!("Destination.Get stream errored for {:?}: {:?}", auth, err);
-                    return DestinationServiceQuery::NeedsReconnect;
+                    return (DestinationServiceQuery::NeedsReconnect, exists);
                 }
             };
+        }
+    }
+
+    fn poll_dns(&mut self, dns_resolver: &dns::Resolver, authority: &DnsNameAndPort) {
+        trace!("checking DNS for {:?}", authority);
+        while let Some(mut query) = self.dns_query.take() {
+            trace!("polling DNS for {:?}", authority);
+            match query.poll() {
+                Ok(Async::NotReady) => {
+                    trace!("DNS query not ready {:?}", authority);
+                    self.dns_query = Some(query);
+                    return;
+                },
+                Ok(Async::Ready(dns::Response::Exists(ips))) => {
+                    trace!("positive result of DNS query for {:?}: {:?}", authority, ips);
+                    self.add(authority, ips.iter().map(|ip| {
+                        SocketAddr::from((*ip, authority.port))
+                    }));
+                },
+                Ok(Async::Ready(dns::Response::DoesNotExist)) => {
+                    trace!("negative result (NXDOMAIN) of DNS query for {:?}", authority);
+                    self.no_endpoints(authority, false);
+                },
+                Err(e) => {
+                    trace!("DNS resolution failed for {}: {}", &authority.host, e);
+                    // Do nothing so that the most recent non-error response is used until a
+                    // non-error response is received.
+                },
+            };
+            // TODO: When we have a TTL to use, we should use that TTL instead of hard-coding this
+            // delay.
+            self.reset_dns_query(dns_resolver, Duration::from_secs(5), &authority)
         }
     }
 }

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -325,52 +325,17 @@ where
 
     fn poll_destinations(&mut self) {
         for (auth, set) in &mut self.destinations {
-            let needs_reconnect = 'set: loop {
-                let poll_result = match set.query {
-                    None |
-                    Some(DestinationServiceQuery::NeedsReconnect) => {
-                        continue;
-                    },
-                    Some(DestinationServiceQuery::ConnectedOrConnecting{ ref mut rx }) => {
-                        rx.poll()
+            set.query = match set.query.take() {
+                Some(DestinationServiceQuery::ConnectedOrConnecting{ rx }) => {
+                    let new_query = set.poll_destination(auth, rx);
+                    if let DestinationServiceQuery::NeedsReconnect = new_query {
+                        set.reset_on_next_modification();
+                        self.reconnects.push_back(auth.clone());
                     }
-                };
-
-                match poll_result {
-                    Ok(Async::Ready(Some(update))) => match update.update {
-                        Some(PbUpdate2::Add(a_set)) =>
-                            set.add(
-                                auth,
-                                a_set.addrs.iter().filter_map(
-                                    |addr| addr.addr.clone().and_then(pb_to_sock_addr))),
-                        Some(PbUpdate2::Remove(r_set)) =>
-                            set.remove(
-                                auth,
-                                r_set.addrs.iter().filter_map(|addr| pb_to_sock_addr(addr.clone()))),
-                        Some(PbUpdate2::NoEndpoints(no_endpoints)) =>
-                            set.no_endpoints(auth, no_endpoints.exists),
-                        None => (),
-                    },
-                    Ok(Async::Ready(None)) => {
-                        trace!(
-                            "Destination.Get stream ended for {:?}, must reconnect",
-                            auth
-                        );
-                        break 'set true;
-                    }
-                    Ok(Async::NotReady) => break 'set false,
-                    Err(err) => {
-                        warn!("Destination.Get stream errored for {:?}: {:?}", auth, err);
-                        break 'set true;
-                    }
-                }
-
+                    Some(new_query)
+                },
+                query => query,
             };
-            if needs_reconnect {
-                set.query = Some(DestinationServiceQuery::NeedsReconnect);
-                set.reset_on_next_modification();
-                self.reconnects.push_back(auth.clone());
-            }
         }
     }
 }
@@ -405,6 +370,48 @@ impl<T: HttpService<RequestBody = BoxBody, ResponseBody = RecvBody>> Destination
 }
 
 // ===== impl DestinationSet =====
+
+impl<T> DestinationSet<T>
+    where T: HttpService<RequestBody = BoxBody, ResponseBody = RecvBody>,
+          T::Error: fmt::Debug
+{
+    fn poll_destination(&mut self, auth: &DnsNameAndPort, mut rx: UpdateRx<T>)
+                        -> DestinationServiceQuery<T>
+    {
+        loop {
+            match rx.poll() {
+                Ok(Async::Ready(Some(update))) => match update.update {
+                    Some(PbUpdate2::Add(a_set)) =>
+                        self.add(
+                            auth,
+                            a_set.addrs.iter().filter_map(
+                                |addr| addr.addr.clone().and_then(pb_to_sock_addr))),
+                    Some(PbUpdate2::Remove(r_set)) =>
+                        self.remove(
+                            auth,
+                            r_set.addrs.iter().filter_map(|addr| pb_to_sock_addr(addr.clone()))),
+                    Some(PbUpdate2::NoEndpoints(no_endpoints)) =>
+                        self.no_endpoints(auth, no_endpoints.exists),
+                    None => (),
+                },
+                Ok(Async::Ready(None)) => {
+                    trace!(
+                        "Destination.Get stream ended for {:?}, must reconnect",
+                        auth
+                    );
+                    return DestinationServiceQuery::NeedsReconnect;
+                },
+                Ok(Async::NotReady) => {
+                    return DestinationServiceQuery::ConnectedOrConnecting { rx };
+                },
+                Err(err) => {
+                    warn!("Destination.Get stream errored for {:?}: {:?}", auth, err);
+                    return DestinationServiceQuery::NeedsReconnect;
+                }
+            };
+        }
+    }
+}
 
 impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
     fn reset_on_next_modification(&mut self) {

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -203,9 +203,10 @@ where
             config.metrics_flush_interval,
         );
 
-        let (control, control_bg) = control::new(config.pod_namespace.clone());
-
         let dns_config = dns::Config::from_file(&config.resolv_conf_path);
+
+        let (control, control_bg) = control::new(dns_config.clone(), config.pod_namespace.clone());
+
         let executor = core.handle();
 
         let bind = Bind::new(executor.clone()).with_sensors(sensors.clone());

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -136,7 +136,7 @@ impl tokio_connect::Connect for LookupAddressAndConnect {
         let handle = self.handle.clone();
         let host = self.host_and_port.host.clone();
         let c = self.dns_resolver
-            .resolve_host(&self.host_and_port.host)
+            .resolve_one_ip(&self.host_and_port.host)
             .map_err(|_| {
                 io::Error::new(io::ErrorKind::NotFound, "DNS resolution failed")
             })

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -36,58 +36,48 @@ func TestEgressHttp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v output:\n%s", err, out)
 	}
+
+	test_case := func(serviceName, dnsName, protocolToUse, methodToUse string) {
+		testName := fmt.Sprintf("Can use egress to send %s request to %s (%s)", methodToUse, protocolToUse, serviceName)
+		t.Run(testName, func(t *testing.T) {
+			expectedURL := fmt.Sprintf("%s://%s/%s", protocolToUse, dnsName, strings.ToLower(methodToUse))
+
+			svcURL, err := TestHelper.GetURLForService(prefixedNs, serviceName)
+			if err != nil {
+				t.Fatalf("Failed to get service URL: %v", err)
+			}
+
+			output, err := TestHelper.HTTPGetURL(svcURL)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			var jsonResponse map[string]interface{}
+			json.Unmarshal([]byte(output), &jsonResponse)
+
+			payloadText := jsonResponse["payload"]
+			if payloadText == nil {
+				t.Fatalf("Expected [%s] request to [%s] to return a payload, got nil. Response:\n%s\n", methodToUse, expectedURL, output)
+			}
+
+			var messagePayload map[string]interface{}
+			json.Unmarshal([]byte(payloadText.(string)), &messagePayload)
+
+			actualURL := messagePayload["url"]
+			if actualURL != expectedURL {
+				t.Fatalf("Expecting response to say egress sent [%s] request to URL [%s] but got [%s]. Response:\n%s\n", methodToUse, expectedURL, actualURL, output)
+			}
+		})
+	}
+
 	supportedProtocols := []string{"http", "https"}
 	methods := []string{"GET", "POST"}
 	for _, protocolToUse := range supportedProtocols {
 		for _, methodToUse := range methods {
-
-			testName := fmt.Sprintf("Can use egress to send %s request to %s", methodToUse, protocolToUse)
-			t.Run(testName, func(t *testing.T) {
-				expectedURL := fmt.Sprintf("%s://www.httpbin.org/%s", protocolToUse, strings.ToLower(methodToUse))
-				serviceName := fmt.Sprintf("egress-test-%s-%s-svc", protocolToUse, strings.ToLower(methodToUse))
-
-				svcURL, err := TestHelper.GetURLForService(prefixedNs, serviceName)
-				if err != nil {
-					t.Fatalf("Failed to get service URL: %v", err)
-				}
-
-				output, err := TestHelper.HTTPGetURL(svcURL)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				var jsonResponse map[string]interface{}
-				json.Unmarshal([]byte(output), &jsonResponse)
-
-				payloadText := jsonResponse["payload"]
-				if payloadText == nil {
-					t.Fatalf("Expected [%s] request to [%s] to return a payload, got nil. Response:\n%s\n", methodToUse, expectedURL, output)
-				}
-
-				var messagePayload map[string]interface{}
-				json.Unmarshal([]byte(payloadText.(string)), &messagePayload)
-
-				actualURL := messagePayload["url"]
-				if actualURL != expectedURL {
-					t.Fatalf("Expecting response to say egress sent [%s] request to URL [%s] but got [%s]. Response:\n%s\n", methodToUse, expectedURL, actualURL, output)
-				}
-			})
+			serviceName := fmt.Sprintf("egress-test-%s-%s-svc", protocolToUse, strings.ToLower(methodToUse))
+			test_case(serviceName, "www.httpbin.org", protocolToUse, methodToUse)
 		}
 	}
 
-	t.Run("Can access egress for domains with fewer than 3 segments", func(t *testing.T) {
-		serviceName := "egress-test-not-www-get-svc"
-
-		svcURL, err := TestHelper.GetURLForService(prefixedNs, serviceName)
-		if err != nil {
-			t.Fatalf("Failed to get service URL: %v", err)
-		}
-
-		output, err := TestHelper.HTTPGetURL(svcURL)
-		if err != nil {
-			t.Skip("Skipping this test until this issue is fixed: https://github.com/runconduit/conduit/issues/155")
-		} else {
-			t.Fatalf("This test was expected to fail unless https://github.com/runconduit/conduit/issues/155 is fixed. Output:\n%s\n", output)
-		}
-
-	})
+	// Test egress for a domain with fewer than 3 segments.
+	test_case("egress-test-not-www-get-svc", "httpbin.org", "https", "GET")
 }

--- a/test/egress/testdata/proxy.yaml
+++ b/test/egress/testdata/proxy.yaml
@@ -188,7 +188,7 @@ spec:
           - "--h1-server-port"
           - "8080"
           - "--url"
-          - "http://httpbin.org/anything"
+          - "https://httpbin.org/get"
           - "--method"
           - "GET"
         ports:


### PR DESCRIPTION
This pull request partially resolves the issue #643 . There is only IPv4Parser in /controller/destination/util.go and now with the IPv6Parser, /controller/destination/dns.go will try to resolve ip address in ipv4/ipv6 format before it throws invalid ip error. There are more do make #643 fully functional:

1. listerner.go throws "could not find pod id error"
2. implement all other ipv6 functions in util.go is needed

Note - to test the fix works:
Either:
* merge 
* run the tests stated in #643 

Or:
* create a branch/clone my version
* changed the import in  `/controller/destination/dns.go` && `/controller/cmd/destination/main.go` to `"github.com/<branchName>/conduit/controller/*"`
* run the tests stated in #643 

Signed-off-by: xabxx <yingqiabbyxu@gmail.com>