### PR TITLE
v0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## v0.4.0
 
-Conduit 0.4.0 replaces Conduit's telemetry system, improves service discovery, and removes
-the need for specifying `--skip-(in|out)bound-ports` for MySQL and SMTP.
+Conduit 0.4.0 ovehauls Conduit's telemetry system and improves service discovery
+reliability.
 
 * Web UI
   * **New** automatically-configured Grafana dashboards for all Deployments.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## v0.4.0
 
-Conduit 0.4.0 ovehauls Conduit's telemetry system and improves service discovery
+Conduit 0.4.0 overhauls Conduit's telemetry system and improves service discovery
 reliability.
 
 * Web UI
@@ -15,8 +15,8 @@ reliability.
   * **New** Prometheus-formatted metrics are now exposed on `:4191/metrics`, including
     rich destination labeling for outbound HTTP requests. The proxy no longer pushes
     metrics to the control plane.
-  * The proxy now gracefully handles `SIGINT` or `SIGTERM`, gracefully draining requests
-    until all are complete or `SIGQUIT` is received.
+  * The proxy now handles `SIGINT` or `SIGTERM`, gracefully draining requests until all
+    are complete or `SIGQUIT` is received.
   * SMTP and MySQL (ports 25 and 3306) are now treated as opaque TCP by default. You
     should no longer have to specify `--skip-outbound-ports` to communicate with such
     services.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,48 @@
+## v0.4.0
+
+Conduit 0.4.0 replaces Conduit's telemetry system, improves service discovery, and removes
+the need for specifying `--skip-(in|out)bound-ports` for MySQL and SMTP.
+
+* Web UI
+  * **New** automatically-configured Grafana dashboards for all Deployments.
+* Command-line interface
+  * `conduit stat` has been completely rewritten to accept arguments like `kubectl get`.
+    The `--to` and `--from` filters can be used to filter traffic by destination and
+    source, respectively.  `conduit stat` currently can operate on `Namespace` and
+    `Deployment` Kubernetes resources. More resource types will be added in the next
+    release!
+* Proxy (data plane)
+  * **New** Prometheus-formatted metrics are now exposed on `:4191/metrics`, including
+    rich destination labeling for outbound HTTP requests. The proxy no longer pushes
+    metrics to the control plane.
+  * The proxy now gracefully handles `SIGINT` or `SIGTERM`, gracefully draining requests
+    until all are complete or `SIGQUIT` is received.
+  * SMTP and MySQL (ports 25 and 3306) are now treated as opaque TCP by default. You
+    should no longer have to specify `--skip-outbound-ports` to communicate with such
+    services.
+  * When the proxy reconnected to the controller, it could continue to send requests to
+    old endpoints. Now, when the proxy reconnects to the controller, it properly removes
+    invalid endpoints.
+  * A bug impacting some HTTP/2 reset scenarios has been fixed.
+* Service Discovery
+  * Previously, the proxy failed to resolve some domain names that could be misinterpreted
+    as a Kubernetes Service name. This has been fixed by extending the _Destination_ API
+    with a negative acknowledgement response.
+* Control Plane
+  * The _Telemetry_ service and associated APIs have been removed.
+* Documentation
+  * Updated [Roadmap](doc/roadmap.md)
+
+Special thanks to @ahume, @alenkacz, & @xiaods for contributing to this release!
+
+### Upgrading from v0.3.1
+
+When upgrading from v0.3.1, it's important to upgrade proxies before upgrading the
+controller. As you upgrade proxies, the controller will lose visibility into some data
+plane stats. Once all proxies are updated, `conduit install |kubectl apply -f -` can be
+run to upgrade the controller without causing any data plane disruptions. Once the
+controller has been restarted, traffic stats should become available.
+
 ## v0.3.1
 
 Conduit 0.3.1 improves Conduit's resilience and transparency.

--- a/doc/get-involved.md
+++ b/doc/get-involved.md
@@ -10,7 +10,7 @@ We're really excited to welcome Contributors to [Conduit](https://github.com/run
 
 There are several ways to get involved:
 
