### PR TITLE
Controller: add more destination labels, fix service label

### DIFF
--- a/controller/destination/k8s_resolver_test.go
+++ b/controller/destination/k8s_resolver_test.go
@@ -321,7 +321,7 @@ func assertIsResolved(t *testing.T, resolver *k8sResolver, nameToExpectedResolve
 			t.Fatalf("Expected name [%s] to resolve to [%s], but got [%v]", name, expectedResolvedName, resolvedName)
 		}
 
-		if *resolvedName != expectedResolvedName {
+		if resolvedName.String() != expectedResolvedName {
 			t.Fatalf("Expected name [%s] to resolve to [%s], but got [%s]", name, expectedResolvedName, *resolvedName)
 		}
 	}

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -129,7 +129,7 @@ func TestEndpointListener(t *testing.T) {
 		actualAddedAddress1MetricLabels := mockGetServer.updatesReceived[0].GetAdd().Addrs[0].MetricLabels
 		expectedAddedAddress1MetricLabels := map[string]string{
 			"pod": expectedPodName,
-			"replicationcontroller": expectedReplicationControllerName,
+			"replication_controller": expectedReplicationControllerName,
 		}
 		if !reflect.DeepEqual(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels) {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedAddedAddress1MetricLabels, actualAddedAddress1MetricLabels)

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/proxy/destination"
 	"github.com/runconduit/conduit/controller/k8s"
 	"github.com/runconduit/conduit/controller/util"
+	pkgK8s "github.com/runconduit/conduit/pkg/k8s"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -91,6 +92,7 @@ func TestEndpointListener(t *testing.T) {
 		expectedServiceName := "service-name"
 		expectedPodName := "pod1"
 		expectedNamespace := "this-namespace"
+		expectedReplicationControllerName := "rc-name"
 
 		addedAddress1 := common.TcpAddress{Ip: &common.IPAddress{Ip: &common.IPAddress_Ipv4{Ipv4: 666}}, Port: 1}
 		ipForAddr1 := util.IPToString(addedAddress1.Ip)
@@ -98,6 +100,9 @@ func TestEndpointListener(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedNamespace,
+				Labels: map[string]string{
+					pkgK8s.ProxyReplicationControllerLabel: expectedReplicationControllerName,
+				},
 			},
 		}
 		addedAddress2 := common.TcpAddress{Ip: &common.IPAddress{Ip: &common.IPAddress_Ipv4{Ipv4: 222}}, Port: 22}
@@ -105,9 +110,12 @@ func TestEndpointListener(t *testing.T) {
 
 		mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}}
 		listener := &endpointListener{
-			podsByIp:    podIndex,
-			serviceName: expectedServiceName,
-			stream:      mockGetServer,
+			podsByIp: podIndex,
+			labels: map[string]string{
+				"service":   expectedServiceName,
+				"namespace": expectedNamespace,
+			},
+			stream: mockGetServer,
 		}
 
 		listener.Update([]common.TcpAddress{addedAddress1, addedAddress2}, nil)
@@ -119,7 +127,10 @@ func TestEndpointListener(t *testing.T) {
 		}
 
 		actualAddedAddress1MetricLabels := mockGetServer.updatesReceived[0].GetAdd().Addrs[0].MetricLabels
