### PR TITLE
Introduce tapByResource cli command

### DIFF
--- a/cli/cmd/tap_by_resource.go
+++ b/cli/cmd/tap_by_resource.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/runconduit/conduit/controller/api/util"
+	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/pkg/k8s"
+	"github.com/spf13/cobra"
+)
+
+var (
+	toResource string
+	validArgs  = []string{
+		k8s.KubernetesDeployments,
+		k8s.KubernetesNamespaces,
+		k8s.KubernetesPods,
+		k8s.KubernetesReplicationControllers,
+	}
+)
+
+var tapByResourceCmd = &cobra.Command{
+	Use:   "tapByResource [flags] (RESOURCE)",
+	Short: "Listen to a traffic stream",
+	Long: `Listen to a traffic stream.
+
+  The RESOURCE argument specifies the resource to tap, for example:
+
+  * deploy
+  * deploy/my-deploy
+  * deploy my-deploy
+  * ns/my-ns
+
+  Valid resource types include:
+
+  * deployments
+  * namespaces
+  * pods
+  * replicationcontrollers`,
+	Example: `  # tap the web deployment in the default namespace
+  conduit tapByResource deploy/web
+
+  # tap the web-dlbvj pod in the default namespace
+  conduit tapByResource pod/web-dlbvj
+
+  # tap the test namespace, filter by request to prod namespace
+  conduit tapByResource ns/test --to ns/prod`,
+	Args:      cobra.RangeArgs(1, 2),
+	ValidArgs: validArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		req, err := buildTapByResourceRequest(
+			args, namespace,
+			toResource, toNamespace,
+			maxRps,
+			scheme, method, authority, path,
+		)
+		if err != nil {
+			return err
+		}
+
+		client, err := newPublicAPIClient()
+		if err != nil {
+			return err
+		}
+
+		return requestTapByResourceFromAPI(os.Stdout, client, req)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(tapByResourceCmd)
+	tapByResourceCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default",
+		"Namespace of the specified resource")
+	tapByResourceCmd.PersistentFlags().StringVar(&toResource, "to", "",
+		"Display requests to this resource")
+	tapByResourceCmd.PersistentFlags().StringVar(&toNamespace, "to-namespace", "",
+		"Sets the namespace used to lookup the \"--to\" resource; by default the current \"--namespace\" is used")
+	tapByResourceCmd.PersistentFlags().Float32Var(&maxRps, "max-rps", 1.0,
+		"Maximum requests per second to tap.")
+	tapByResourceCmd.PersistentFlags().StringVar(&scheme, "scheme", "",
+		"Display requests with this scheme")
+	tapByResourceCmd.PersistentFlags().StringVar(&method, "method", "",
+		"Display requests with this HTTP method")
+	tapByResourceCmd.PersistentFlags().StringVar(&authority, "authority", "",
+		"Display requests with this :authority")
+	tapByResourceCmd.PersistentFlags().StringVar(&path, "path", "",
+		"Display requests with paths that start with this prefix")
+}
+
+func buildTapByResourceRequest(
+	resource []string, namespace string,
+	toResource, toNamespace string,
+	maxRps float32,
+	scheme, method, authority, path string,
+) (*pb.TapByResourceRequest, error) {
+
+	target, err := util.BuildResource(namespace, resource...)
+	if err != nil {
+		return nil, fmt.Errorf("target resource invalid: %s", err)
+	}
+	if !contains(validArgs, target.Type) {
+		return nil, fmt.Errorf("unsupported resource type [%s]", target.Type)
+	}
+
+	matches := []*pb.TapByResourceRequest_Match{}
+
+	if toResource != "" {
+		destination, err := util.BuildResource(toNamespace, toResource)
+		if err != nil {
+			return nil, fmt.Errorf("destination resource invalid: %s", err)
+		}
+
+		match := pb.TapByResourceRequest_Match{
+			Match: &pb.TapByResourceRequest_Match_Destinations{
+				Destinations: &pb.ResourceSelection{
+					Resource: &destination,
+				},
+			},
+		}
+		matches = append(matches, &match)
+	}
+
+	if scheme != "" {
+		match := buildMatchHTTP(&pb.TapByResourceRequest_Match_Http{
+			Match: &pb.TapByResourceRequest_Match_Http_Scheme{Scheme: scheme},
+		})
+		matches = append(matches, &match)
+	}
+	if method != "" {
+		match := buildMatchHTTP(&pb.TapByResourceRequest_Match_Http{
+			Match: &pb.TapByResourceRequest_Match_Http_Method{Method: method},
+		})
+		matches = append(matches, &match)
+	}
+	if authority != "" {
+		match := buildMatchHTTP(&pb.TapByResourceRequest_Match_Http{
+			Match: &pb.TapByResourceRequest_Match_Http_Authority{Authority: authority},
+		})
+		matches = append(matches, &match)
+	}
+	if path != "" {
+		match := buildMatchHTTP(&pb.TapByResourceRequest_Match_Http{
+			Match: &pb.TapByResourceRequest_Match_Http_Path{Path: path},
+		})
+		matches = append(matches, &match)
+	}
+
+	return &pb.TapByResourceRequest{
+		Target: &pb.ResourceSelection{
+			Resource: &target,
+		},
+		MaxRps: maxRps,
+		Match: &pb.TapByResourceRequest_Match{
+			Match: &pb.TapByResourceRequest_Match_All{
+				All: &pb.TapByResourceRequest_Match_Seq{
+					Matches: matches,
+				},
+			},
+		},
+	}, nil
+}
+
+func contains(list []string, s string) bool {
+	for _, elem := range list {
+		if s == elem {
+			return true
+		}
+	}
+	return false
+}
+
+func buildMatchHTTP(match *pb.TapByResourceRequest_Match_Http) pb.TapByResourceRequest_Match {
+	return pb.TapByResourceRequest_Match{
+		Match: &pb.TapByResourceRequest_Match_Http_{
+			Http: match,
+		},
+	}
+}
+
+func requestTapByResourceFromAPI(w io.Writer, client pb.ApiClient, req *pb.TapByResourceRequest) error {
+	rsp, err := client.TapByResource(context.Background(), req)
+	if err != nil {
+		return err
+	}
+
+	return renderTap(w, rsp)
+}

