### PR TITLE
Upgrade Prometheus from 2.1.0 to 2.2.1

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -63,7 +63,7 @@ func validateAndBuildConfig() (*installConfig, error) {
 		Namespace:                controlPlaneNamespace,
 		ControllerImage:          fmt.Sprintf("%s/controller:%s", dockerRegistry, conduitVersion),
 		WebImage:                 fmt.Sprintf("%s/web:%s", dockerRegistry, conduitVersion),
-		PrometheusImage:          "prom/prometheus:v2.1.0",
+		PrometheusImage:          "prom/prometheus:v2.2.1",
 		GrafanaImage:             fmt.Sprintf("%s/grafana:%s", dockerRegistry, conduitVersion),
 		ControllerReplicas:       controllerReplicas,
 		WebReplicas:              webReplicas,

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -403,7 +403,7 @@ spec:
       - args:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
-        image: prom/prometheus:v2.1.0
+        image: prom/prometheus:v2.2.1
         imagePullPolicy: IfNotPresent
         name: prometheus
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     - -template-dir=/templates
 
   prometheus:
-    image: prom/prometheus:v2.1.0
+    image: prom/prometheus:v2.2.1
     ports:
     - 9090:9090
     volumes:


### PR DESCRIPTION
There have been a number of performance improvements and bug fixes since
v2.1.0.

Bump our Prometheus container to v2.2.1.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Relevant release notes:
https://github.com/prometheus/prometheus/releases/tag/v2.2.0
https://github.com/prometheus/prometheus/releases/tag/v2.2.1
