### PR TITLE
Refactor control::Cache and add tests

### DIFF
--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -73,7 +73,7 @@ where
         F: for<'value> FnMut(CacheChange<'value, K, V>),
     {
         fn update_inner<K, V, F>(
-            inner: & mut IndexMap<K, V>,
+            inner: &mut IndexMap<K, V>,
             key: K,
             new_value: V,
             on_change: &mut F

--- a/proxy/src/control/cache.rs
+++ b/proxy/src/control/cache.rs
@@ -1,6 +1,5 @@
 use indexmap::{IndexMap, IndexSet};
 use indexmap::map::{self, Entry};
-use std::borrow::Borrow;
 use std::hash::Hash;
 use std::iter::IntoIterator;
 use std::mem;
@@ -121,11 +120,6 @@ where
                     k
                 })
                 .collect();
-            // This retain is similar to `update_intersection`'s removal of
-            // non-present keys but without updating values, since we've
-            // already updated any values present in `to_insert`. We do this
-            // instead of just calling `update_intersection` so we don't have
-            // to clone the values we already know were inserted here.
             self.inner.retain(|key, _| if retained_keys.contains(key) {
                 true
             } else {
@@ -160,50 +154,6 @@ where
         for (key, _) in self.inner.drain(..) {
             on_change(CacheChange::Removal { key })
         };
-        self.reset_on_next_modification = false;
-    }
-
-    /// Update the cache to contain the intersection of its current contents
-    /// and the key-value pairs in `to_update`. Pairs not present in
-    /// `to_update` will be removed from the cache, and any keys in the cache
-    /// with different inner from those in `to_update` will be ovewritten to
-    /// match `to_update`.
-    pub fn update_intersection<F, Q>(
-        &mut self,
-        mut to_update: IndexMap<Q, V>,
-        mut on_change: F
-    )
-    where
-        F: for<'value> FnMut(CacheChange<'value, K, V>),
-        K: Borrow<Q>,
-        Q: Hash + Eq,
-        V: Clone,
-    {
-        self.inner.retain(|key, value| {
-            match to_update.remove(key.borrow()) {
-                // New value matches old value. Do nothing.
-                Some(ref new_value) if new_value == value => true,
-                // If the new value isn't equal to the old value, overwrite
-                // the old value.
-                Some(new_value) =>  {
-                    // TODO: ideally, we wouldn't clone here, but we can't
-                    // borrow the value from `self.inner` after inserting it,
-                    // as `self.inner` is already borrowed mutably by `retain`.
-                    // It would be nice to figure this out.
-                    let _ = mem::replace(value, new_value.clone());
-                    on_change(CacheChange::Modification {
-                        key: *key,
-                        new_value: &new_value,
-                    });
-                    true
-                },
-                // Key doesn't exist, remove it from the map.
-                None => {
-                    on_change(CacheChange::Removal { key: *key });
-                    false
-                }
-            }
-        });
         self.reset_on_next_modification = false;
     }
 }
@@ -290,68 +240,6 @@ mod tests {
         );
         assert_eq!(insertions, 3);
         assert_eq!(modifications, 3);
-    }
-
-    #[test]
-    fn update_intersection_fires_events() {
-        let mut cache = Cache {
-            inner: indexmap!{ 1 => "one",  2 => "two", 3 => "three" },
-            reset_on_next_modification: false,
-        };
-
-        let mut removals = 0;
-        let mut modifications = 0;
-
-        cache.update_intersection(
-            indexmap!{ 1 => "one", 3 => "three"},
-            &mut |change: CacheChange<usize, &str>| {
-                removals += 1;
-                assert_eq!(change, CacheChange::Removal{ key: 2, });
-            },
-        );
-        assert_eq!(cache.inner, indexmap!{ 1 => "one", 3 => "three"});
-        assert_eq!(removals, 1);
-
-        cache.update_intersection(
-            indexmap!{ 3 => "3", 4 => "four" },
-            &mut |change: CacheChange<usize, &str>| match change {
-                CacheChange::Removal { key } => {
-                    removals += 1;
-                    assert_eq!(key, 1);
-                }
-                CacheChange::Insertion { ..  } => {
-                    panic!("no insertion events should be fired");
-                }
-                CacheChange::Modification { key, new_value} => {
-                    modifications += 1;
-                    assert_eq!(key, 3);
-                    assert_eq!(new_value, &"3")
-                },
-            }
-        );
-        assert_eq!(cache.inner, indexmap!{ 3 => "3" });
-        assert_eq!(removals, 2);
-        assert_eq!(modifications, 1);
-
-        cache.update_intersection(
-            indexmap!{ 5 => "five", 6 => "six" },
-            &mut |change: CacheChange<usize, &str>| match change {
-                CacheChange::Removal { key } => {
-                    removals += 1;
-                    assert_eq!(key, 3);
-                }
-                CacheChange::Insertion { ..  } => {
-                    panic!("no insertion events should be fired");
-                }
-                CacheChange::Modification { ..  } => {
-                    panic!("no more modification events should be fired");
-                }
-            }
-        );
-
-        assert!(cache.inner.is_empty());
-        assert_eq!(removals, 3);
-        assert_eq!(modifications, 1);
     }
 
     #[test]

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -127,7 +127,7 @@ enum RxError<T> {
     Stream(grpc::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum Update {
     Insert(SocketAddr, Metadata),
     Remove(SocketAddr),
@@ -611,14 +611,7 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
         };
         cache.update_union(
             addrs_to_add,
-            &mut |(addr, meta), change| Self::on_change(
-                &mut self.txs,
-                authority_for_logging,
-                addr,
-                meta,
-                change,
-            )
-        );
+            &mut |change| Self::on_change(&mut self.txs, authority_for_logging, change));
         self.addrs = Exists::Yes(cache);
     }
 
