### PR TITLE
Misc cleanup following the telemetry rewrite

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -41,7 +41,7 @@ var completionCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf(out)
+		fmt.Print(out)
 		return nil
 	},
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -40,8 +40,6 @@ var versionCmd = &cobra.Command{
 				fmt.Printf("Server version: %s\n", serverVersion)
 			}
 		}
-
-		return
 	},
 }
 

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	ApiRoot                 = "/" // Must be absolute (with a leading slash).
-	ApiVersion              = "v1"
-	ApiPrefix               = "api/" + ApiVersion + "/" // Must be relative (without a leading slash).
+	apiRoot                 = "/" // Must be absolute (with a leading slash).
+	apiVersion              = "v1"
+	apiPrefix               = "api/" + apiVersion + "/" // Must be relative (without a leading slash).
 	ConduitApiSubsystemName = "conduit-api"
 )
 
@@ -168,7 +168,7 @@ func newClient(apiURL *url.URL, httpClientToUse *http.Client) (pb.ApiClient, err
 		return nil, fmt.Errorf("server URL must be absolute, was [%s]", apiURL.String())
 	}
 
-	serverUrl := apiURL.ResolveReference(&url.URL{Path: ApiPrefix})
+	serverUrl := apiURL.ResolveReference(&url.URL{Path: apiPrefix})
 
 	log.Debugf("Expecting Conduit Public API to be served over [%s]", serverUrl)
 

