### PR TITLE
proxy tests: reduce some boilerplate, improve error information

### DIFF
--- a/proxy/tests/shutdown.rs
+++ b/proxy/tests/shutdown.rs
@@ -9,9 +9,7 @@ fn h2_goaways_connections() {
     let (shdn, rx) = shutdown_signal();
 
     let srv = server::http2().route("/", "hello").run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .shutdown_signal(rx)
         .run();
@@ -41,9 +39,7 @@ fn h2_exercise_goaways_connections() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .shutdown_signal(rx)
         .run();
@@ -109,9 +105,7 @@ fn http1_closes_idle_connections() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .shutdown_signal(rx)
         .run();
@@ -145,9 +139,7 @@ fn tcp_waits_for_proxies_to_close() {
                 .map_err(|e| panic!("tcp server error: {}", e))
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .shutdown_signal(rx)
         .run();

--- a/proxy/tests/support/proxy.rs
+++ b/proxy/tests/support/proxy.rs
@@ -44,6 +44,9 @@ impl Proxy {
         }
     }
 
+    /// Pass a customized support `Controller` for this proxy to use.
+    ///
+    /// If not used, a default controller will be used.
     pub fn controller(mut self, c: controller::Listening) -> Self {
         self.controller = Some(c);
         self
@@ -122,7 +125,7 @@ impl conduit_proxy::GetOriginalDst for MockOriginalDst {
 fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
     use self::conduit_proxy::config;
 
-    let controller = proxy.controller.expect("proxy controller missing");
+    let controller = proxy.controller.unwrap_or_else(|| controller::new().run());
     let inbound = proxy.inbound;
     let outbound = proxy.outbound;
     let mut mock_orig_dst = DstInner::default();

--- a/proxy/tests/support/tcp.rs
+++ b/proxy/tests/support/tcp.rs
@@ -2,6 +2,7 @@ use support::*;
 
 use std::collections::VecDeque;
 use std::io;
+use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -14,6 +15,7 @@ type TcpConnSender = mpsc::UnboundedSender<(Option<Vec<u8>>, oneshot::Sender<io:
 pub fn client(addr: SocketAddr) -> TcpClient {
     let tx = run_client(addr);
     TcpClient {
+        addr,
         tx,
     }
 }
@@ -25,6 +27,7 @@ pub fn server() -> TcpServer {
 }
 
 pub struct TcpClient {
+    addr: SocketAddr,
     tx: TcpSender,
 }
 
@@ -45,6 +48,7 @@ pub struct TcpServer {
 }
 
 pub struct TcpConn {
+    addr: SocketAddr,
     tx: TcpConnSender,
 }
 
@@ -56,6 +60,7 @@ impl TcpClient {
             .wait()
             .unwrap();
         TcpConn {
+            addr: self.addr,
             tx,
         }
     }
@@ -97,7 +102,11 @@ impl TcpServer {
 
 impl TcpConn {
     pub fn read(&self) -> Vec<u8> {
-        self.try_read().expect("read")
+        self
+            .try_read()
+            .unwrap_or_else(|e| {
+                panic!("TcpConn(addr={}) read() error: {:?}", self.addr, e)
+            })
     }
 
     pub fn try_read(&self) -> io::Result<Vec<u8>> {
@@ -122,7 +131,8 @@ impl TcpConn {
 
 fn run_client(addr: SocketAddr) -> TcpSender {
     let (tx, rx) = mpsc::unbounded();
-    ::std::thread::Builder::new().name("support tcp client".into()).spawn(move || {
+    let thread_name = format!("support tcp client (addr={})", addr);
+    ::std::thread::Builder::new().name(thread_name).spawn(move || {
         let mut core = Core::new().unwrap();
         let handle = core.handle();
 
@@ -183,18 +193,23 @@ fn run_client(addr: SocketAddr) -> TcpSender {
 
 fn run_server(tcp: TcpServer) -> server::Listening {
     let (tx, rx) = shutdown_signal();
-    let (addr_tx, addr_rx) = oneshot::channel();
+    let (started_tx, started_rx) = oneshot::channel();
     let conn_count = Arc::new(AtomicUsize::from(0));
     let srv_conn_count = Arc::clone(&conn_count);
-    ::std::thread::Builder::new().name("support tcp server".into()).spawn(move || {
+    let any_port = SocketAddr::from(([127, 0, 0, 1], 0));
+    let std_listener = StdTcpListener::bind(&any_port).expect("bind");
+    let addr = std_listener.local_addr().expect("local_addr");
+    let thread_name = format!("support tcp server (addr={})", addr);
+    ::std::thread::Builder::new().name(thread_name).spawn(move || {
         let mut core = Core::new().unwrap();
         let reactor = core.handle();
 
-        let addr = ([127, 0, 0, 1], 0).into();
-        let bind = TcpListener::bind(&addr, &reactor).expect("bind");
+        let bind = TcpListener::from_listener(
+            std_listener,
+            &addr,
+            &reactor
+        ).expect("from_listener");
 
-        let local_addr = bind.local_addr().expect("local_addr");
-        let _ = addr_tx.send(local_addr);
 
         let mut accepts = tcp.accepts;
 
@@ -212,10 +227,12 @@ fn run_server(tcp: TcpServer) -> server::Listening {
             .map_err(|e| panic!("tcp accept error: {}", e));
 
         core.handle().spawn(listen);
+
+        let _ = started_tx.send(());
         core.run(rx).unwrap();
     }).unwrap();
 
-    let addr = addr_rx.wait().expect("addr");
+    started_rx.wait().expect("support tcp server started");
     server::Listening {
         addr,
         shutdown: tx,

--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -41,9 +41,7 @@ impl Fixture {
     }
 
     fn inbound_with_server(srv: server::Listening) -> Self {
-        let ctrl = controller::new().run();
         let proxy = proxy::new()
-            .controller(ctrl)
             .inbound(srv)
             .run();
         let metrics = client::http1(proxy.metrics, "localhost");
@@ -91,9 +89,7 @@ impl TcpFixture {
     }
 
     fn inbound() -> Self {
-        let ctrl = controller::new().run();
         let proxy = proxy::new()
-            .controller(ctrl)
             .inbound(TcpFixture::server())
             .run();
 
@@ -103,9 +99,7 @@ impl TcpFixture {
     }
 
     fn outbound() -> Self {
-        let ctrl = controller::new().run();
         let proxy = proxy::new()
-            .controller(ctrl)
             .outbound(TcpFixture::server())
             .run();
 

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -21,9 +21,7 @@ fn inbound_http1() {
     let _ = env_logger::try_init();
 
     let srv = server::http1().route("/", "hello h1").run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
@@ -37,9 +35,7 @@ fn http1_connect_not_supported() {
 
     let srv = server::tcp()
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -66,9 +62,7 @@ fn http1_removes_connection_headers() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
@@ -96,9 +90,7 @@ fn http10_with_host() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, host);
@@ -126,10 +118,7 @@ fn http10_without_host() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new()
-        .run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -160,9 +149,7 @@ fn http11_absolute_uri_differs_from_host() {
             Response::new("".into())
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1_absolute_uris(proxy.inbound, auth);
@@ -188,9 +175,7 @@ fn outbound_tcp() {
             msg2
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .outbound(srv)
         .run();
 
@@ -215,9 +200,7 @@ fn inbound_tcp() {
             msg2
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -253,9 +236,7 @@ fn tcp_server_first() {
                 .map_err(|e| panic!("tcp server error: {}", e))
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .disable_inbound_ports_protocol_detection(vec![srv.addr.port()])
         .inbound(srv)
         .run();
@@ -276,9 +257,7 @@ fn tcp_with_no_orig_dst() {
     let srv = server::tcp()
         .accept(move |_| "don't read me")
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -324,9 +303,7 @@ fn tcp_connections_close_if_client_closes() {
                 .map_err(|e| panic!("tcp server error: {}", e))
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -374,9 +351,7 @@ fn http11_upgrade_not_supported() {
             msg2
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -408,9 +383,7 @@ fn http1_requests_without_body_doesnt_add_transfer_encoding() {
             res
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
@@ -453,9 +426,7 @@ fn http1_content_length_zero_is_preserved() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
@@ -507,9 +478,7 @@ fn http1_bodyless_responses() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
@@ -566,9 +535,7 @@ fn http1_head_responses() {
                 .unwrap()
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
@@ -611,9 +578,7 @@ fn http1_response_end_of_file() {
             "
         })
         .run();
-    let ctrl = controller::new().run();
     let proxy = proxy::new()
-        .controller(ctrl)
         .inbound(srv)
         .run();
 
@@ -659,9 +624,7 @@ fn http1_one_connection_per_host() {
     let srv = server::http1()
         .route_empty_ok("/")
         .run();
-    let ctrl = controller::new()
-        .run();
-    let proxy = proxy::new().controller(ctrl).inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run();
 
     let client = client::http1(proxy.inbound, "foo.bar");
 
@@ -720,9 +683,7 @@ fn http1_requests_without_host_have_unique_connections() {
     let srv = server::http1()
         .route_empty_ok("/")
         .run();
-    let ctrl = controller::new()
-        .run();
-    let proxy = proxy::new().controller(ctrl).inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run();
 
     let client = client::http1(proxy.inbound, "foo.bar");
 


### PR DESCRIPTION
The `controller` part of the proxy will now use a default, removing the
need to pass the exact same `controller::new().run()` in every test
case.

The TCP server and client will include their socket addresses in some
panics.

----

I cannot seem to trigger the flakiness locally, but hopefully this additional information will be able to help identify some errors. I could even retry CI in this PR a few times till the flakiness shows itself...