@@ -629,14 +622,7 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
             Exists::Yes(mut cache) => {
                 cache.remove(
                     addrs_to_remove,
-                    &mut |(addr, meta), change| Self::on_change(
-                        &mut self.txs,
-                        authority_for_logging,
-                        addr,
-                        meta,
-                        change,
-                    )
-                );
+                    &mut |change| Self::on_change(&mut self.txs, authority_for_logging, change));
                 cache
             },
             Exists::Unknown | Exists::No => Cache::new(),
@@ -650,14 +636,7 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
         match self.addrs.take() {
             Exists::Yes(mut cache) => {
                 cache.clear(
-                    &mut |(addr, meta), change| Self::on_change(
-                        &mut self.txs,
-                        authority_for_logging,
-                        addr,
-                        meta,
-                        change
-                    )
-                );
+                    &mut |change| Self::on_change(&mut self.txs, authority_for_logging, change));
             },
             Exists::Unknown | Exists::No => (),
         };
@@ -670,21 +649,17 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
 
     fn on_change(txs: &mut Vec<mpsc::UnboundedSender<Update>>,
                  authority_for_logging: &DnsNameAndPort,
-                 addr: SocketAddr,
-                 meta: Metadata,
-                 change: CacheChange) {
-        let (update_str, update_constructor): (&'static str, fn(SocketAddr, Metadata) -> Update) =
-            match change {
-                CacheChange::Insertion => ("insert", Update::Insert),
-                CacheChange::Removal =>
-                    ("remove", |addr, _| Update::Remove(addr)),
-                CacheChange::Modification =>
-                    ("change metadata for", Update::ChangeMetadata),
-            };
+                 change: CacheChange<SocketAddr, Metadata>) {
+        let (update_str, update, addr) = match change {
+            CacheChange::Insertion { key, value } => ("insert", Update::Insert(key, value), key),
+            CacheChange::Removal { key } => ("remove", Update::Remove(key), key),
+            CacheChange::Modification { key, new_value } =>
+                ("change metadata for", Update::ChangeMetadata(key, new_value), key),
+        };
         trace!("{} {:?} for {:?}", update_str, addr, authority_for_logging);
         // retain is used to drop any senders that are dead
         txs.retain(|tx| {
-            tx.unbounded_send(update_constructor(addr, meta.clone())).is_ok()
+            tx.unbounded_send(update.clone()).is_ok()
         });
     }
 }

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -651,10 +651,12 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
                  authority_for_logging: &DnsNameAndPort,
                  change: CacheChange<SocketAddr, Metadata>) {
         let (update_str, update, addr) = match change {
-            CacheChange::Insertion { key, value } => ("insert", Update::Insert(key, value), key),
-            CacheChange::Removal { key } => ("remove", Update::Remove(key), key),
+            CacheChange::Insertion { key, value } =>
+                ("insert", Update::Insert(key, value.clone()), key),
+            CacheChange::Removal { key } =>
+                ("remove", Update::Remove(key), key),
             CacheChange::Modification { key, new_value } =>
-                ("change metadata for", Update::ChangeMetadata(key, new_value), key),
+                ("change metadata for", Update::ChangeMetadata(key, new_value.clone()), key),
         };
         trace!("{} {:?} for {:?}", update_str, addr, authority_for_logging);
         // retain is used to drop any senders that are dead


### PR DESCRIPTION
Closes #713. This is a follow-up from #688.

This PR makes a number of refactorings to the proxy's `control::Cache` module and removes all but one of the `clone` calls. 

The `CacheChange` enum now contains the changed key and a reference to the changed value when applicable. This simplifies `on_change` functions, which no longer have to take both a tuple of `(K, V)` and a `CacheChange` and can now simply destructure the `CacheChange`, and since the changed value is passed as a reference, the `on_change` function can now decide whether or not it should be cloned. This means that we can remove a majority of the clones previously present here.

I've also rewritten `Cache::update_union` so that it no longer clones values (twice if the cache was invalidated). There's still one `clone` call in `Cache::update_intersection`, but it seems like it will be fairly tricky to remove. However, I've moved the `V: Clone` bound to that function specifically. `Cache::clear` and `Cache::update_union` so that they no longer call `Cache::update_intersection` internally, so they don't need a `V: Clone` bound.

In addition, I've added some unit tests that test that `on_change` is called with the correct `CacheChange`s when key/value pairs are modified.