### PR TITLE
proxy: Support destination label matching for tap

### DIFF
--- a/proxy/controller-grpc/src/arbitrary.rs
+++ b/proxy/controller-grpc/src/arbitrary.rs
@@ -54,6 +54,15 @@ impl Arbitrary for observe_request::match_::Seq {
     }
 }
 
+impl Arbitrary for observe_request::match_::Label {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        observe_request::match_::Label {
+            key: Arbitrary::arbitrary(g),
+            value: Arbitrary::arbitrary(g),
+        }
+    }
+}
+
 impl Arbitrary for observe_request::match_::Tcp {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         observe_request::match_::Tcp {

--- a/proxy/src/telemetry/tap/match_.rs
+++ b/proxy/src/telemetry/tap/match_.rs
@@ -34,16 +34,16 @@ pub enum InvalidMatch {
 }
 
 #[derive(Clone, Debug)]
+pub(super) struct LabelMatch {
+    key: String,
+    value: String,
+}
+
+#[derive(Clone, Debug)]
 pub(super) enum TcpMatch {
     // Inclusive
     PortRange(u16, u16),
     Net(NetMatch),
-}
-
-#[derive(Clone, Debug)]
-pub(super) struct LabelMatch {
-    pub key: String,
-    pub value: String,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Now, the tap server may specify that requests should be matched by destination
label.

For example, if the controller's Destination service returns the labels:
`{"service": "users", "namespace": "prod"}` for an endpoint, then tap would be
able to specify a match like `namespace=prod` to match requests destined to
that namespace.