### PR TITLE
Add transport-level metrics to proxy-metrics.md

### DIFF
--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -152,15 +152,18 @@ A gauge of the number of transport connections currently open.
 
 ### `tcp_write_bytes_total`
 
-A counter of the total number of sent bytes.
+A counter of the total number of sent bytes. This is updated when the 
+connection closes.
 
 ### `tcp_read_bytes_total`
 
-A counter of the total number of recieved bytes.
+A counter of the total number of recieved bytes. This is updated when the 
+connection closes.
 
 ### `tcp_connection_duration_ms`
 
-A histogram of the duration of the lifetime of a connection, in milliseconds.
+A histogram of the duration of the lifetime of a connection, in milliseconds. 
+This is updated when the connection closes.
 
 ## Labels
 
@@ -179,8 +182,7 @@ are also added to transport-level metrics, when applicable.
 ### Connection Close Labels
 
 The following labels are added only to metrics which are updated when a connection closes
-(`tcp_accept_close_total`, `tcp_connect_close_total`, `sent_bytes`, `received_bytes`, and
-`tcp_connection_duration_ms`):
+(`tcp_close_total` and `tcp_connection_duration_ms`):
 
 + `classification`: `success` if the connection terminated cleanly, `failure` if the
                     connection closed due to a connection failure.

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -186,6 +186,14 @@ Each of these metrics has the following labels:
 Note that the labels described above under the heading "Prometheus Collector labels"
 are also added to transport-level metrics, when applicable.
 
+### Connection Close Labels
+
+The following labels are added only to metrics which are updated when a connection closes
+(`tcp_accept_close_total`, `tcp_connect_close_total`, `sent_bytes`, `received_bytes`, and 
+`tcp_connection_duration_ms`):
+
++ `classification`: `success` if the connection terminated cleanly, `failure` if the
+                    connection closed due to a connection failure.
 
 [prom-format]: https://prometheus.io/docs/instrumenting/exposition_formats/#format-version-0.0.4
 [pod-template-hash]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -179,19 +179,29 @@ This is incremented when a connection closes.
 
 Each of these metrics has the following labels:
 
-* `direction`: `inbound` if the connection was to/from the proxy's Inbound router,
-               `outbound` if the connection was to/from the proxy's Outbound router.
-* `kind`: `client` if the connection was initiated by the proxy to an upstream server,
-          `server` if the connection was initiated by an upstream client to the proxy.
-* `remote_address`: the IP address and port of the remote end of the connection.
+* `direction`: `inbound` if the connection was established either from outside the
+                pod to the proxy, or from the proxy to the application,
+               `outbound` if the connection was established either from the
+                application to the proxy, or from the proxy to outside the pod.
+* `kind`: `client` if the connection was initiated by the proxy,
+          `server` if the connection was initiated to the proxy.
 * `protocol`: `http` if the connection corresponds to an HTTP/1 or HTTP/2 request,
               `tcp` if the connection is proxied as a raw TCP stream.
 
-### Server Labels
+### Outbound HTTP labels
 
-These labels are only applicable if `kind="server"`:
+The following labels are only applicable if `direction="outbound"`, `protocol="http",`
+_and_ `kind="server"`.
 
