### PR TITLE
Service support in stat command

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -29,6 +29,7 @@ type (
 		replicaSetLister            applisters.ReplicaSetLister
 		podLister                   corelisters.PodLister
 		replicationControllerLister corelisters.ReplicationControllerLister
+		serviceLister               corelisters.ServiceLister
 		controllerNamespace         string
 		ignoredNamespaces           []string
 	}
@@ -50,6 +51,7 @@ func newGrpcServer(
 	replicaSetLister applisters.ReplicaSetLister,
 	podLister corelisters.PodLister,
 	replicationControllerLister corelisters.ReplicationControllerLister,
+	serviceLister corelisters.ServiceLister,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *grpcServer {
@@ -61,6 +63,7 @@ func newGrpcServer(
 		replicaSetLister:            replicaSetLister,
 		podLister:                   podLister,
 		replicationControllerLister: replicationControllerLister,
+		serviceLister:               serviceLister,
 		controllerNamespace:         controllerNamespace,
 		ignoredNamespaces:           ignoredNamespaces,
 	}

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -171,6 +171,7 @@ spec:
 			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 			podInformer := sharedInformers.Core().V1().Pods()
 			replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
+			serviceInformer := sharedInformers.Core().V1().Services()
 
 			fakeGrpcServer := newGrpcServer(
 				&MockProm{Res: exp.promRes},
@@ -180,6 +181,7 @@ spec:
 				replicaSetInformer.Lister(),
 				podInformer.Lister(),
 				replicationControllerInformer.Lister(),
+				serviceInformer.Lister(),
 				"conduit",
 				[]string{},
 			)

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -201,6 +201,7 @@ func NewServer(
 	replicaSetLister applisters.ReplicaSetLister,
 	podLister corelisters.PodLister,
 	replicationControllerLister corelisters.ReplicationControllerLister,
+	serviceLister corelisters.ServiceLister,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *http.Server {
@@ -213,6 +214,7 @@ func NewServer(
 			replicaSetLister,
 			podLister,
 			replicationControllerLister,
+			serviceLister,
 			controllerNamespace,
 			ignoredNamespaces,
 		),

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -157,6 +157,7 @@ status:
 			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
 			podInformer := sharedInformers.Core().V1().Pods()
 			replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
+			serviceInformer := sharedInformers.Core().V1().Services()
 
 			fakeGrpcServer := newGrpcServer(
 				&MockProm{Res: exp.promRes},
@@ -166,6 +167,7 @@ status:
 				replicaSetInformer.Lister(),
 				podInformer.Lister(),
 				replicationControllerInformer.Lister(),
+				serviceInformer.Lister(),
 				"conduit",
 				[]string{},
 			)
@@ -178,6 +180,7 @@ status:
 				replicaSetInformer.Informer().HasSynced,
 				podInformer.Informer().HasSynced,
 				replicationControllerInformer.Informer().HasSynced,
+				serviceInformer.Informer().HasSynced,
 			) {
 				t.Fatalf("timed out wait for caches to sync")
 			}
@@ -238,6 +241,7 @@ status:
 				sharedInformers.Apps().V1beta2().ReplicaSets().Lister(),
 				sharedInformers.Core().V1().Pods().Lister(),
 				sharedInformers.Core().V1().ReplicationControllers().Lister(),
+				sharedInformers.Core().V1().Services().Lister(),
 				"conduit",
 				[]string{},
 			)

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -13,7 +13,31 @@ import (
   Shared utilities for interacting with the controller public api
 */
 
-var defaultMetricTimeWindow = "1m"
+var (
+	defaultMetricTimeWindow = "1m"
+
+	// ValidTargets specifies resource types allowed as a target:
+	// target resource on an inbound query
+	// target resource on an outbound 'to' query
+	// destination resource on an outbound 'from' query
+	ValidTargets = []string{
+		k8s.KubernetesDeployments,
+		k8s.KubernetesNamespaces,
+		k8s.KubernetesPods,
+		k8s.KubernetesReplicationControllers,
+	}
+
+	// validDestinations specifies resource types allowed as a destination:
+	// destination resource on an outbound 'to' query
+	// target resource on an outbound 'from' query
+	validDestinations = []string{
+		k8s.KubernetesDeployments,
+		k8s.KubernetesNamespaces,
+		k8s.KubernetesPods,
+		k8s.KubernetesReplicationControllers,
+		k8s.KubernetesServices,
+	}
+)
 
 type StatSummaryRequestParams struct {
 	TimeWindow    string

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -72,6 +72,9 @@ func main() {
 	replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
 	replicationControllerInformerSynced := replicationControllerInformer.Informer().HasSynced
 
+	serviceInformer := sharedInformers.Core().V1().Services()
+	serviceInformerSynced := serviceInformer.Informer().HasSynced
+
 	sharedInformers.Start(nil)
 
 	prometheusClient, err := promApi.NewClient(promApi.Config{Address: *prometheusUrl})
@@ -88,6 +91,7 @@ func main() {
 		replicaSetInformer.Lister(),
 		podInformer.Lister(),
 		replicationControllerInformer.Lister(),
+		serviceInformer.Lister(),
 		*controllerNamespace,
 		strings.Split(*ignoredNamespaces, ","),
 	)
@@ -104,6 +108,7 @@ func main() {
 			replicaSetInformerSynced,
 			podInformerSynced,
 			replicationControllerInformerSynced,
+			serviceInformerSynced,
 		) {
 			log.Fatalf("timed out wait for caches to sync")
 		}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -13,6 +13,7 @@ const (
 	KubernetesNamespaces             = "namespaces"
 	KubernetesPods                   = "pods"
 	KubernetesReplicationControllers = "replicationcontrollers"
+	KubernetesServices               = "services"
 )
 
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
@@ -66,6 +67,8 @@ func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error
 		return KubernetesPods, nil
 	case "rc", "replicationcontroller", "replicationcontrollers":
 		return KubernetesReplicationControllers, nil
+	case "svc", "service", "services":
+		return KubernetesServices, nil
 	}
 
 	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)


### PR DESCRIPTION
The `stat` command did not support `service` as a resource type.

This change adds `service` support to the `stat` command. Specifically:
- as a destination resource on `--to` commands
- as a target resource on `--from` commands

Fixes #805

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

```bash
$ bin/go-run cli -n emojivoto stat svc --from-resource deploy
NAME         MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
emoji-svc       1/1   100.00%   2.0rps           2ms          41ms          48ms
voting-svc      1/1    77.97%   1.0rps           2ms          77ms          96ms
web-svc         1/1    88.89%   1.9rps           5ms          75ms          95ms

$ bin/go-run cli -n emojivoto stat svc --from-resource deploy --from web
github.com/runconduit/conduit/controller/api/util
NAME         MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
emoji-svc       1/1   100.00%   1.9rps           2ms           4ms           5ms
voting-svc      1/1    79.66%   1.0rps           2ms           8ms          10ms

$ bin/go-run cli -n emojivoto stat deploy web --to-resource svc --to voting-svc
NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
web       1/1    72.88%   1.0rps           2ms           7ms           9ms
```