### PR TITLE
Ignore flaky telemetry tests on CI

### DIFF
--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -798,7 +798,12 @@ mod outbound_dst_labels {
             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",classification=\"success\",status_code=\"200\"} 1");
     }
 
+    // Ignore this test on CI, as it may fail due to the reduced concurrency
+    // on CI containers causing the proxy to see both label updates from
+    // the mock controller before the first request has finished.
+    // See https://github.com/runconduit/conduit/issues/751
     #[test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_addr_labels() {
         let _ = env_logger::try_init();
                 info!("running test server");
@@ -850,7 +855,12 @@ mod outbound_dst_labels {
             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",classification=\"success\",status_code=\"200\"} 1");
     }
 
+    // Ignore this test on CI, as it may fail due to the reduced concurrency
+    // on CI containers causing the proxy to see both label updates from
+    // the mock controller before the first request has finished.
+    // See https://github.com/runconduit/conduit/issues/751
     #[test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_set_labels() {
         let _ = env_logger::try_init();
                 info!("running test server");


### PR DESCRIPTION
The tests for label metadata updates from the control plane are flaky on CI. This is likely due to the CI containers not having enough cores to execute the test proxy thread, the test proxy's controller client thread, the mock controller thread, and the test server thread simultaneously --- see #751 for more information. 

For now, I'm ignoring these on CI. Eventually, I'd like to change the mock controller code in test support so that we can trigger it to send a second metadata update only after the request has finished.

I think this issue also makes merging #738 a higher priority, so that we can still have some tests running on CI that exercise some part of the label update behaviour.