--- a/cli/cmd/tap_by_resource_test.go
+++ b/cli/cmd/tap_by_resource_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	google_protobuf "github.com/golang/protobuf/ptypes/duration"
+	"github.com/runconduit/conduit/controller/api/public"
+	common "github.com/runconduit/conduit/controller/gen/common"
+	"github.com/runconduit/conduit/pkg/k8s"
+)
+
+func TestRequestTapByResourceFromAPI(t *testing.T) {
+	t.Run("Should render busy response if everything went well", func(t *testing.T) {
+		resourceType := k8s.KubernetesPods
+		targetName := "pod-666"
+		scheme := "https"
+		method := "GET"
+		authority := "localhost"
+		path := "/some/path"
+
+		req, err := buildTapByResourceRequest(
+			[]string{resourceType, targetName},
+			"", "", "", 0,
+			scheme, method, authority, path,
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		event1 := createEvent(&common.TapEvent_Http{
+			Event: &common.TapEvent_Http_RequestInit_{
+				RequestInit: &common.TapEvent_Http_RequestInit{
+					Id: &common.TapEvent_Http_StreamId{
+						Base: 1,
+					},
+					Authority: authority,
+					Path:      path,
+				},
+			},
+		})
+		event2 := createEvent(&common.TapEvent_Http{
+			Event: &common.TapEvent_Http_ResponseEnd_{
+				ResponseEnd: &common.TapEvent_Http_ResponseEnd{
+					Id: &common.TapEvent_Http_StreamId{
+						Base: 1,
+					},
+					Eos: &common.Eos{
+						End: &common.Eos_GrpcStatusCode{GrpcStatusCode: 666},
+					},
+					SinceRequestInit: &google_protobuf.Duration{
+						Seconds: 10,
+					},
+					SinceResponseInit: &google_protobuf.Duration{
+						Seconds: 100,
+					},
+					ResponseBytes: 1337,
+				},
+			},
+		})
+		mockApiClient := &public.MockConduitApiClient{}
+		mockApiClient.Api_TapByResourceClientToReturn = &public.MockApi_TapByResourceClient{
+			TapEventsToReturn: []common.TapEvent{event1, event2},
+		}
+
+		writer := bytes.NewBufferString("")
+		err = requestTapByResourceFromAPI(writer, mockApiClient, req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		goldenFileBytes, err := ioutil.ReadFile("testdata/tap_busy_output.golden")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		expectedContent := string(goldenFileBytes)
+		output := writer.String()
+		if expectedContent != output {
+			t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
+		}
+	})
+
+	t.Run("Should render empty response if no events returned", func(t *testing.T) {
+		resourceType := k8s.KubernetesPods
+		targetName := "pod-666"
+		scheme := "https"
+		method := "GET"
+		authority := "localhost"
+		path := "/some/path"
+
+		req, err := buildTapByResourceRequest(
+			[]string{resourceType, targetName},
+			"", "", "", 0,
+			scheme, method, authority, path,
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		mockApiClient := &public.MockConduitApiClient{}
+		mockApiClient.Api_TapByResourceClientToReturn = &public.MockApi_TapByResourceClient{
+			TapEventsToReturn: []common.TapEvent{},
+		}
+
+		writer := bytes.NewBufferString("")
+		err = requestTapByResourceFromAPI(writer, mockApiClient, req)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		goldenFileBytes, err := ioutil.ReadFile("testdata/tap_empty_output.golden")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		expectedContent := string(goldenFileBytes)
+		output := writer.String()
+		if expectedContent != output {
+			t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
+		}
+	})
+
+	t.Run("Should return error if stream returned error", func(t *testing.T) {
+		t.SkipNow()
+		resourceType := k8s.KubernetesPods
+		targetName := "pod-666"
+		scheme := "https"
+		method := "GET"
+		authority := "localhost"
+		path := "/some/path"
+
+		req, err := buildTapByResourceRequest(
+			[]string{resourceType, targetName},
+			"", "", "", 0,
+			scheme, method, authority, path,
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		mockApiClient := &public.MockConduitApiClient{}
+		mockApiClient.Api_TapByResourceClientToReturn = &public.MockApi_TapByResourceClient{
+			ErrorsToReturn: []error{errors.New("expected")},
+		}
+
+		writer := bytes.NewBufferString("")
+		err = requestTapByResourceFromAPI(writer, mockApiClient, req)
+		if err == nil {
+			t.Fatalf("Expecting error, got nothing but output [%s]", writer.String())
+		}
+	})
+}
+
+// TODO: re-introduce TestEventToString and friends from tap_test.go

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -13,6 +13,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+//
+// Conduit Public API client
+//
+
 type MockConduitApiClient struct {
 	ErrorToReturn                   error
 	VersionInfoToReturn             *pb.VersionInfo
@@ -68,6 +72,32 @@ func (a *MockApi_TapClient) Recv() (*common.TapEvent, error) {
 
 	return &eventPopped, errorPopped
 }
+
+type MockApi_TapByResourceClient struct {
+	TapEventsToReturn []common.TapEvent
+	ErrorsToReturn    []error
+	grpc.ClientStream
+}
+
+func (a *MockApi_TapByResourceClient) Recv() (*common.TapEvent, error) {
+	var eventPopped common.TapEvent
+	var errorPopped error
+	if len(a.TapEventsToReturn) == 0 && len(a.ErrorsToReturn) == 0 {
+		return nil, io.EOF
+	}
+	if len(a.TapEventsToReturn) != 0 {
+		eventPopped, a.TapEventsToReturn = a.TapEventsToReturn[0], a.TapEventsToReturn[1:]
+	}
+	if len(a.ErrorsToReturn) != 0 {
+		errorPopped, a.ErrorsToReturn = a.ErrorsToReturn[0], a.ErrorsToReturn[1:]
+	}
+
+	return &eventPopped, errorPopped
+}
+
+//
+// Prometheus client
+//
 
 type MockProm struct {
 	Res model.Value


### PR DESCRIPTION
The existing `tap` command is being deprecated.

Introduce a `tapByResource` cli command. It supports tapping a Kubernetes
resource or collection of resources, optionally filtered by outbound resources.
This command will eventually replace `tap`.

Part of #778

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

```bash
$ bin/go-run cli tapByResource -h
Listen to a traffic stream.

  The RESOURCE argument specifies the resource to tap, for example:

  * deploy
  * deploy/my-deploy
  * deploy my-deploy
  * ns/my-ns

  Valid resource types include:

  * deployments
  * namespaces
  * pods
  * replicationcontrollers

Usage:
  conduit tapByResource [flags] (RESOURCE)

Examples:
  # tap the web deployment in the default namespace
  conduit tapByResource deploy/web

  # tap the web-dlbvj pod in the default namespace
  conduit tapByResource pod/web-dlbvj

  # tap the test namespace, filter by request to prod namespace
  conduit tapByResource ns/test --to ns/prod

Flags:
      --authority string      Display requests with this :authority
  -h, --help                  help for tapByResource
      --max-rps float32       Maximum requests per second to tap. (default 1)
      --method string         Display requests with this HTTP method
  -n, --namespace string      Namespace of the specified resource (default "default")
      --path string           Display requests with paths that start with this prefix
      --scheme string         Display requests with this scheme
      --to string             Display requests to this resource
      --to-namespace string   Sets the namespace used to lookup the "--to" resource; by default the current "--namespace" is used

Global Flags:
      --api-addr string            Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)
  -c, --conduit-namespace string   Namespace in which Conduit is installed (default "conduit")
      --kubeconfig string          Path to the kubeconfig file to use for CLI requests
      --verbose                    Turn on debug logging
```