### PR TITLE
Add unit tests for Labeled middleware

### DIFF
--- a/proxy/src/telemetry/metrics/prometheus/labels.rs
+++ b/proxy/src/telemetry/metrics/prometheus/labels.rs
@@ -308,7 +308,7 @@ mod test {
         fn call(&mut self, req: Self::Request) -> Self::Future {
             future::ok(req.extensions()
                 .get::<DstLabels>()
-                .map(|DstLabels(ref inner)| inner.as_ref().to_string()))
+                .map(|&DstLabels(ref inner)| inner.as_ref().to_string()))
         }
     }
 


### PR DESCRIPTION
This PR should merge after #661.

I've added unit tests for the `Labeled` middleware used to add Destination labels in the proxy, as @olix0r requested in https://github.com/runconduit/conduit/pull/661#discussion_r179897783. 