### PR TITLE
cli: standardize kubernetes resource parsing

### DIFF
--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -27,10 +27,10 @@ var (
 		k8s.KubernetesReplicationControllers,
 	}
 
-	// validDestinations specifies resource types allowed as a destination:
+	// ValidDestinations specifies resource types allowed as a destination:
 	// destination resource on an outbound 'to' query
 	// target resource on an outbound 'from' query
-	validDestinations = []string{
+	ValidDestinations = []string{
 		k8s.KubernetesDeployments,
 		k8s.KubernetesNamespaces,
 		k8s.KubernetesPods,


### PR DESCRIPTION
The Tap command leveraged new cli parsing code, enabling Kubernetes
resources specified as `(TYPE [NAME] | TYPE/NAME)`. The Stat command
did not use this.

Modify the Stat command to use the same cli flag parsing code as Tap.
Remove the to/from-resource flags from Stat.

Fixes #792

Signed-off-by: Andrew Seigner <siggy@buoyant.io>