### PR TITLE
proxy: Add tcp_connection_duration_ms histogram metric

### DIFF
--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -838,6 +838,36 @@ mod transport {
     }
 
     #[test]
+    fn inbound_tcp_duration() {
+        let _ = env_logger::try_init();
+        let TcpFixture { client, metrics, proxy: _proxy } =
+            TcpFixture::inbound();
+
+        let msg1 = "custom tcp hello";
+        let msg2 = "custom tcp bye";
+
+        let tcp_client = client.connect();
+
+        tcp_client.write(msg1);
+        assert_eq!(tcp_client.read(), msg2.as_bytes());
+        drop(tcp_client);
+        // TODO: make assertions about buckets
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_connection_duration_ms_count{direction=\"inbound\",protocol=\"tcp\"} 4");
+
+        let tcp_client = client.connect();
+
+        tcp_client.write(msg1);
+        assert_eq!(tcp_client.read(), msg2.as_bytes());
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_connection_duration_ms_count{direction=\"inbound\",protocol=\"tcp\"} 2");
+
+        drop(tcp_client);
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_connection_duration_ms_count{direction=\"inbound\",protocol=\"tcp\"} 4");
+    }
+
+    #[test]
     fn outbound_tcp_connect() {
         let _ = env_logger::try_init();
         let TcpFixture { client, metrics, proxy: _proxy } =
@@ -885,5 +915,35 @@ mod transport {
         drop(tcp_client);
         assert_contains!(metrics.get("/metrics"),
             "tcp_accept_close_total{direction=\"outbound\",protocol=\"tcp\"} 2");
+    }
+
+    #[test]
+    fn outbound_tcp_duration() {
+        let _ = env_logger::try_init();
+        let TcpFixture { client, metrics, proxy: _proxy } =
+            TcpFixture::outbound();
+
+        let msg1 = "custom tcp hello";
+        let msg2 = "custom tcp bye";
+
+        let tcp_client = client.connect();
+
+        tcp_client.write(msg1);
+        assert_eq!(tcp_client.read(), msg2.as_bytes());
+        drop(tcp_client);
+        // TODO: make assertions about buckets
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_connection_duration_ms_count{direction=\"outbound\",protocol=\"tcp\"} 2");
+
+        let tcp_client = client.connect();
+
+        tcp_client.write(msg1);
+        assert_eq!(tcp_client.read(), msg2.as_bytes());
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_connection_duration_ms_count{direction=\"outbound\",protocol=\"tcp\"} 2");
+
+        drop(tcp_client);
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_connection_duration_ms_count{direction=\"outbound\",protocol=\"tcp\"} 4");
     }
 }


### PR DESCRIPTION
This PR adds the `tcp_connection_duration_ms` metric as described in #742, as well as tests for that metric.

This should merge after #785.