### PR TITLE
Destination service provides pod-template-hash

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -746,6 +746,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "85096b26ceba678986d333d0cbe7491966a073a4419b20975beb8b2c88d85bf7"
+  inputs-digest = "f5ff9662192d238efdb260226a886088d05da0924292833660466258fd80c8c0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:799047c7 as golang
+FROM gcr.io/runconduit/go-deps:d17b1119 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:799047c7 as golang
+FROM gcr.io/runconduit/go-deps:d17b1119 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -67,6 +67,10 @@ The following labels are only applicable if `direction=outbound`.
                                 is being sent.
 * `dst_namespace`: The namespace to which this request is being sent.
 * `dst_service`: The service to which this request is being sent.
+* `dst_pod_template_hash`: The [pod-template-hash][pod-template-hash] of the pod
+                           to which this request is being sent. This label
+                           selector roughly approximates a pod's `ReplicaSet` or
+                           `ReplicationController`.
 
 ### Prometheus Collector labels
 
@@ -85,7 +89,9 @@ Prometheus labels.
 * `pod`: Kubernetes pod name.
 * `pod_template_hash`: Corresponds to the [pod-template-hash][pod-template-hash]
                        Kubernetes label. This value changes during redeploys and
-                       rolling restarts.
+                       rolling restarts. This label selector roughly
+                       approximates a pod's `ReplicaSet` or
+                       `ReplicationController`.
 
 #### Conduit labels added at collection time
 

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/runconduit/conduit/pkg/version"
+	k8sV1 "k8s.io/api/apps/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,6 +66,7 @@ var proxyLabels = []string{
 	ProxyReplicaSetLabel,
 	ProxyJobLabel,
 	ProxyDaemonSetLabel,
+	k8sV1.DefaultDeploymentUniqueLabelKey,
 }
 
 // CreatedByAnnotationValue returns the value associated with

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	k8sV1 "k8s.io/api/apps/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -11,11 +12,12 @@ func TestGetOwnerLabels(t *testing.T) {
 	t.Run("Maps proxy labels to prometheus labels", func(t *testing.T) {
 		metadata := meta.ObjectMeta{
 			Labels: map[string]string{
-				ProxyDeploymentLabel:            "test-deployment",
-				ProxyReplicationControllerLabel: "test-replication-controller",
-				ProxyReplicaSetLabel:            "test-replica-set",
-				ProxyJobLabel:                   "test-job",
-				ProxyDaemonSetLabel:             "test-daemon-set",
+				ProxyDeploymentLabel:                  "test-deployment",
+				ProxyReplicationControllerLabel:       "test-replication-controller",
+				ProxyReplicaSetLabel:                  "test-replica-set",
+				ProxyJobLabel:                         "test-job",
+				ProxyDaemonSetLabel:                   "test-daemon-set",
+				k8sV1.DefaultDeploymentUniqueLabelKey: "test-pth",
 			},
 		}
 
@@ -25,6 +27,7 @@ func TestGetOwnerLabels(t *testing.T) {
 			"replica_set":            "test-replica-set",
 			"k8s_job":                "test-job",
 			"daemon_set":             "test-daemon-set",
+			"pod_template_hash":      "test-pth",
 		}
 
 		ownerLabels := GetOwnerLabels(metadata)

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:799047c7 as golang
+FROM gcr.io/runconduit/go-deps:d17b1119 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:799047c7 as golang
+FROM gcr.io/runconduit/go-deps:d17b1119 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
The Destination service does not provide ReplicaSet information to the
proxy.

The `pod-template-hash` label approximates selecting over all pods in a
ReplicaSet or ReplicationController. Modify the Destination service to
provide this label to the proxy.

Relates to #508 and #741

Signed-off-by: Andrew Seigner <siggy@buoyant.io>