### PR TITLE
Added IPv6 Parser support and changed logic for ip addr inspection

### DIFF
--- a/controller/destination/dns.go
+++ b/controller/destination/dns.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"time"
+	s "strings"
 
 	common "github.com/runconduit/conduit/controller/gen/common"
 	"github.com/runconduit/conduit/controller/util"
@@ -112,12 +113,22 @@ func (i *informer) run() {
 		} else {
 			addresses := make([]common.TcpAddress, 0)
 			for _, addr := range addrs {
-				ip, err := util.ParseIPV4(addr)
-				if err != nil {
-					log.Printf("[%s] is not a valid IP address: %v", addr, err)
+				if (s.Contains(addr, ".")) {
+					ip, err := util.ParseIPV4(addr)
+					if err != nil {
+						log.Printf("[%s] is not valid IPv4 address %v", addr, err)
+					} else {
+						address := common.TcpAddress{Ip: ip, Port: 80}
+						addresses = append(addresses, address)
+					}
 				} else {
-					address := common.TcpAddress{Ip: ip, Port: 80}
-					addresses = append(addresses, address)
+					ip, err := util.ParseIPV6(addr)
+					if err != nil {
+						log.Printf("[%s] is not valid IPv6 address %v", addr, err)
+					} else {
+						address := common.TcpAddress{Ip: ip, Port: 80}
+						addresses = append(addresses, address)
+					}
 				}
 			}
 			i.update(addresses)


### PR DESCRIPTION
This pull request partially resolves the issue #643 . There is only IPv4Parser in /controller/destination/util.go and now with the IPv6Parser, /controller/destination/dns.go will try to resolve ip address in ipv4/ipv6 format before it throws invalid ip error. There are more do make #643 fully functional:

1. listerner.go throws "could not find pod id error"
2. implement all other ipv6 functions in util.go is needed

Note - to test the fix works:
Either:

* merge
* run the tests stated in #643

Or:
* create a branch/clone my version
* changed the import in /controller/destination/dns.go && /controller/cmd/destination/main.go to "github.com/<branchName>/conduit/controller/*"
* run the tests stated in #643

Signed-off-by: Abby Xu  <yingqiabbyxu@gmail.com>