### PR TITLE
Handle NaN metrics

### DIFF
--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -249,7 +249,10 @@ func processRequests(results []promResult, labelSelector string) map[string]*pb.
 				basicStats[label] = &pb.BasicStats{}
 			}
 
-			value := uint64(math.Round(float64(sample.Value)))
+			value := uint64(0)
+			if !math.IsNaN(float64(sample.Value)) {
+				value = uint64(math.Round(float64(sample.Value)))
+			}
 
 			switch result.prom {
 			case promRequests:


### PR DESCRIPTION
The Prometheus client sometimes returns NaN if a calculation is invalid,
such as histogram_quantile when no requests have occurred.

Add IsNaN check in the public-api and set output to zero.

Fixes #747

Signed-off-by: Andrew Seigner <siggy@buoyant.io>