-* `local_address`: the address of the TCP socket for this connection.
+* `dst_deployment`: The deployment to which this request is being sent.
+* `dst_job`: The job to which this request is being sent.
+* `dst_replica_set`: The replica set to which this request is being sent.
+* `dst_daemon_set`: The daemon set to which this request is being sent.
+* `dst_replication_controller`: The replication controller to which this request
+                                is being sent.
+* `dst_namespace`: The namespace to which this request is being sent.
+* `dst_service`: The service to which this request is being sent.
+
 
 ### Prometheus Collector labels
 

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -138,35 +138,23 @@ request_total{
 The following metrics are collected at the level of the underlying transport
 layer.
 
-### `tcp_accept_open_total`
+### `tcp_open_total`
 
-A counter of the total number of transport connections which have been accepted
-by the proxy.
+A counter of the total number of opened transport connections.
 
-### `tcp_accept_close_total`
+### `tcp_close_total`
 
-A counter of the total number of transport connections accepted by the proxy
-which have been closed.
+A counter of the total number of transport connections which have closed.
 
-### `tcp_connect_open_total`
-
-A counter of the total number of transport connections which have been opened
-by the proxy.
-
-### `tcp_connect_close_total`
-
-A counter of the total number of transport connections opened by the proxy
-which have been closed.
-
-### `tcp_connections_open`
+### `tcp_open_connections`
 
 A gauge of the number of transport connections currently open.
 
-### `sent_bytes`
+### `tcp_write_bytes_total`
 
 A counter of the total number of sent bytes.
 
-### `received_bytes`
+### `tcp_read_bytes_total`
 
 A counter of the total number of recieved bytes.
 
@@ -182,6 +170,8 @@ Each of these metrics has the following labels:
                 pod to the proxy, or from the proxy to the application,
                `outbound` if the connection was established either from the
                 application to the proxy, or from the proxy to outside the pod.
+* `peer`: `src` if the connection was accepted by the proxy from the source,
+          `dst` if the connection was opened by the proxy to the destination.
 
 Note that the labels described above under the heading "Prometheus Collector labels"
 are also added to transport-level metrics, when applicable.
@@ -189,7 +179,7 @@ are also added to transport-level metrics, when applicable.
 ### Connection Close Labels
 
 The following labels are added only to metrics which are updated when a connection closes
-(`tcp_accept_close_total`, `tcp_connect_close_total`, `sent_bytes`, `received_bytes`, and 
+(`tcp_accept_close_total`, `tcp_connect_close_total`, `sent_bytes`, `received_bytes`, and
 `tcp_connection_duration_ms`):
 
 + `classification`: `success` if the connection terminated cleanly, `failure` if the

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -165,16 +165,6 @@ A counter of the total number of recieved bytes.
 
 A histogram of the duration of the lifetime of a connection, in milliseconds.
 
-### `connection_sent_bytes`
-
-A histogram of the number of bytes sent over the lifetime of a connection.
-This is updated when a connection closes.
-
-### `connection_recieved_bytes`
-
-A histogram of the number of bytes recieved over the lifetime of a connection.
-This is incremented when a connection closes.
-
 ## Labels
 
 Each of these metrics has the following labels:
@@ -187,6 +177,10 @@ Each of these metrics has the following labels:
           `server` if the connection was initiated to the proxy.
 * `protocol`: `http` if the connection corresponds to an HTTP/1 or HTTP/2 request,
               `tcp` if the connection is proxied as a raw TCP stream.
+
+Note that the labels described above under the heading "Prometheus Collector labels"
+are also added to transport-level metrics, when applicable.
+
 
 ### Outbound HTTP labels
 
@@ -201,36 +195,3 @@ _and_ `kind="server"`.
                                 is being sent.
 * `dst_namespace`: The namespace to which this request is being sent.
 * `dst_service`: The service to which this request is being sent.
-
-
-### Prometheus Collector labels
-
-The following labels are added by the Prometheus collector.
-
-* `instance`: ip:port of the pod.
-* `job`: The Prometheus job responsible for the collection, typically
-         `conduit-proxy`.
-
-#### Kubernetes labels added at collection time
-
-Kubernetes namespace, pod name, and all labels are mapped to corresponding
-Prometheus labels.
-
-* `namespace`: Kubernetes namespace that the pod belongs to.
-* `pod`: Kubernetes pod name.
-* `pod_template_hash`: Corresponds to the [pod-template-hash][pod-template-hash]
-                       Kubernetes label. This value changes during redeploys and
-                       rolling restarts.
-
-#### Conduit labels added at collection time
-
-Kubernetes labels prefixed with `conduit.io/` are added to your application at
-`conduit inject` time. More specifically, Kubernetes labels prefixed with
-`conduit.io/proxy-*` will correspond to these Prometheus labels:
-
-* `daemon_set`: The daemon set that the pod belongs to (if applicable).
-* `deployment`: The deployment that the pod belongs to (if applicable).
-* `k8s_job`: The job that the pod belongs to (if applicable).
-* `replica_set`: The replica set that the pod belongs to (if applicable).
-* `replication_controller`: The replication controller that the pod belongs to
-                            (if applicable).

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -133,23 +133,32 @@ request_total{
 }
 ```
 
-[prom-format]: https://prometheus.io/docs/instrumenting/exposition_formats/#format-version-0.0.4
-[pod-template-hash]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label
-
 # Transport-Level Metrics
 
 The following metrics are collected at the level of the underlying transport
 layer.
 
-### `connection_opens`
+### `tcp_accept_open_total`
 
-A counter of the total number of transport connections which have been opened.
+A counter of the total number of transport connections which have been accepted
+by the proxy.
 
-### `connection_closes`
+### `tcp_accept_close_total`
 
-A counter of the total number of transport connections which have been closed.
+A counter of the total number of transport connections accepted by the proxy
+which have been closed.
 
-### `connections`
+### `tcp_connect_open_total`
+
+A counter of the total number of transport connections which have been opened
+by the proxy.
+
+### `tcp_connect_close_total`
+
+A counter of the total number of transport connections opened by the proxy
+which have been closed.
+
+### `tcp_connections_open`
 
 A gauge of the number of transport connections currently open.
 
@@ -161,7 +170,7 @@ A counter of the total number of sent bytes.
 
 A counter of the total number of recieved bytes.
 
-### `connection_duration_ms`
+### `tcp_connection_duration_ms`
 
 A histogram of the duration of the lifetime of a connection, in milliseconds.
 
@@ -173,8 +182,6 @@ Each of these metrics has the following labels:
                 pod to the proxy, or from the proxy to the application,
                `outbound` if the connection was established either from the
                 application to the proxy, or from the proxy to outside the pod.
-* `kind`: `client` if the connection was initiated by the proxy,
-          `server` if the connection was initiated to the proxy.
 * `protocol`: `http` if the connection corresponds to an HTTP/1 or HTTP/2 request,
               `tcp` if the connection is proxied as a raw TCP stream.
 
@@ -182,16 +189,5 @@ Note that the labels described above under the heading "Prometheus Collector lab
 are also added to transport-level metrics, when applicable.
 
 
-### Outbound HTTP labels
-
-The following labels are only applicable if `direction="outbound"`, `protocol="http",`
-_and_ `kind="server"`.
-
-* `dst_deployment`: The deployment to which this request is being sent.
-* `dst_job`: The job to which this request is being sent.
-* `dst_replica_set`: The replica set to which this request is being sent.
-* `dst_daemon_set`: The daemon set to which this request is being sent.
-* `dst_replication_controller`: The replication controller to which this request
-                                is being sent.
-* `dst_namespace`: The namespace to which this request is being sent.
-* `dst_service`: The service to which this request is being sent.
+[prom-format]: https://prometheus.io/docs/instrumenting/exposition_formats/#format-version-0.0.4
+[pod-template-hash]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template-hash-label

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -182,8 +182,6 @@ Each of these metrics has the following labels:
                 pod to the proxy, or from the proxy to the application,
                `outbound` if the connection was established either from the
                 application to the proxy, or from the proxy to outside the pod.
-* `protocol`: `http` if the connection corresponds to an HTTP/1 or HTTP/2 request,
-              `tcp` if the connection is proxied as a raw TCP stream.
 
 Note that the labels described above under the heading "Prometheus Collector labels"
 are also added to transport-level metrics, when applicable.


### PR DESCRIPTION
This PR adds a proposed description of the transport-level metrics which the proxy should expose. All of the metrics described here can be added with information that the proxy currently collects.

This is a request for comments on a proposed design. Once we agree that the design documented here is appropriate, we can either merge this as an aspirational description or wait until the features described here are implemented.