### PR TITLE
Fix top-line Grafana counts

### DIFF
--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -264,7 +264,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(request_total{dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"})",
+          "expr": "count(count(request_total{dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}) by (namespace, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -346,7 +346,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=~\"$outbound\", direction=\"outbound\"})",
+          "expr": "count(count(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}) by (namespace, dst_deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -264,7 +264,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(request_total{dst_namespace=\"$namespace\", dst_pod=\"$pod\", direction=\"outbound\"})",
+          "expr": "count(count(request_total{dst_namespace=\"$namespace\", dst_pod=\"$pod\", direction=\"outbound\"}) by (namespace, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -346,7 +346,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"})",
+          "expr": "count(count(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}) by (namespace, dst_pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -269,7 +269,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Namespaces Monitored",
+      "title": "NAMESPACES MONITORED",
       "type": "singlestat",
       "valueFontSize": "200%",
       "valueMaps": [
@@ -351,7 +351,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Deployments Monitored",
+      "title": "DEPLOYMENTS MONITORED",
       "type": "singlestat",
       "valueFontSize": "200%",
       "valueMaps": [


### PR DESCRIPTION
The top-line single stat numbers were not calculated properly, resulting
in inflated counts.

Modify the underlying Prometheus queries to ensure accurate counts of
Deployments, Pods, and Namespaces.

Fixes #801.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>