### PR TITLE
proxy: Make control::discovery::Bind generic over its Endpoint type

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -231,6 +231,7 @@ impl<B> control::discovery::Bind for BindProtocol<Arc<ctx::Proxy>, B>
 where
     B: tower_h2::Body + 'static,
 {
+    type Endpoint = SocketAddr;
     type Request = http::Request<B>;
     type Response = HttpResponse;
     type Error = <Service<B> as tower::Service>::Error;

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -136,6 +136,9 @@ enum Update {
 
 /// Bind a `SocketAddr` with a protocol.
 pub trait Bind {
+    /// The type of endpoint upon which a `Service` is bound.
+    type Endpoint;
+
     /// Requests handled by the discovered services
     type Request;
 
@@ -150,8 +153,8 @@ pub trait Bind {
     /// The discovered `Service` instance.
     type Service: Service<Request = Self::Request, Response = Self::Response, Error = Self::Error>;
 
-    /// Bind a socket address with a service.
-    fn bind(&self, addr: &SocketAddr) -> Result<Self::Service, Self::BindError>;
+    /// Bind a service from an endpoint.
+    fn bind(&self, addr: &Self::Endpoint) -> Result<Self::Service, Self::BindError>;
 }
 
 /// Creates a "channel" of `Discovery` to `Background` handles.
@@ -221,7 +224,7 @@ impl<B> Watch<B> {
 
 impl<B, A> Discover for Watch<B>
 where
-    B: Bind<Request = http::Request<A>>,
+    B: Bind<Endpoint = SocketAddr, Request = http::Request<A>>,
 {
     type Key = SocketAddr;
     type Request = B::Request;
@@ -673,6 +676,7 @@ where
     F: Fn(&SocketAddr) -> Result<S, E>,
     S: Service,
 {
+    type Endpoint = SocketAddr;
     type Request = S::Request;
     type Response = S::Response;
     type Error = S::Error;

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -669,25 +669,6 @@ impl <T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
     }
 }
 
-// ===== impl Bind =====
-
-impl<F, S, E> Bind for F
-where
-    F: Fn(&SocketAddr) -> Result<S, E>,
-    S: Service,
-{
-    type Endpoint = SocketAddr;
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Service = S;
-    type BindError = E;
-
-    fn bind(&self, addr: &SocketAddr) -> Result<Self::Service, Self::BindError> {
-        (*self)(addr)
-    }
-}
-
 // ===== impl UpdateRx =====
 
 impl<T> Stream for UpdateRx<T>


### PR DESCRIPTION
Previously, `Bind` required that it bind to `SocketAddr` (and `SocketAddr`
only). This makes it hard to pass additional information from service discovery
into the client's stack.

To resolve this, `Bind` now has an additional `Endpoint` trait-generic type,
and `Bind::bind` accepts an `Endpoint` rather than a `SocketAddr`.

No additional endpoints have been introduced yet. There are no functional
changes in this refactor.