--- a/controller/api/public/client_test.go
+++ b/controller/api/public/client_test.go
@@ -47,6 +47,9 @@ func TestNewInternalClient(t *testing.T) {
 		}
 
 		_, err = client.Version(context.Background(), &pb.Empty{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 
 		expectedUrlRequested := "http://some-hostname/api/v1/Version"
 		actualUrlRequested := mockTransport.requestSent.URL.String()

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -63,7 +63,7 @@ func newGrpcServer(
 	}
 }
 
-func (_ *grpcServer) Version(ctx context.Context, req *pb.Empty) (*pb.VersionInfo, error) {
+func (*grpcServer) Version(ctx context.Context, req *pb.Empty) (*pb.VersionInfo, error) {
 	return &pb.VersionInfo{GoVersion: runtime.Version(), ReleaseVersion: version.Version, BuildDate: "1970-01-01T00:00:00Z"}, nil
 }
 

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/protobuf/jsonpb"
 	promApi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	common "github.com/runconduit/conduit/controller/gen/common"
@@ -20,8 +19,6 @@ import (
 )
 
 var (
-	jsonMarshaler   = jsonpb.Marshaler{EmitDefaults: true}
-	jsonUnmarshaler = jsonpb.Unmarshaler{}
 	statSummaryPath = fullUrlPathFor("StatSummary")
 	versionPath     = fullUrlPathFor("Version")
 	listPodsPath    = fullUrlPathFor("ListPods")
@@ -186,13 +183,13 @@ func (s tapServer) Send(msg *common.TapEvent) error {
 // satisfy the pb.Api_TapServer interface
 func (s tapServer) SetHeader(metadata.MD) error  { return nil }
 func (s tapServer) SendHeader(metadata.MD) error { return nil }
-func (s tapServer) SetTrailer(metadata.MD)       { return }
+func (s tapServer) SetTrailer(metadata.MD)       {}
 func (s tapServer) Context() context.Context     { return s.req.Context() }
 func (s tapServer) SendMsg(interface{}) error    { return nil }
 func (s tapServer) RecvMsg(interface{}) error    { return nil }
 
 func fullUrlPathFor(method string) string {
-	return ApiRoot + ApiPrefix + method
+	return apiRoot + apiPrefix + method
 }
 
 func NewServer(

--- a/controller/api/public/http_server_test.go
+++ b/controller/api/public/http_server_test.go
@@ -235,7 +235,7 @@ func assertCallWasForwarded(t *testing.T, mockGrpcServer *mockGrpcServer, expect
 	}
 
 	mockGrpcServer.ErrorToReturn = errors.New("expected")
-	actualResponse, err = functionCall()
+	_, err = functionCall()
 	if err == nil {
 		t.Fatalf("Expecting error, got nothing")
 	}

--- a/controller/api/public/proto_over_http_test.go
+++ b/controller/api/public/proto_over_http_test.go
@@ -450,7 +450,15 @@ func TestCheckIfResponseHasError(t *testing.T) {
 	t.Run("returns error in body if response contains Conduit error", func(t *testing.T) {
 		expectedErrorMessage := "expected error message"
 		protoInBytes, err := proto.Marshal(&pb.ApiError{Error: expectedErrorMessage})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
 		message, err := serializeAsPayload(protoInBytes)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
 		response := &http.Response{
 			Header: make(http.Header),
 			Body:   ioutil.NopCloser(bytes.NewReader(message)),
@@ -470,7 +478,15 @@ func TestCheckIfResponseHasError(t *testing.T) {
 
 	t.Run("returns error if response contains Conduit error but body isn't error message", func(t *testing.T) {
 		protoInBytes, err := proto.Marshal(&pb.VersionInfo{ReleaseVersion: "0.0.1"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
 		message, err := serializeAsPayload(protoInBytes)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
 		response := &http.Response{
 			Header: make(http.Header),
 			Body:   ioutil.NopCloser(bytes.NewReader(message)),

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -198,29 +198,29 @@ func promResourceType(resource *pb.Resource) model.LabelName {
 }
 
 func buildRequestLabels(req *pb.StatSummaryRequest) (model.LabelSet, model.LabelNames) {
+	var labelNames model.LabelNames
 	labels := model.LabelSet{}
-	aggregations := model.LabelNames{}
 
 	switch out := req.Outbound.(type) {
 	case *pb.StatSummaryRequest_ToResource:
-		aggregations = promLabelNames(req.Selector.Resource)
+		labelNames = promLabelNames(req.Selector.Resource)
 		labels = labels.Merge(promDstLabels(out.ToResource))
 		labels = labels.Merge(promLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	case *pb.StatSummaryRequest_FromResource:
-		aggregations = promDstLabelNames(req.Selector.Resource)
+		labelNames = promDstLabelNames(req.Selector.Resource)
 		labels = labels.Merge(promLabels(out.FromResource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	default:
-		aggregations = promLabelNames(req.Selector.Resource)
+		labelNames = promLabelNames(req.Selector.Resource)
 		labels = labels.Merge(promLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("inbound"))
 
 	}
 
-	return labels, aggregations
+	return labels, labelNames
 }
 
 func (s *grpcServer) getRequests(ctx context.Context, req *pb.StatSummaryRequest, timeWindow string) (map[string]*pb.BasicStats, error) {
@@ -445,12 +445,4 @@ func (s *grpcServer) queryProm(ctx context.Context, query string) (model.Vector,
 	}
 
 	return res.(model.Vector), nil
-}
-
-func mapKeys(m map[string]interface{}) []string {
-	res := make([]string, 0)
-	for k := range m {
-		res = append(res, k)
-	}
-	return res
 }

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -65,7 +65,6 @@ func (a *MockApi_TapClient) Recv() (*common.TapEvent, error) {
 }
 
 type MockProm struct {
-	api v1.API
 	Res model.Value
 }
 

--- a/controller/k8s/watcher_test.go
+++ b/controller/k8s/watcher_test.go
@@ -72,14 +72,10 @@ func TestWatcher(t *testing.T) {
 		watcher := newWatcher(resource, "resourcestring", testWatchInit, stopCh)
 		watcher.timeout = 500 * time.Millisecond
 		_ = watcher.run()
-		select {
-		case <-stopCh:
-			calls := atomic.LoadInt32(&watchInitNumOfCalls)
-			if calls != expectedWatchInitNumOfCalls {
-				t.Fatalf("expected [%d] calls but observed [%d]", expectedWatchInitNumOfCalls, watchInitNumOfCalls)
-			}
-
+		<-stopCh
+		calls := atomic.LoadInt32(&watchInitNumOfCalls)
+		if calls != expectedWatchInitNumOfCalls {
+			t.Fatalf("expected [%d] calls but observed [%d]", expectedWatchInitNumOfCalls, watchInitNumOfCalls)
 		}
-
 	})
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -55,15 +55,10 @@ func TestSelfChecker(t *testing.T) {
 			observedResults = append(observedResults, r)
 		}
 
-		allChecks := make([]*healthcheckPb.CheckResult, 0)
-		allChecks = append(allChecks, workingSubsystem1.checksToReturn...)
-		allChecks = append(allChecks, workingSubsystem2.checksToReturn...)
-		allChecks = append(allChecks, failingSubsystem1.checksToReturn...)
-
 		expectedResults := make([]*healthcheckPb.CheckResult, 0)
-		for _, check := range allChecks {
-			expectedResults = append(expectedResults, check)
-		}
+		expectedResults = append(expectedResults, workingSubsystem1.checksToReturn...)
+		expectedResults = append(expectedResults, workingSubsystem2.checksToReturn...)
+		expectedResults = append(expectedResults, failingSubsystem1.checksToReturn...)
 
 		healthChecker.PerformCheck(observer)
 

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -31,13 +31,6 @@ Find more information at https://conduit.io/.`,
 	},
 }
 
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
-}
-
 func init() {
 	RootCmd.PersistentFlags().IntVarP(&incomingProxyPort, "incoming-proxy-port", "p", -1, "Port to redirect incoming traffic")
 	RootCmd.PersistentFlags().IntVarP(&outgoingProxyPort, "outgoing-proxy-port", "o", -1, "Port to redirect outgoing traffic")


### PR DESCRIPTION
This branch removes some unused artifacts that were left behind after the telemetry rewrite that just happened, and fixes some small linting / naming issues. I used some of the tools from https://github.com/dominikh/go-tools to track these down.