### PR TITLE
Add replication controller stats in CLI

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -34,22 +34,28 @@ Valid resource types include:
 	* deployments
 	* namespaces
 	* pods
+	* replicationcontrollers
 
 This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases.
 If no resource name is specified, displays stats about all resources of the specified RESOURCETYPE`,
 	Example: `  # Get all deployments in the test namespace.
   conduit stat deployments -n test
 
-  # Get the hello1 deployment in the test namespace.
-  conduit stat deployments hello1 -n test
+  # Get the hello1 replication controller in the test namespace.
+  conduit stat replicationcontrollers hello1 -n test
 
   # Get all namespaces.
   conduit stat namespaces
 
   # Get all pods in all namespaces that call the hello1 deployment in the test namesapce.
   conduit stat pods --to hello1 --to-resource deployment --to-namespace test --all-namespaces`,
-	Args:      cobra.RangeArgs(1, 2),
-	ValidArgs: []string{k8s.KubernetesDeployments, k8s.KubernetesNamespaces, k8s.KubernetesPods},
+	Args: cobra.RangeArgs(1, 2),
+	ValidArgs: []string{
+		k8s.KubernetesDeployments,
+		k8s.KubernetesNamespaces,
+		k8s.KubernetesPods,
+		k8s.KubernetesReplicationControllers,
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch len(args) {
 		case 1:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -23,7 +23,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces"]
+  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 
 ---

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -23,7 +23,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces"]
+  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 
 ---

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -26,7 +26,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces"]
+  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 
 ---

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -22,19 +22,20 @@ import (
 
 type (
 	grpcServer struct {
-		prometheusAPI       promv1.API
-		tapClient           tapPb.TapClient
-		namespaceLister     corelisters.NamespaceLister
-		deployLister        applisters.DeploymentLister
-		replicaSetLister    applisters.ReplicaSetLister
-		podLister           corelisters.PodLister
-		controllerNamespace string
-		ignoredNamespaces   []string
+		prometheusAPI               promv1.API
+		tapClient                   tapPb.TapClient
+		namespaceLister             corelisters.NamespaceLister
+		deployLister                applisters.DeploymentLister
+		replicaSetLister            applisters.ReplicaSetLister
+		podLister                   corelisters.PodLister
+		replicationControllerLister corelisters.ReplicationControllerLister
+		controllerNamespace         string
+		ignoredNamespaces           []string
 	}
 )
 
 const (
-	podQuery                   = "sum(request_total) by (pod)"
+	podQuery                   = "count(process_start_time_seconds) by (pod)"
 	K8sClientSubsystemName     = "kubernetes"
 	K8sClientCheckDescription  = "control plane can talk to Kubernetes"
 	PromClientSubsystemName    = "prometheus"
@@ -48,18 +49,20 @@ func newGrpcServer(
 	deployLister applisters.DeploymentLister,
 	replicaSetLister applisters.ReplicaSetLister,
 	podLister corelisters.PodLister,
+	replicationControllerLister corelisters.ReplicationControllerLister,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *grpcServer {
 	return &grpcServer{
-		prometheusAPI:       promAPI,
-		tapClient:           tapClient,
-		namespaceLister:     namespaceLister,
-		deployLister:        deployLister,
-		replicaSetLister:    replicaSetLister,
-		podLister:           podLister,
-		controllerNamespace: controllerNamespace,
-		ignoredNamespaces:   ignoredNamespaces,
+		prometheusAPI:               promAPI,
+		tapClient:                   tapClient,
+		namespaceLister:             namespaceLister,
+		deployLister:                deployLister,
+		replicaSetLister:            replicaSetLister,
+		podLister:                   podLister,
+		replicationControllerLister: replicationControllerLister,
+		controllerNamespace:         controllerNamespace,
+		ignoredNamespaces:           ignoredNamespaces,
 	}
 }
 

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -170,6 +170,7 @@ spec:
 			deployInformer := sharedInformers.Apps().V1beta2().Deployments()
 			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 			podInformer := sharedInformers.Core().V1().Pods()
+			replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
 
 			fakeGrpcServer := newGrpcServer(
 				&MockProm{Res: exp.promRes},
@@ -178,6 +179,7 @@ spec:
 				deployInformer.Lister(),
 				replicaSetInformer.Lister(),
 				podInformer.Lister(),
+				replicationControllerInformer.Lister(),
 				"conduit",
 				[]string{},
 			)
@@ -189,6 +191,7 @@ spec:
 				deployInformer.Informer().HasSynced,
 				replicaSetInformer.Informer().HasSynced,
 				podInformer.Informer().HasSynced,
+				replicationControllerInformer.Informer().HasSynced,
 			) {
 				t.Fatalf("timed out wait for caches to sync")
 			}

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -200,6 +200,7 @@ func NewServer(
 	deployLister applisters.DeploymentLister,
 	replicaSetLister applisters.ReplicaSetLister,
 	podLister corelisters.PodLister,
+	replicationControllerLister corelisters.ReplicationControllerLister,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *http.Server {
@@ -211,6 +212,7 @@ func NewServer(
 			deployLister,
 			replicaSetLister,
 			podLister,
+			replicationControllerLister,
 			controllerNamespace,
 			ignoredNamespaces,
 		),

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -107,9 +107,7 @@ metadata:
 														LatencyMsP95: 123,
 														LatencyMsP99: 123,
 													},
-													TimeWindow:     "1m",
-													MeshedPodCount: 1,
-													TotalPodCount:  2,
+													TimeWindow: "1m",
 												},
 											},
 										},
@@ -140,6 +138,7 @@ metadata:
 			deployInformer := sharedInformers.Apps().V1beta2().Deployments()
 			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 			podInformer := sharedInformers.Core().V1().Pods()
+			replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
 
 			fakeGrpcServer := newGrpcServer(
 				&MockProm{Res: exp.promRes},
@@ -148,6 +147,7 @@ metadata:
 				deployInformer.Lister(),
 				replicaSetInformer.Lister(),
 				podInformer.Lister(),
+				replicationControllerInformer.Lister(),
 				"conduit",
 				[]string{},
 			)
@@ -159,6 +159,7 @@ metadata:
 				deployInformer.Informer().HasSynced,
 				replicaSetInformer.Informer().HasSynced,
 				podInformer.Informer().HasSynced,
+				replicationControllerInformer.Informer().HasSynced,
 			) {
 				t.Fatalf("timed out wait for caches to sync")
 			}
@@ -218,6 +219,7 @@ metadata:
 				sharedInformers.Apps().V1beta2().Deployments().Lister(),
 				sharedInformers.Apps().V1beta2().ReplicaSets().Lister(),
 				sharedInformers.Core().V1().Pods().Lister(),
+				sharedInformers.Core().V1().ReplicationControllers().Lister(),
 				"conduit",
 				[]string{},
 			)

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -56,6 +56,8 @@ metadata:
     app: emoji-svc
   annotations:
     conduit.io/proxy-version: testinjectversion
+status:
+  phase: Running
 `, `
 apiVersion: v1
 kind: Pod
@@ -64,6 +66,20 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
+status:
+  phase: Running
+`, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emojivoto-meshed-not-running
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+  annotations:
+    conduit.io/proxy-version: testinjectversion
+status:
+  phase: Completed
 `,
 				},
 				promRes: model.Vector{
@@ -107,7 +123,9 @@ metadata:
 														LatencyMsP95: 123,
 														LatencyMsP99: 123,
 													},
-													TimeWindow: "1m",
+													TimeWindow:     "1m",
+													MeshedPodCount: 1,
+													TotalPodCount:  2,
 												},
 											},
 										},

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -69,6 +69,9 @@ func main() {
 	podInformer := sharedInformers.Core().V1().Pods()
 	podInformerSynced := podInformer.Informer().HasSynced
 
+	replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
+	replicationControllerInformerSynced := replicationControllerInformer.Informer().HasSynced
+
 	sharedInformers.Start(nil)
 
 	prometheusClient, err := promApi.NewClient(promApi.Config{Address: *prometheusUrl})
@@ -84,6 +87,7 @@ func main() {
 		deployInformer.Lister(),
 		replicaSetInformer.Lister(),
 		podInformer.Lister(),
+		replicationControllerInformer.Lister(),
 		*controllerNamespace,
 		strings.Split(*ignoredNamespaces, ","),
 	)
@@ -99,6 +103,7 @@ func main() {
 			deployInformerSynced,
 			replicaSetInformerSynced,
 			podInformerSynced,
+			replicationControllerInformerSynced,
 		) {
 			log.Fatalf("timed out wait for caches to sync")
 		}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	KubernetesDeployments = "deployments"
-	KubernetesNamespaces  = "namespaces"
-	KubernetesPods        = "pods"
+	KubernetesDeployments            = "deployments"
+	KubernetesNamespaces             = "namespaces"
+	KubernetesPods                   = "pods"
+	KubernetesReplicationControllers = "replicationcontrollers"
 )
 
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
@@ -63,6 +64,8 @@ func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error
 		return KubernetesNamespaces, nil
 	case "po", "pod", "pods":
 		return KubernetesPods, nil
+	case "rc", "replicationcontroller", "replicationcontrollers":
+		return KubernetesReplicationControllers, nil
 	}
 
 	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)


### PR DESCRIPTION
This branch adds replication controller stats to the CLI stat command. For example:

```
$ conduit stat rc
NAME      MESHED   SUCCESS       RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
authors      3/3    89.29%   10.1rps           8ms          30ms          40ms
books        3/3    86.45%   13.5rps           9ms          29ms          88ms
web          3/3    81.52%   12.3rps          24ms          72ms          94ms
```

As part of this change I'm also fixing two other small issues that I found with the stat API:

* We now only report pending and running pods in mesh counts
* We now consider a pod to be meshed if it reports an uptime stat, rather than waiting for the pod to receive at least one request