### PR TITLE
proxy: Remove the `Labeled` middleware in favor of client context labels

### DIFF
--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -29,7 +29,7 @@ use transport::DnsNameAndPort;
 
 use control::cache::{Cache, CacheChange, Exists};
 
-use ::telemetry::metrics::{DstLabels, Labeled};
+use ::telemetry::metrics::DstLabels;
 
 /// A handle to start watching a destination for address changes.
 #[derive(Clone, Debug)]
@@ -274,7 +274,7 @@ where
     type Request = B::Request;
     type Response = B::Response;
     type Error = B::Error;
-    type Service = Labeled<B::Service>;
+    type Service = B::Service;
     type DiscoverError = ();
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {
@@ -295,7 +295,6 @@ where
                     let endpoint = Endpoint::new(addr, labels_watch.clone());
 
                     let service = self.bind.bind(&endpoint)
-                        .map(|svc| Labeled::new(svc, labels_watch))
                         .map_err(|_| ())?;
 
                     return Ok(Async::Ready(Change::Insert(addr, service)))

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use control::discovery::DstLabelsWatch;
 use ctx;
-use telemetry::metrics::DstLabels;
 
 
 /// Describes a stream's request headers.
@@ -20,11 +19,6 @@ pub struct Request {
 
     /// Identifies the proxy client that dispatched the request.
     pub client: Arc<ctx::transport::Client>,
-
-    /// Optional information on the request's destination service, which may
-    /// be provided by the control plane for destinations lookups against its
-    /// discovery API.
-    pub dst_labels: Option<DstLabels>,
 }
 
 /// Describes a stream's response headers.
@@ -49,19 +43,12 @@ impl Request {
         client: &Arc<ctx::transport::Client>,
         id: usize,
     ) -> Arc<Self> {
-        // Look up whether the request has been extended with optional
-        // destination labels from the control plane's discovery API.
-        let dst_labels = request
-            .extensions()
-            .get::<DstLabels>()
-            .cloned();
         let r = Self {
             id,
             uri: request.uri().clone(),
             method: request.method().clone(),
             server: Arc::clone(server),
             client: Arc::clone(client),
-            dst_labels,
         };
 
         Arc::new(r)

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -18,7 +18,6 @@ use bind::{self, Bind, Protocol};
 use control::{self, discovery};
 use control::discovery::Bind as BindTrait;
 use ctx;
-use telemetry::metrics;
 use timeout::Timeout;
 use transparency::h1;
 use transport::{DnsNameAndPort, Host, HostAndPort};
@@ -170,7 +169,7 @@ where
     type Request = http::Request<B>;
     type Response = bind::HttpResponse;
     type Error = <Self::Service as tower::Service>::Error;
-    type Service = metrics::Labeled<bind::Service<B>>;
+    type Service = bind::Service<B>;
     type DiscoverError = BindError;
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {
@@ -185,9 +184,6 @@ where
                 // closing down when the connection is no longer usable.
                 if let Some((addr, bind)) = opt.take() {
                     let svc = bind.bind(&addr.into())
-                        // The controller has no labels to add to an external
-                        // service.
-                        .map(metrics::Labeled::none)
                         .map_err(|_| BindError::External{ addr })?;
                     Ok(Async::Ready(Change::Insert(addr, svc)))
                 } else {

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -51,7 +51,7 @@ mod latency;
 
 use self::labels::{RequestLabels, ResponseLabels};
 use self::latency::{BUCKET_BOUNDS, Histogram};
-pub use self::labels::{DstLabels, Labeled};
+pub use self::labels::DstLabels;
 
 #[derive(Debug, Clone)]
 struct Metrics {


### PR DESCRIPTION
The `Labeled` middleware is used to add `DstLabels` to each request. Now that
each client context maintains a watch on its endpoint's `DstLabels`, the
`Labeled` middleware can safely be removed.

This has one subtle behavior change: labels are associated with requests
_lazily_, whereas before they were determined _eagerly_. This means that if an
endpoint's labels are updated before the telemetry system captures the labels
for the request, it may use the newer labels. Previously, it would only use the
labels at the time that the request originated.