-		expectedAddedAddress1MetricLabels := map[string]string{"pod": expectedPodName}
+		expectedAddedAddress1MetricLabels := map[string]string{
+			"pod": expectedPodName,
+			"replicationcontroller": expectedReplicationControllerName,
+		}
 		if !reflect.DeepEqual(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels) {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedAddedAddress1MetricLabels, actualAddedAddress1MetricLabels)
 		}

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -107,8 +107,7 @@ func (s *server) Get(dest *common.Destination, stream pb.Destination_GetServer) 
 }
 
 func (s *server) streamResolutionUsingCorrectResolverFor(host string, port int, stream pb.Destination_GetServer) error {
-	serviceName := fmt.Sprintf("%s:%d", host, port)
-	listener := &endpointListener{serviceName: serviceName, stream: stream, podsByIp: s.podsByIp}
+	listener := &endpointListener{stream: stream, podsByIp: s.podsByIp}
 
 	for _, resolver := range s.resolvers {
 		resolverCanResolve, err := resolver.canResolve(host, port)

--- a/controller/destination/test_helper.go
+++ b/controller/destination/test_helper.go
@@ -24,6 +24,8 @@ func (c *collectUpdateListener) Done() <-chan struct{} {
 
 func (c *collectUpdateListener) NoEndpoints(exists bool) {}
 
+func (c *collectUpdateListener) SetServiceId(id *serviceId) {}
+
 func newCollectUpdateListener() (*collectUpdateListener, context.CancelFunc) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	return &collectUpdateListener{context: ctx}, cancelFn

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -60,7 +60,7 @@ The following labels are only applicable on `response_*` metrics.
 The following labels are only applicable if `direction=outbound`.
 
 * `dst_deployment`: The deployment to which this request is being sent.
-* `dst_job`: The job to which this request is being sent.
+* `dst_k8s_job`: The job to which this request is being sent.
 * `dst_replica_set`: The replica set to which this request is being sent.
 * `dst_daemon_set`: The daemon set to which this request is being sent.
 * `dst_replication_controller`: The replication controller to which this request

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/runconduit/conduit/pkg/version"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -57,8 +58,26 @@ const (
 	ProxyVersionAnnotation = "conduit.io/proxy-version"
 )
 
+var ownerLabels = map[string]string{
+	"deployment":            ProxyDeploymentLabel,
+	"replicationcontroller": ProxyReplicationControllerLabel,
+	"replicaset":            ProxyReplicaSetLabel,
+	"job":                   ProxyJobLabel,
+	"daemonset":             ProxyDaemonSetLabel,
+}
+
 // CreatedByAnnotationValue returns the value associated with
 // CreatedByAnnotation.
 func CreatedByAnnotationValue() string {
 	return fmt.Sprintf("conduit/cli %s", version.Version)
+}
+
+func GetOwnerLabels(objectMeta meta.ObjectMeta) map[string]string {
+	labels := make(map[string]string)
+	for ownerLabel, conduitLabel := range ownerLabels {
+		if labelValue, ok := objectMeta.Labels[conduitLabel]; ok {
+			labels[ownerLabel] = labelValue
+		}
+	}
+	return labels
 }

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetOwnerLabels(t *testing.T) {
+	t.Run("Maps proxy labels to prometheus labels", func(t *testing.T) {
+		metadata := meta.ObjectMeta{
+			Labels: map[string]string{
+				ProxyDeploymentLabel:            "test-deployment",
+				ProxyReplicationControllerLabel: "test-replication-controller",
+				ProxyReplicaSetLabel:            "test-replica-set",
+				ProxyJobLabel:                   "test-job",
+				ProxyDaemonSetLabel:             "test-daemon-set",
+			},
+		}
+
+		expectedLabels := map[string]string{
+			"deployment":             "test-deployment",
+			"replication_controller": "test-replication-controller",
+			"replica_set":            "test-replica-set",
+			"k8s_job":                "test-job",
+			"daemon_set":             "test-daemon-set",
+		}
+
+		ownerLabels := GetOwnerLabels(metadata)
+
+		if !reflect.DeepEqual(ownerLabels, expectedLabels) {
+			t.Fatalf("Expected owner labels [%v] but got [%v]", expectedLabels, ownerLabels)
+		}
+	})
+
+	t.Run("Ignores non-proxy labels", func(t *testing.T) {
+		metadata := meta.ObjectMeta{
+			Labels: map[string]string{"app": "foo"},
+		}
+
+		ownerLabels := GetOwnerLabels(metadata)
+
+		if len(ownerLabels) != 0 {
+			t.Fatalf("Expected no owner labels but got [%v]", ownerLabels)
+		}
+	})
+}


### PR DESCRIPTION
In #654, the destination service's Get response was updated to support the "namespace", "service", and "pod" labels. In this branch I'm adding "deployment", "replicationcontroller", "replicaset", "job", and "daemonset". I'm also modifying the "service" label so that it reflects the actual service name, rather than the fully-qualified host:port for the service.

The updated labels look like:

```
$ ./bin/go-run controller/script/destination-client -path voting-svc.emojivoto.svc.cluster.local:8080
INFO[0000] Add:                                         
INFO[0000] metric_labels: map[namespace:emojivoto service:voting-svc] 
INFO[0000] - 172.17.0.11:8080 - map[deployment:voting pod:voting-7c84f4d97b-w8j9t] 
```

Fixes #668.
Fixes #718.
Fixes #719.
Fixes #720.
Fixes #721.