### PR TITLE
Move request open timestamp to the top of the stack

### DIFF
--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -351,7 +351,7 @@ where
         let router = router.clone();
 
         // Map errors to appropriate response error codes.
-        MapErr::new(router, |e| {
+        let map_err = MapErr::new(router, |e| {
             match e {
                 RouteError::Route(r) => {
                     error!(" turning route error: {} into 500", r);
@@ -366,7 +366,12 @@ where
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
             }
-        })
+        });
+
+        // Install the request open timestamp module at the very top
+        // of the stack, in order to take the timestamp as close as
+        // possible to the beginning of the request's lifetime.
+        telemetry::sensor::http::TimestampRequestOpen::new(map_err)
     }));
 
     let listen_addr = bound_port.local_addr();

--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -227,13 +227,6 @@ where
             req.extensions_mut().remove::<RequestOpen>()
         );
         let (inner, body_inner) = match metadata {
-            (ctx @ None, request_open) | (ctx, request_open @ None) => {
-                warn!(
-                    "missing metadata for a request to {:?}; ctx={:?}; request_open={:?};",
-                    req.uri(), ctx, request_open
-                );
-                (None, None)
-            },
             (Some(ctx), Some(RequestOpen(request_open))) => {
                 let id = self.next_id.fetch_add(1, Ordering::SeqCst);
                 let ctx = ctx::http::Request::new(&req, &ctx, &self.client_ctx, id);
@@ -267,7 +260,14 @@ where
                         })
                     };
                 (respond_inner, body_inner)
-            }
+            },
+            (ctx, request_open) => {
+                warn!(
+                    "missing metadata for a request to {:?}; ctx={:?}; request_open={:?};",
+                    req.uri(), ctx, request_open
+                );
+                (None, None)
+            },
         };
         let req = {
             let (parts, body) = req.into_parts();

--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, IntoBuf};
-use futures::{Async, Future, Poll, Stream};
+use futures::{future, Async, Future, Poll, Stream};
 use h2;
 use http;
 use std::default::Default;
@@ -14,6 +14,25 @@ use ctx;
 use telemetry::event::{self, Event};
 
 const GRPC_STATUS: &str = "grpc-status";
+
+/// A `RequestOpen` timestamp.
+///
+/// This is added to a request's `Extensions` by the `TimestampRequestOpen`
+/// middleware. It's a newtype in order to distinguish it from other
+/// `Instant`s that may be added as request extensions.
+#[derive(Copy, Clone, Debug)]
+pub struct RequestOpen(pub Instant);
+
+/// Middleware that adds a `RequestOpen` timestamp to requests.
+///
+/// This is a separate middleware from `sensor::Http`, because we want
+/// to install it at the earliest point in the stack. This is in order
+/// to ensure that request latency metrics cover the overhead added by
+/// the proxy as accurately as possible.
+#[derive(Copy, Clone, Debug)]
+pub struct TimestampRequestOpen<S> {
+    inner: S,
+}
 
 pub struct NewHttp<N, A, B> {
     next_id: Arc<AtomicUsize>,
@@ -212,7 +231,9 @@ where
                 self.handle
                     .send(|| Event::StreamRequestOpen(Arc::clone(&ctx)));
 
-                let request_open = Instant::now();
+                let RequestOpen(request_open) = req.extensions_mut()
+                    .remove::<RequestOpen>()
+                    .expect("request open timestamp should always be inserted");
 
                 let respond_inner = Some(RespondInner {
                     ctx: ctx.clone(),
@@ -572,5 +593,50 @@ impl BodySensor for RequestBodyInner {
 
     fn bytes_sent(&mut self) -> &mut u64 {
         &mut self.bytes_sent
+    }
+}
+
+impl<S> TimestampRequestOpen<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, B> Service for TimestampRequestOpen<S>
+where
+    S: Service<Request = http::Request<B>>,
+{
+    type Request = http::Request<B>;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, mut req: Self::Request) -> Self::Future {
+        let request_open = Instant::now();
+        req.extensions_mut().insert(RequestOpen(request_open));
+        self.inner.call(req)
+    }
+}
+
+impl<S, B> NewService for TimestampRequestOpen<S>
+where
+    S: NewService<Request = http::Request<B>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type InitError = S::InitError;
+    type Future = future::Map<
+        S::Future,
+        fn(S::Service) -> Self::Service
+    >;
+    type Service = TimestampRequestOpen<S::Service>;
+
+    fn new_service(&self) -> Self::Future {
+        self.inner.new_service().map(TimestampRequestOpen::new)
     }
 }


### PR DESCRIPTION
Currently, the request open timestamp, which is used for calculating latency, is captured in the `sensor::http::Http` middleware. However, the sensor middleware is placed fairly low in the stack, below some of the proxy's components that can add measurable latency (e.g. the router).

This PR moves the request_open timestamp out of the `Http` middleware and into a new `TimestampRequestOpen` middleware, which is installed at the top of the stack (before the router). The `TimestampRequestOpen` middleware adds the timestamp as a request extension, so that it can later be consumed by the `Http` sensor to generate the request stats.

By moving the timestamping to the top of the stack, the timestamp should more accurately cover the overhead of the proxy, but a majority of the telemetry work can still be done where it was previously.

I'd like to have included unit tests for this change, but since the expected improvement is in the accuracy of latency measurements, there's no easy way to test this programmatically. 

Fixes #479.