### PR TITLE
Use apps/v1beta2 for Kubernetes 1.8 compatibility

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -746,6 +746,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fcb8abf65ef829da5c65b12728673c4c60aadcc2ae4037874e24943ab3a2db89"
+  inputs-digest = "85096b26ceba678986d333d0cbe7491966a073a4419b20975beb8b2c88d85bf7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:bccd0b8c as golang
+FROM gcr.io/runconduit/go-deps:799047c7 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:bccd0b8c as golang
+FROM gcr.io/runconduit/go-deps:799047c7 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	k8sV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	applisters "k8s.io/client-go/listers/apps/v1"
+	applisters "k8s.io/client-go/listers/apps/v1beta2"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -102,7 +102,7 @@ status:
   phase: Pending
   podIP: 4.3.2.1
 `, `
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: rs-emojivoto-meshed
@@ -116,7 +116,7 @@ spec:
     matchLabels:
       pod-template-hash: hash-meshed
 `, `
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: rs-emojivoto-not-meshed
@@ -166,8 +166,8 @@ spec:
 			clientSet := fake.NewSimpleClientset(k8sObjs...)
 			sharedInformers := informers.NewSharedInformerFactory(clientSet, 10*time.Minute)
 
-			deployInformer := sharedInformers.Apps().V1().Deployments()
-			replicaSetInformer := sharedInformers.Apps().V1().ReplicaSets()
+			deployInformer := sharedInformers.Apps().V1beta2().Deployments()
+			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 			podInformer := sharedInformers.Core().V1().Pods()
 
 			fakeGrpcServer := newGrpcServer(

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/runconduit/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"
-	applisters "k8s.io/client-go/listers/apps/v1"
+	applisters "k8s.io/client-go/listers/apps/v1beta2"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )
 

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -13,7 +13,7 @@ import (
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
 	log "github.com/sirupsen/logrus"
-	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -286,18 +286,18 @@ func metricToKey(metric model.Metric, labelSelector string) string {
 	)
 }
 
-func (s *grpcServer) getDeployments(res *pb.Resource) ([]*appsv1.Deployment, map[string]*meshedCount, error) {
+func (s *grpcServer) getDeployments(res *pb.Resource) ([]*appsv1beta2.Deployment, map[string]*meshedCount, error) {
 	var err error
-	var deployments []*appsv1.Deployment
+	var deployments []*appsv1beta2.Deployment
 
 	if res.Namespace == "" {
 		deployments, err = s.deployLister.List(labels.Everything())
 	} else if res.Name == "" {
 		deployments, err = s.deployLister.Deployments(res.Namespace).List(labels.Everything())
 	} else {
-		var deployment *appsv1.Deployment
+		var deployment *appsv1beta2.Deployment
 		deployment, err = s.deployLister.Deployments(res.Namespace).Get(res.Name)
-		deployments = []*appsv1.Deployment{deployment}
+		deployments = []*appsv1beta2.Deployment{deployment}
 	}
 
 	if err != nil {
@@ -350,7 +350,7 @@ func isInMesh(pod *apiv1.Pod) bool {
 
 func getSelectorFromObject(obj runtime.Object) (labels.Selector, error) {
 	switch typed := obj.(type) {
-	case *appsv1.Deployment:
+	case *appsv1beta2.Deployment:
 		return labels.Set(typed.Spec.Selector.MatchLabels).AsSelector(), nil
 
 	default:

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -32,7 +32,7 @@ func TestStatSummary(t *testing.T) {
 			statSumExpected{
 				err: nil,
 				k8sRes: []string{`
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: emoji
@@ -136,8 +136,8 @@ metadata:
 			clientSet := fake.NewSimpleClientset(k8sObjs...)
 			sharedInformers := informers.NewSharedInformerFactory(clientSet, 10*time.Minute)
 
-			deployInformer := sharedInformers.Apps().V1().Deployments()
-			replicaSetInformer := sharedInformers.Apps().V1().ReplicaSets()
+			deployInformer := sharedInformers.Apps().V1beta2().Deployments()
+			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 			podInformer := sharedInformers.Core().V1().Pods()
 
 			fakeGrpcServer := newGrpcServer(
@@ -211,8 +211,8 @@ metadata:
 			fakeGrpcServer := newGrpcServer(
 				&MockProm{Res: exp.promRes},
 				tap.NewTapClient(nil),
-				sharedInformers.Apps().V1().Deployments().Lister(),
-				sharedInformers.Apps().V1().ReplicaSets().Lister(),
+				sharedInformers.Apps().V1beta2().Deployments().Lister(),
+				sharedInformers.Apps().V1beta2().ReplicaSets().Lister(),
 				sharedInformers.Core().V1().Pods().Lister(),
 				"conduit",
 				[]string{},

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -57,10 +57,10 @@ func main() {
 
 	sharedInformers := informers.NewSharedInformerFactory(k8sClient, 10*time.Minute)
 
-	deployInformer := sharedInformers.Apps().V1().Deployments()
+	deployInformer := sharedInformers.Apps().V1beta2().Deployments()
 	deployInformerSynced := deployInformer.Informer().HasSynced
 
-	replicaSetInformer := sharedInformers.Apps().V1().ReplicaSets()
+	replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 	replicaSetInformerSynced := replicaSetInformer.Informer().HasSynced
 
 	podInformer := sharedInformers.Core().V1().Pods()
@@ -85,7 +85,7 @@ func main() {
 	)
 
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
 		log.Infof("waiting for caches to sync")

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:bccd0b8c as golang
+FROM gcr.io/runconduit/go-deps:799047c7 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:bccd0b8c as golang
+FROM gcr.io/runconduit/go-deps:799047c7 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
Conduit was relying on apps/v1 to Deployment and ReplicaSet APIs.
apps/v1 is not available on Kubernetes 1.8. This prevented the
public-api from starting.

Switch Conduit to use apps/v1beta2. Also increase the Kubernetes API
cache sync timeout from 10 to 60 seconds, as it was taking 11 seconds on
a test cluster.

Fixes #761

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Tested against:
- v1.8.9-gke.1
- v1.9.6