### PR TITLE
Destination service returns "Running" pod labels

### DIFF
--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -30,21 +30,23 @@ func (m *MockEndpointsWatcher) Run() error {
 func (m *MockEndpointsWatcher) Stop() {}
 
 type InMemoryPodIndex struct {
-	BackingMap map[string]*v1.Pod
+	BackingMap map[string][]*v1.Pod
 }
 
 func (i *InMemoryPodIndex) GetPod(key string) (*v1.Pod, error) {
-	return i.BackingMap[key], nil
+	return i.BackingMap[key][0], nil
 }
 
 func (i *InMemoryPodIndex) GetPodsByIndex(key string) ([]*v1.Pod, error) {
-	return []*v1.Pod{i.BackingMap[key]}, nil
+	return i.BackingMap[key], nil
 }
 
 func (i *InMemoryPodIndex) List() ([]*v1.Pod, error) {
 	var pods []*v1.Pod
-	for _, value := range i.BackingMap {
-		pods = append(pods, value)
+	for _, byIndex := range i.BackingMap {
+		for _, pod := range byIndex {
+			pods = append(pods, pod)
+		}
 	}
 
 	return pods, nil
@@ -53,5 +55,5 @@ func (i *InMemoryPodIndex) Run() error { return nil }
 func (i *InMemoryPodIndex) Stop()      {}
 
 func NewEmptyPodIndex() PodIndex {
-	return &InMemoryPodIndex{BackingMap: map[string]*v1.Pod{}}
+	return &InMemoryPodIndex{BackingMap: map[string][]*v1.Pod{}}
 }


### PR DESCRIPTION
When the Destination sees an IP address, it looks up Pods by that IP,
and associates Pod label data to it. If the lookup by IP returned more
than one Pod, it simply picked the first one. This is not correct,
specifically in cases where one pod is in a Running state, and others
are not.

Modify the Destination service to only return label data for Pods in the
Running state.

Fixes #773

Signed-off-by: Andrew Seigner <siggy@buoyant.io>