-- Conduit on [Github](https://github.com/runconduit/conduit)
+- Conduit on [GitHub](https://github.com/runconduit/conduit)
 - Join us on the #conduit channel in [Linkerd slack](https://slack.linkerd.io/)
 - Join the mailing lists
   - Users list: [conduit-users@googlegroups.com](https://groups.google.com/forum/#!forum/conduit-users)

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -22,7 +22,7 @@ request headers are received to when the request stream has completed.
 ### `response_total`
 
 A counter of the number of responses the proxy has received.  This is
-incremeneted when the response stream ends.
+incremented when the response stream ends.
 
 ### `response_duration_ms`
 

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -1,10 +1,3 @@
-+++
-title = "Conduit roadmap"
-docpage = true
-[menu.docs]
-  parent = "roadmap"
-+++
-
 This is the planned roadmap for Conduit. Of course, as with any software project
 (especially open source) even the best of plans change rapidly as development progresses.
 
@@ -13,38 +6,39 @@ featureset, then to build functionality out from there. We’ll make alpha / bet
 designations based on actual community usage, and generally will err on the side of being
 overly conservative.
 
-##### Status: alpha
-## [0.3: Telemetry Stability](https://github.com/runconduit/conduit/milestone/5)
 
-#### Late February 2018
+##### Status: beta
+## [0.4.0: Rich, Kubernetes-aware Grafana & Prometheus](https://github.com/runconduit/conduit/milestone/6)
+#### 2018-04-16
 
 ### Visibility
 
-- Stable, automatic top-line metrics for small-scale clusters.
-
-### Usability
-
-- Routing to external DNS names
+- Rich, Kubernets-aware `conduit stat`:
+  - Works on deployments & namespaces.
+  - `--from` & `--to` flags filter stats by source & destination.
+- Proxy exposes Prometheus labeled with rich outbound stats.
+- Grafana dashboards for Kubernetes Deployments & Namespaces.
 
 ### Reliability
 
-- Least-loaded L7 load balancing
-- Improved error handling
-- Improved egress support
+- The proxy properly routes egress traffic to arbitrary DNS names.
 
-### Development
 
-- Published (this) roadmap
-- All milestones, issues, PRs, & mailing lists made public
+## [0.4.1: Rich, Kubernetes-aware debugging](https://github.com/runconduit/conduit/milestones)
+#### Late April 2018
+##### Status: beta
 
-## [0.4: Automatic TLS; Prometheus++](https://github.com/runconduit/conduit/milestone/6)
+### Visibility
 
-#### Late March 2018
+- `conduit stat` works on many Kubernetes resources.
+  - Per-authority HTTP stats.
+  - TCP-level stats
+- `conduit tap` works on many Kubernetes resources, too.
+- `conduit wtf`: what's the failure?
 
-### Usability
 
-- Helm integration
-- Mutating webhook admission controller
+## [0.5: Private, Stable communication](https://github.com/runconduit/conduit/milestone/7)
+#### Mid-May 2018
 
 ### Security
 
@@ -53,57 +47,45 @@ overly conservative.
 - Automatically provide all meshed services with cryptographic identity
 - Automatically secure all meshed communication
 
-### Visibility
-
-- Enhanced server-side metrics, including per-path and per-status-code counts & latencies.
-- Client-side metrics to surface egress traffic, etc.
-
 ### Reliability
 
-- Latency-aware load balancing
+- Stable Service Discovery semantics.
+- Latency-aware load balancing.
 
-## [0.5: Controllable Deadlines/Timeouts](https://github.com/runconduit/conduit/milestone/7)
 
-#### Early April 2018
-
-### Reliability
-
-- Controllable latency objectives to configure timeouts
-- Controllable response classes to inform circuit breaking, retryability, & success rate calculation
-- High-availability controller
-
-### Visibility
-
-- OpenTracing integration
-
-### Security
-
-- Mutual authentication
-- Key rotation
-
-## [0.6: Controllable Response Classification & Retries](https://github.com/runconduit/conduit/milestone/8)
-
-#### Late April 2018
-
-### Reliability
-
-- Automatic alerting for latency & success objectives
-- Controllable retry policies
+## [0.6: Externaly accessible](https://github.com/runconduit/conduit/milestone/8)
+#### Early June 2018
 
 ### Routing
 
-- Rich ingress routing
-- Contextual route overrides
+- Kubernetes `Ingress` support
 
 ### Security
 
-- Authorization policy
+- Explicitly configured TLS for ingress
+- Server Name Indication (SNI)
 
-## And Beyond:
+### Reliability
 
-- Controller policy plugins
-- Support for non-Kubernetes services
-- Failure injection (aka "chaos chihuahua")
+- Scales to many cores.
+- High-availability controller
+- Circuit-breaking.
+
+### Usability
+
+- Helm integration
+
+
+## And then...
+
+- Mutual authentication
+- Key rotation
+- Let's Encrypt Ingress support
+- Automatic alerting for latency & success objectives
+- Controllable retry policies
+- OpenTracing integration
+- Pluggable authorization policy
+- Failure injection
 - Speculative retries
 - Dark traffic
 - gRPC payload-aware `tap`

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -31,7 +31,7 @@ overly conservative.
 - The proxy properly routes egress traffic to arbitrary DNS names.
 
 
-## [0.4.1: Rich, Kubernetes-aware debugging](https://github.com/runconduit/conduit/milestones)
+## [0.4.1: Rich, Kubernetes-aware debugging](https://github.com/runconduit/conduit/milestone/10)
 #### Late April 2018
 
 ### Visibility
@@ -43,7 +43,7 @@ overly conservative.
 - `conduit wtf`: what's the failure?
 
 
-## [0.5: Private, Stable communication](https://github.com/runconduit/conduit/milestone/7)
+## [0.5: Stable, private communication](https://github.com/runconduit/conduit/milestone/7)
 #### Mid-May 2018
 
 ### Security

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -1,3 +1,10 @@
++++
+title = "Conduit roadmap"
+docpage = true
+[menu.docs]
+  parent = "roadmap"
++++
+
 This is the planned roadmap for Conduit. Of course, as with any software project
 (especially open source) even the best of plans change rapidly as development progresses.
 
@@ -7,13 +14,13 @@ designations based on actual community usage, and generally will err on the side
 overly conservative.
 
 
-##### Status: beta
+##### Status: alpha
 ## [0.4.0: Rich, Kubernetes-aware Grafana & Prometheus](https://github.com/runconduit/conduit/milestone/6)
 #### 2018-04-16
 
 ### Visibility
 
-- Rich, Kubernets-aware `conduit stat`:
+- Rich, Kubernetes-aware `conduit stat`:
   - Works on deployments & namespaces.
   - `--from` & `--to` flags filter stats by source & destination.
 - Proxy exposes Prometheus labeled with rich outbound stats.
@@ -26,7 +33,6 @@ overly conservative.
 
 ## [0.4.1: Rich, Kubernetes-aware debugging](https://github.com/runconduit/conduit/milestones)
 #### Late April 2018
-##### Status: beta
 
 ### Visibility
 
@@ -53,7 +59,7 @@ overly conservative.
 - Latency-aware load balancing.
 
 
-## [0.6: Externaly accessible](https://github.com/runconduit/conduit/milestone/8)
+## [0.6: Externally accessible](https://github.com/runconduit/conduit/milestone/8)
 #### Early June 2018
 
 ### Routing


### PR DESCRIPTION

Conduit 0.4.0 overhauls Conduit's telemetry system and improves service discovery
reliability.

* Web UI
  * **New** automatically-configured Grafana dashboards for all Deployments.
* Command-line interface
  * `conduit stat` has been completely rewritten to accept arguments like `kubectl get`.
    The `--to` and `--from` filters can be used to filter traffic by destination and
    source, respectively.  `conduit stat` currently can operate on `Namespace` and
    `Deployment` Kubernetes resources. More resource types will be added in the next
    release!
* Proxy (data plane)
  * **New** Prometheus-formatted metrics are now exposed on `:4191/metrics`, including
    rich destination labeling for outbound HTTP requests. The proxy no longer pushes
    metrics to the control plane.
  * The proxy now handles `SIGINT` or `SIGTERM`, gracefully draining requests until all
    are complete or `SIGQUIT` is received.
  * SMTP and MySQL (ports 25 and 3306) are now treated as opaque TCP by default. You
    should no longer have to specify `--skip-outbound-ports` to communicate with such
    services.
  * When the proxy reconnected to the controller, it could continue to send requests to
    old endpoints. Now, when the proxy reconnects to the controller, it properly removes
    invalid endpoints.
  * A bug impacting some HTTP/2 reset scenarios has been fixed.
* Service Discovery
  * Previously, the proxy failed to resolve some domain names that could be misinterpreted
    as a Kubernetes Service name. This has been fixed by extending the _Destination_ API
    with a negative acknowledgement response.
* Control Plane
  * The _Telemetry_ service and associated APIs have been removed.
* Documentation
  * Updated Roadmap
  * Added prometheus metrics guide
