### PR TITLE
Implement Public API and Tap on top of Lister

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -746,6 +746,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "325d0175a74db86d1fed482bddc8279459d63be9d5338d9a420722c24eea5534"
+  inputs-digest = "182946acde1cd53f9b8e6e3137ea55d1d14d7467a175ce261ddf30d74de3168e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,8 +1,9 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:a6e8221d as golang
+FROM gcr.io/runconduit/go-deps:ff0dc047 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
+COPY controller/k8s controller/k8s
 COPY controller/api controller/api
 COPY controller/gen controller/gen
 COPY controller/util controller/util

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -30,8 +30,8 @@ Only pod resources (aka pods, po) are supported.`,
 		friendlyName := args[0]
 		resourceType, err := k8s.CanonicalKubernetesNameFromFriendlyName(friendlyName)
 
-		if err != nil || resourceType != k8s.KubernetesPods {
-			return fmt.Errorf("invalid resource type %s, only %s are allowed as resource types", friendlyName, k8s.KubernetesPods)
+		if err != nil || resourceType != k8s.Pods {
+			return fmt.Errorf("invalid resource type %s, only %s are allowed as resource types", friendlyName, k8s.Pods)
 		}
 		client, err := newPublicAPIClient()
 		if err != nil {

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -92,12 +92,12 @@ func init() {
 
 func requestTapFromApi(w io.Writer, client pb.ApiClient, targetName string, resourceType string, req *pb.TapRequest) error {
 	switch resourceType {
-	case k8s.KubernetesDeployments:
+	case k8s.Deployments:
 		req.Target = &pb.TapRequest_Deployment{
 			Deployment: targetName,
 		}
 
-	case k8s.KubernetesPods:
+	case k8s.Pods:
 		req.Target = &pb.TapRequest_Pod{
 			Pod: targetName,
 		}

--- a/cli/cmd/tap_by_resource_test.go
+++ b/cli/cmd/tap_by_resource_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRequestTapByResourceFromAPI(t *testing.T) {
 	t.Run("Should render busy response if everything went well", func(t *testing.T) {
-		resourceType := k8s.KubernetesPods
+		resourceType := k8s.Pods
 		targetName := "pod-666"
 		scheme := "https"
 		method := "GET"
@@ -83,7 +83,7 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 	})
 
 	t.Run("Should render empty response if no events returned", func(t *testing.T) {
-		resourceType := k8s.KubernetesPods
+		resourceType := k8s.Pods
 		targetName := "pod-666"
 		scheme := "https"
 		method := "GET"
@@ -123,7 +123,7 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 
 	t.Run("Should return error if stream returned error", func(t *testing.T) {
 		t.SkipNow()
-		resourceType := k8s.KubernetesPods
+		resourceType := k8s.Pods
 		targetName := "pod-666"
 		scheme := "https"
 		method := "GET"

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -21,7 +21,7 @@ func TestRequestTapFromApi(t *testing.T) {
 	t.Run("Should render busy response if everything went well", func(t *testing.T) {
 		authority := "localhost"
 		targetName := "pod-666"
-		resourceType := k8s.KubernetesPods
+		resourceType := k8s.Pods
 		scheme := "https"
 		method := "GET"
 		path := "/some/path"
@@ -95,7 +95,7 @@ func TestRequestTapFromApi(t *testing.T) {
 	t.Run("Should render empty response if no events returned", func(t *testing.T) {
 		authority := "localhost"
 		targetName := "pod-666"
-		resourceType := k8s.KubernetesPods
+		resourceType := k8s.Pods
 		scheme := "https"
 		method := "GET"
 		path := "/some/path"
@@ -140,7 +140,7 @@ func TestRequestTapFromApi(t *testing.T) {
 		t.SkipNow()
 		authority := "localhost"
 		targetName := "pod-666"
-		resourceType := k8s.KubernetesPods
+		resourceType := k8s.Pods
 		scheme := "https"
 		method := "GET"
 		path := "/some/path"

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:a6e8221d as golang
+FROM gcr.io/runconduit/go-deps:ff0dc047 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -11,27 +11,21 @@ import (
 	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
 	tapPb "github.com/runconduit/conduit/controller/gen/controller/tap"
 	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/controller/k8s"
 	pkgK8s "github.com/runconduit/conduit/pkg/k8s"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 	k8sV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	applisters "k8s.io/client-go/listers/apps/v1beta2"
-	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
 type (
 	grpcServer struct {
-		prometheusAPI               promv1.API
-		tapClient                   tapPb.TapClient
-		namespaceLister             corelisters.NamespaceLister
-		deployLister                applisters.DeploymentLister
-		replicaSetLister            applisters.ReplicaSetLister
-		podLister                   corelisters.PodLister
-		replicationControllerLister corelisters.ReplicationControllerLister
-		serviceLister               corelisters.ServiceLister
-		controllerNamespace         string
-		ignoredNamespaces           []string
+		prometheusAPI       promv1.API
+		tapClient           tapPb.TapClient
+		lister              *k8s.Lister
+		controllerNamespace string
+		ignoredNamespaces   []string
 	}
 )
 
@@ -46,26 +40,16 @@ const (
 func newGrpcServer(
 	promAPI promv1.API,
 	tapClient tapPb.TapClient,
-	namespaceLister corelisters.NamespaceLister,
-	deployLister applisters.DeploymentLister,
-	replicaSetLister applisters.ReplicaSetLister,
-	podLister corelisters.PodLister,
-	replicationControllerLister corelisters.ReplicationControllerLister,
-	serviceLister corelisters.ServiceLister,
+	lister *k8s.Lister,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *grpcServer {
 	return &grpcServer{
-		prometheusAPI:               promAPI,
-		tapClient:                   tapClient,
-		namespaceLister:             namespaceLister,
-		deployLister:                deployLister,
-		replicaSetLister:            replicaSetLister,
-		podLister:                   podLister,
-		replicationControllerLister: replicationControllerLister,
-		serviceLister:               serviceLister,
-		controllerNamespace:         controllerNamespace,
-		ignoredNamespaces:           ignoredNamespaces,
+		prometheusAPI:       promAPI,
+		tapClient:           tapClient,
+		lister:              lister,
+		controllerNamespace: controllerNamespace,
+		ignoredNamespaces:   ignoredNamespaces,
 	}
 }
 
@@ -92,7 +76,7 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.Empty) (*pb.ListPodsR
 		reports[pod] = time.Unix(0, int64(timestamp)*int64(time.Millisecond))
 	}
 
-	pods, err := s.podLister.List(labels.Everything())
+	pods, err := s.lister.Pod.List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +135,7 @@ func (s *grpcServer) SelfCheck(ctx context.Context, in *healthcheckPb.SelfCheckR
 		CheckDescription: K8sClientCheckDescription,
 		Status:           healthcheckPb.CheckStatus_OK,
 	}
-	_, err := s.podLister.List(labels.Everything())
+	_, err := s.lister.Pod.List(labels.Everything())
 	if err != nil {
 		k8sClientCheck.Status = healthcheckPb.CheckStatus_ERROR
 		k8sClientCheck.FriendlyMessageToUser = fmt.Sprintf("Error talking to Kubernetes from control plane: %s", err.Error())
@@ -242,7 +226,7 @@ func (s *grpcServer) getDeploymentFor(pod *k8sV1.Pod) (string, error) {
 		return "", fmt.Errorf("Pod %s parent is not a ReplicaSet", pod.Name)
 	}
 
-	rs, err := s.replicaSetLister.GetPodReplicaSets(pod)
+	rs, err := s.lister.RS.GetPodReplicaSets(pod)
 	if err != nil {
 		return "", err
 	}

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/prometheus/common/model"
 	tap "github.com/runconduit/conduit/controller/gen/controller/tap"
 	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/controller/k8s"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
 )
 
 type listPodsExpected struct {
@@ -164,38 +162,17 @@ spec:
 			}
 
 			clientSet := fake.NewSimpleClientset(k8sObjs...)
-			sharedInformers := informers.NewSharedInformerFactory(clientSet, 10*time.Minute)
-
-			namespaceInformer := sharedInformers.Core().V1().Namespaces()
-			deployInformer := sharedInformers.Apps().V1beta2().Deployments()
-			replicaSetInformer := sharedInformers.Apps().V1beta2().ReplicaSets()
-			podInformer := sharedInformers.Core().V1().Pods()
-			replicationControllerInformer := sharedInformers.Core().V1().ReplicationControllers()
-			serviceInformer := sharedInformers.Core().V1().Services()
+			lister := k8s.NewLister(clientSet)
 
 			fakeGrpcServer := newGrpcServer(
 				&MockProm{Res: exp.promRes},
 				tap.NewTapClient(nil),
-				namespaceInformer.Lister(),
-				deployInformer.Lister(),
-				replicaSetInformer.Lister(),
-				podInformer.Lister(),
-				replicationControllerInformer.Lister(),
-				serviceInformer.Lister(),
+				lister,
 				"conduit",
 				[]string{},
 			)
-			stopCh := make(chan struct{})
-			sharedInformers.Start(stopCh)
-			if !cache.WaitForCacheSync(
-				stopCh,
-				namespaceInformer.Informer().HasSynced,
-				deployInformer.Informer().HasSynced,
-				replicaSetInformer.Informer().HasSynced,
-				podInformer.Informer().HasSynced,
-				replicationControllerInformer.Informer().HasSynced,
-				serviceInformer.Informer().HasSynced,
-			) {
+			err := lister.Sync()
+			if err != nil {
 				t.Fatalf("timed out wait for caches to sync")
 			}
 

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -11,11 +11,10 @@ import (
 	healthcheckPb "github.com/runconduit/conduit/controller/gen/common/healthcheck"
 	tapPb "github.com/runconduit/conduit/controller/gen/controller/tap"
 	pb "github.com/runconduit/conduit/controller/gen/public"
+	"github.com/runconduit/conduit/controller/k8s"
 	"github.com/runconduit/conduit/controller/util"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"
-	applisters "k8s.io/client-go/listers/apps/v1beta2"
-	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
 var (
@@ -221,12 +220,7 @@ func NewServer(
 	addr string,
 	prometheusClient promApi.Client,
 	tapClient tapPb.TapClient,
-	namespaceLister corelisters.NamespaceLister,
-	deployLister applisters.DeploymentLister,
-	replicaSetLister applisters.ReplicaSetLister,
-	podLister corelisters.PodLister,
-	replicationControllerLister corelisters.ReplicationControllerLister,
-	serviceLister corelisters.ServiceLister,
+	lister *k8s.Lister,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *http.Server {
@@ -234,12 +228,7 @@ func NewServer(
 		grpcServer: newGrpcServer(
 			promv1.NewAPI(prometheusClient),
 			tapClient,
-			namespaceLister,
-			deployLister,
-			replicaSetLister,
-			podLister,
-			replicationControllerLister,
-			serviceLister,
+			lister,
 			controllerNamespace,
 			ignoredNamespaces,
 		),

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -8,13 +8,15 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/runconduit/conduit/controller/api/util"
 	pb "github.com/runconduit/conduit/controller/gen/public"
 	"github.com/runconduit/conduit/pkg/k8s"
 	log "github.com/sirupsen/logrus"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 )
@@ -35,26 +37,11 @@ const (
 	promLatencyP95 = promType("0.95")
 	promLatencyP99 = promType("0.99")
 
-	deploymentLabel            = model.LabelName("deployment")
-	namespaceLabel             = model.LabelName("namespace")
-	podLabel                   = model.LabelName("pod")
-	replicationControllerLabel = model.LabelName("replication_controller")
-	serviceLabel               = model.LabelName("service")
-
+	namespaceLabel    = model.LabelName("namespace")
 	dstNamespaceLabel = model.LabelName("dst_namespace")
 )
 
-var (
-	promTypes = []promType{promRequests, promLatencyP50, promLatencyP95, promLatencyP99}
-
-	k8sResourceTypesToPromLabels = map[string]model.LabelName{
-		k8s.KubernetesDeployments:            deploymentLabel,
-		k8s.KubernetesNamespaces:             namespaceLabel,
-		k8s.KubernetesPods:                   podLabel,
-		k8s.KubernetesReplicationControllers: replicationControllerLabel,
-		k8s.KubernetesServices:               serviceLabel,
-	}
-)
+var promTypes = []promType{promRequests, promLatencyP50, promLatencyP95, promLatencyP99}
 
 type meshedCount struct {
 	inMesh uint64
@@ -62,42 +49,53 @@ type meshedCount struct {
 }
 
 func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest) (*pb.StatSummaryResponse, error) {
-	var err error
-	var objectMap map[string]metav1.ObjectMeta
-	var meshCount map[string]*meshedCount
+	// special case to check for services as outbound only
+	if req.Selector.Resource.Type == k8s.Services &&
+		req.Outbound.(*pb.StatSummaryRequest_FromResource) == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "service only supported as a target on 'from' queries, or as a destination on 'to' queries.")
+	}
 
-	switch req.Selector.Resource.Type {
-	case k8s.KubernetesDeployments:
-		objectMap, meshCount, err = s.getDeployments(req.Selector.Resource)
-	case k8s.KubernetesNamespaces:
-		objectMap, meshCount, err = s.getNamespaces(req.Selector.Resource)
-	case k8s.KubernetesPods:
-		objectMap, meshCount, err = s.getPods(req.Selector.Resource)
-	case k8s.KubernetesReplicationControllers:
-		objectMap, meshCount, err = s.getReplicationControllers(req.Selector.Resource)
-	case k8s.KubernetesServices:
+	objects, err := s.lister.GetObjects(req.Selector.Resource.Namespace, req.Selector.Resource.Type, req.Selector.Resource.Name)
+	if err != nil {
+		return nil, util.GRPCError(err)
+	}
 
-		switch req.Outbound.(type) {
-		case *pb.StatSummaryRequest_FromResource:
-			objectMap, meshCount, err = s.getServices(req.Selector.Resource)
-		default:
-			err = fmt.Errorf("Service only supported as a target on 'from' queries, or as a destination on 'to' queries.")
+	// TODO: make these one struct:
+	// string => {metav1.ObjectMeta, meshedCount}
+	objectMap := map[string]metav1.Object{}
+	meshCountMap := map[string]*meshedCount{}
+
+	for _, object := range objects {
+		key, err := cache.MetaNamespaceKeyFunc(object)
+		if err != nil {
+			return nil, util.GRPCError(err)
+		}
+		metaObj, err := meta.Accessor(object)
+		if err != nil {
+			return nil, util.GRPCError(err)
 		}
 
-	default:
-		err = fmt.Errorf("Unimplemented resource type: %v", req.Selector.Resource.Type)
-	}
-	if err != nil {
-		return nil, err
+		objectMap[key] = metaObj
+
+		meshCount, err := s.getMeshedPodCount(object)
+		if err != nil {
+			return nil, util.GRPCError(err)
+		}
+		meshCountMap[key] = meshCount
 	}
 
-	return s.objectQuery(ctx, req, objectMap, meshCount)
+	res, err := s.objectQuery(ctx, req, objectMap, meshCountMap)
+	if err != nil {
+		return nil, util.GRPCError(err)
+	}
+
+	return res, nil
 }
 
 func (s *grpcServer) objectQuery(
 	ctx context.Context,
 	req *pb.StatSummaryRequest,
-	objects map[string]metav1.ObjectMeta,
+	objects map[string]metav1.Object,
 	meshCount map[string]*meshedCount,
 ) (*pb.StatSummaryResponse, error) {
 	rows := make([]*pb.StatTable_PodGroup_Row, 0)
@@ -129,9 +127,9 @@ func (s *grpcServer) objectQuery(
 
 		row := pb.StatTable_PodGroup_Row{
 			Resource: &pb.Resource{
-				Namespace: resource.Namespace,
+				Namespace: resource.GetNamespace(),
 				Type:      req.Selector.Resource.Type,
-				Name:      resource.Name,
+				Name:      resource.GetName(),
 			},
 			TimeWindow: req.TimeWindow,
 			Stats:      requestMetrics[key],
@@ -166,7 +164,7 @@ func (s *grpcServer) objectQuery(
 
 func promLabelNames(resource *pb.Resource) model.LabelNames {
 	names := model.LabelNames{namespaceLabel}
-	if resource.Type != k8s.KubernetesNamespaces {
+	if resource.Type != k8s.Namespaces {
 		names = append(names, promResourceType(resource))
 	}
 	return names
@@ -174,7 +172,7 @@ func promLabelNames(resource *pb.Resource) model.LabelNames {
 
 func promDstLabelNames(resource *pb.Resource) model.LabelNames {
 	names := model.LabelNames{dstNamespaceLabel}
-	if resource.Type != k8s.KubernetesNamespaces {
+	if resource.Type != k8s.Namespaces {
 		names = append(names, "dst_"+promResourceType(resource))
 	}
 	return names
@@ -185,7 +183,7 @@ func promLabels(resource *pb.Resource) model.LabelSet {
 	if resource.Name != "" {
 		set[promResourceType(resource)] = model.LabelValue(resource.Name)
 	}
-	if resource.Type != k8s.KubernetesNamespaces && resource.Namespace != "" {
+	if resource.Type != k8s.Namespaces && resource.Namespace != "" {
 		set[namespaceLabel] = model.LabelValue(resource.Namespace)
 	}
 	return set
@@ -196,7 +194,7 @@ func promDstLabels(resource *pb.Resource) model.LabelSet {
 	if resource.Name != "" {
 		set["dst_"+promResourceType(resource)] = model.LabelValue(resource.Name)
 	}
-	if resource.Type != k8s.KubernetesNamespaces && resource.Namespace != "" {
+	if resource.Type != k8s.Namespaces && resource.Namespace != "" {
 		set[dstNamespaceLabel] = model.LabelValue(resource.Namespace)
 	}
 	return set
@@ -209,7 +207,7 @@ func promDirectionLabels(direction string) model.LabelSet {
 }
 
 func promResourceType(resource *pb.Resource) model.LabelName {
-	return k8sResourceTypesToPromLabels[resource.Type]
+	return model.LabelName(k8s.ResourceTypesToProxyLabels[resource.Type])
 }
 
 func buildRequestLabels(req *pb.StatSummaryRequest) (model.LabelSet, model.LabelNames) {
@@ -330,210 +328,14 @@ func metricToKey(metric model.Metric, groupBy model.LabelNames) string {
 	return strings.Join(values, "/")
 }
 
-func (s *grpcServer) getDeployments(res *pb.Resource) (map[string]metav1.ObjectMeta, map[string]*meshedCount, error) {
-	var err error
-	var deployments []*appsv1beta2.Deployment
-
-	if res.Namespace == "" {
-		deployments, err = s.deployLister.List(labels.Everything())
-	} else if res.Name == "" {
-		deployments, err = s.deployLister.Deployments(res.Namespace).List(labels.Everything())
-	} else {
-		var deployment *appsv1beta2.Deployment
-		deployment, err = s.deployLister.Deployments(res.Namespace).Get(res.Name)
-		deployments = []*appsv1beta2.Deployment{deployment}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meshedPodCount := make(map[string]*meshedCount)
-	deploymentMap := make(map[string]metav1.ObjectMeta)
-	for _, deployment := range deployments {
-		key, err := cache.MetaNamespaceKeyFunc(deployment)
-		if err != nil {
-			return nil, nil, err
-		}
-		deploymentMap[key] = deployment.ObjectMeta
-
-		meshCount, err := s.getMeshedPodCount(deployment.Namespace, deployment)
-		if err != nil {
-			return nil, nil, err
-		}
-		meshedPodCount[key] = meshCount
-	}
-
-	return deploymentMap, meshedPodCount, nil
-}
-
-func (s *grpcServer) getNamespaces(res *pb.Resource) (map[string]metav1.ObjectMeta, map[string]*meshedCount, error) {
-	var err error
-	var namespaces []*apiv1.Namespace
-
-	if res.Name == "" {
-		namespaces, err = s.namespaceLister.List(labels.Everything())
-	} else {
-		var namespace *apiv1.Namespace
-		namespace, err = s.namespaceLister.Get(res.Name)
-		namespaces = []*apiv1.Namespace{namespace}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meshedPodCount := make(map[string]*meshedCount)
-	namespaceMap := make(map[string]metav1.ObjectMeta)
-	for _, namespace := range namespaces {
-		key, err := cache.MetaNamespaceKeyFunc(namespace)
-		if err != nil {
-			return nil, nil, err
-		}
-		namespaceMap[key] = namespace.ObjectMeta
-
-		meshCount, err := s.getMeshedPodCount(namespace.Name, namespace)
-		if err != nil {
-			return nil, nil, err
-		}
-		meshedPodCount[key] = meshCount
-	}
-
-	return namespaceMap, meshedPodCount, nil
-}
-
-func (s *grpcServer) getPods(res *pb.Resource) (map[string]metav1.ObjectMeta, map[string]*meshedCount, error) {
-	var err error
-	var pods []*apiv1.Pod
-
-	if res.Namespace == "" {
-		pods, err = s.podLister.List(labels.Everything())
-	} else if res.Name == "" {
-		pods, err = s.podLister.Pods(res.Namespace).List(labels.Everything())
-	} else {
-		var pod *apiv1.Pod
-		pod, err = s.podLister.Pods(res.Namespace).Get(res.Name)
-		pods = []*apiv1.Pod{pod}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meshedPodCount := make(map[string]*meshedCount)
-	podMap := make(map[string]metav1.ObjectMeta)
-	for _, pod := range pods {
-		if !isPendingOrRunning(pod) {
-			continue
-		}
-
-		key, err := cache.MetaNamespaceKeyFunc(pod)
-		if err != nil {
-			return nil, nil, err
-		}
-		podMap[key] = pod.ObjectMeta
-
-		meshCount := &meshedCount{total: 1}
-		if isInMesh(pod) {
-			meshCount.inMesh++
-		}
-		meshedPodCount[key] = meshCount
-	}
-
-	return podMap, meshedPodCount, nil
-}
-
-func (s *grpcServer) getReplicationControllers(res *pb.Resource) (map[string]metav1.ObjectMeta, map[string]*meshedCount, error) {
-	var err error
-	var rcs []*apiv1.ReplicationController
-
-	if res.Namespace == "" {
-		rcs, err = s.replicationControllerLister.List(labels.Everything())
-	} else if res.Name == "" {
-		rcs, err = s.replicationControllerLister.ReplicationControllers(res.Namespace).List(labels.Everything())
-	} else {
-		var rc *apiv1.ReplicationController
-		rc, err = s.replicationControllerLister.ReplicationControllers(res.Namespace).Get(res.Name)
-		rcs = []*apiv1.ReplicationController{rc}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meshedPodCount := make(map[string]*meshedCount)
-	rcMap := make(map[string]metav1.ObjectMeta)
-	for _, rc := range rcs {
-		key, err := cache.MetaNamespaceKeyFunc(rc)
-		if err != nil {
-			return nil, nil, err
-		}
-		rcMap[key] = rc.ObjectMeta
-
-		meshCount, err := s.getMeshedPodCount(rc.Namespace, rc)
-		if err != nil {
-			return nil, nil, err
-		}
-		meshedPodCount[key] = meshCount
-	}
-
-	return rcMap, meshedPodCount, nil
-}
-
-func (s *grpcServer) getServices(res *pb.Resource) (map[string]metav1.ObjectMeta, map[string]*meshedCount, error) {
-	var err error
-	var services []*apiv1.Service
-
-	if res.Namespace == "" {
-		services, err = s.serviceLister.List(labels.Everything())
-	} else if res.Name == "" {
-		services, err = s.serviceLister.Services(res.Namespace).List(labels.Everything())
-	} else {
-		var svc *apiv1.Service
-		svc, err = s.serviceLister.Services(res.Namespace).Get(res.Name)
-		services = []*apiv1.Service{svc}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meshedPodCount := make(map[string]*meshedCount)
-	svcMap := make(map[string]metav1.ObjectMeta)
-	for _, svc := range services {
-		key, err := cache.MetaNamespaceKeyFunc(svc)
-		if err != nil {
-			return nil, nil, err
-		}
-		svcMap[key] = svc.ObjectMeta
-
-		meshCount, err := s.getMeshedPodCount(svc.Namespace, svc)
-		if err != nil {
-			return nil, nil, err
-		}
-		meshedPodCount[key] = meshCount
-	}
-
-	return svcMap, meshedPodCount, nil
-}
-
-func (s *grpcServer) getMeshedPodCount(namespace string, obj runtime.Object) (*meshedCount, error) {
-	selector, err := getSelectorFromObject(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	pods, err := s.podLister.Pods(namespace).List(selector)
+func (s *grpcServer) getMeshedPodCount(obj runtime.Object) (*meshedCount, error) {
+	pods, err := s.lister.GetPodsFor(obj)
 	if err != nil {
 		return nil, err
 	}
 
 	meshCount := &meshedCount{}
 	for _, pod := range pods {
-		if !isPendingOrRunning(pod) {
-			continue
-		}
-
 		meshCount.total++
 		if isInMesh(pod) {
 			meshCount.inMesh++
@@ -546,32 +348,6 @@ func (s *grpcServer) getMeshedPodCount(namespace string, obj runtime.Object) (*m
 func isInMesh(pod *apiv1.Pod) bool {
 	_, ok := pod.Annotations[k8s.ProxyVersionAnnotation]
 	return ok
-}
-
-func isPendingOrRunning(pod *apiv1.Pod) bool {
-	pending := pod.Status.Phase == apiv1.PodPending
-	running := pod.Status.Phase == apiv1.PodRunning
-	terminating := pod.DeletionTimestamp != nil
-	return (pending || running) && !terminating
-}
-
-func getSelectorFromObject(obj runtime.Object) (labels.Selector, error) {
-	switch typed := obj.(type) {
-	case *apiv1.Namespace:
-		return labels.Everything(), nil
-
-	case *appsv1beta2.Deployment:
-		return labels.Set(typed.Spec.Selector.MatchLabels).AsSelector(), nil
-
-	case *apiv1.ReplicationController:
-		return labels.Set(typed.Spec.Selector).AsSelector(), nil
-
-	case *apiv1.Service:
-		return labels.Set(typed.Spec.Selector).AsSelector(), nil
-
-	default:
-		return nil, fmt.Errorf("Cannot get object selector: %v", obj)
-	}
 }
 
 func (s *grpcServer) queryProm(ctx context.Context, query string) (model.Vector, error) {

--- a/controller/k8s/lister_test.go
+++ b/controller/k8s/lister_test.go
@@ -1,28 +1,168 @@
 package k8s
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/runconduit/conduit/pkg/k8s"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-type listerExpected struct {
-	err error
+func TestGetObjects(t *testing.T) {
 
-	// all 3 of these are used to seed the k8s client
-	k8sResInput   string   // object used as input to GetPodFor()
-	k8sResResults []string // expected results from GetPodFor
-	k8sResMisc    []string // additional k8s objects for seeding the k8s client
+	type getObjectsExpected struct {
+		err error
+
+		// input
+		namespace string
+		resType   string
+		name      string
+
+		// these are used to seed the k8s client
+		k8sResResults []string // expected results from GetObjects
+		k8sResMisc    []string // additional k8s objects for seeding the k8s client
+	}
+
+	t.Run("Returns expected objects based on input", func(t *testing.T) {
+		expectations := []getObjectsExpected{
+			getObjectsExpected{
+				err:           status.Errorf(codes.Unimplemented, "unimplemented resource type: bar"),
+				namespace:     "foo",
+				resType:       "bar",
+				name:          "baz",
+				k8sResResults: []string{},
+				k8sResMisc:    []string{},
+			},
+			getObjectsExpected{
+				err:       nil,
+				namespace: "my-ns",
+				resType:   k8s.Pods,
+				name:      "my-pod",
+				k8sResResults: []string{`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: my-ns`,
+				},
+				k8sResMisc: []string{},
+			},
+			getObjectsExpected{
+				err:           errors.New("pod \"my-pod\" not found"),
+				namespace:     "not-my-ns",
+				resType:       k8s.Pods,
+				name:          "my-pod",
+				k8sResResults: []string{},
+				k8sResMisc: []string{`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: my-ns`,
+				},
+			},
+			getObjectsExpected{
+				err:       nil,
+				namespace: "",
+				resType:   k8s.ReplicationControllers,
+				name:      "",
+				k8sResResults: []string{`
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: my-rc
+  namespace: my-ns`,
+				},
+				k8sResMisc: []string{},
+			},
+			getObjectsExpected{
+				err:       nil,
+				namespace: "my-ns",
+				resType:   k8s.Deployments,
+				name:      "",
+				k8sResResults: []string{`
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: my-deploy
+  namespace: my-ns`,
+				},
+				k8sResMisc: []string{`
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: my-deploy
+  namespace: not-my-ns`,
+				},
+			},
+		}
+
+		for _, exp := range expectations {
+			k8sObjs := []runtime.Object{}
+
+			k8sResults := []runtime.Object{}
+			for _, res := range exp.k8sResResults {
+				decode := scheme.Codecs.UniversalDeserializer().Decode
+				obj, _, err := decode([]byte(res), nil, nil)
+				if err != nil {
+					t.Fatalf("could not decode yml: %s", err)
+				}
+				k8sObjs = append(k8sObjs, obj)
+				k8sResults = append(k8sResults, obj)
+			}
+
+			for _, res := range exp.k8sResMisc {
+				decode := scheme.Codecs.UniversalDeserializer().Decode
+				obj, _, err := decode([]byte(res), nil, nil)
+				if err != nil {
+					t.Fatalf("could not decode yml: %s", err)
+				}
+				k8sObjs = append(k8sObjs, obj)
+			}
+
+			clientSet := fake.NewSimpleClientset(k8sObjs...)
+			lister := NewLister(clientSet)
+			err := lister.Sync()
+			if err != nil {
+				t.Fatalf("lister.Sync() returned an error: %s", err)
+			}
+
+			pods, err := lister.GetObjects(exp.namespace, exp.resType, exp.name)
+			if err != nil || exp.err != nil {
+				if (err == nil && exp.err != nil) ||
+					(err != nil && exp.err == nil) ||
+					(err.Error() != exp.err.Error()) {
+					t.Fatalf("lister.GetObjects() unexpected error, expected [%s] got: [%s]", exp.err, err)
+				}
+			} else {
+				if !reflect.DeepEqual(pods, k8sResults) {
+					t.Fatalf("Expected: %+v, Got: %+v", k8sResults, pods)
+				}
+			}
+		}
+	})
 }
 
 func TestGetPodsFor(t *testing.T) {
+
+	type getPodsForExpected struct {
+		err error
+
+		// all 3 of these are used to seed the k8s client
+		k8sResInput   string   // object used as input to GetPodFor()
+		k8sResResults []string // expected results from GetPodFor
+		k8sResMisc    []string // additional k8s objects for seeding the k8s client
+	}
+
 	t.Run("Returns expected pods based on input", func(t *testing.T) {
-		expectations := []listerExpected{
-			listerExpected{
+		expectations := []getPodsForExpected{
+			getPodsForExpected{
 				err: nil,
 				k8sResInput: `
 apiVersion: apps/v1beta2
@@ -47,7 +187,7 @@ status:
   phase: Finished`,
 				},
 			},
-			listerExpected{
+			getPodsForExpected{
 				err: nil,
 				k8sResInput: `
 apiVersion: apps/v1beta2

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -9,12 +9,22 @@ import (
 )
 
 const (
-	KubernetesDeployments            = "deployments"
-	KubernetesNamespaces             = "namespaces"
-	KubernetesPods                   = "pods"
-	KubernetesReplicationControllers = "replicationcontrollers"
-	KubernetesServices               = "services"
+	Deployments            = "deployments"
+	Namespaces             = "namespaces"
+	Pods                   = "pods"
+	ReplicationControllers = "replicationcontrollers"
+	Services               = "services"
 )
+
+// ResourceTypesToProxyLabels maps Kubernetes resource type names to keys
+// understood by the proxy, specifically Destination and Prometheus labels.
+var ResourceTypesToProxyLabels = map[string]string{
+	Deployments: "deployment",
+	Namespaces:  "namespace",
+	Pods:        "pod",
+	ReplicationControllers: "replication_controller",
+	Services:               "service",
+}
 
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
 	if string(extraPathStartingWithSlash[0]) != "/" {
@@ -60,15 +70,15 @@ func getConfig(fpath string) (*rest.Config, error) {
 func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error) {
 	switch friendlyName {
 	case "deploy", "deployment", "deployments":
-		return KubernetesDeployments, nil
+		return Deployments, nil
 	case "ns", "namespace", "namespaces":
-		return KubernetesNamespaces, nil
+		return Namespaces, nil
 	case "po", "pod", "pods":
-		return KubernetesPods, nil
+		return Pods, nil
 	case "rc", "replicationcontroller", "replicationcontrollers":
-		return KubernetesReplicationControllers, nil
+		return ReplicationControllers, nil
 	case "svc", "service", "services":
-		return KubernetesServices, nil
+		return Services, nil
 	}
 
 	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -82,10 +82,10 @@ func TestGetConfig(t *testing.T) {
 func TestCanonicalKubernetesNameFromFriendlyName(t *testing.T) {
 	t.Run("Returns canonical name for all known variants", func(t *testing.T) {
 		expectations := map[string]string{
-			"po":          KubernetesPods,
-			"pod":         KubernetesPods,
-			"deployment":  KubernetesDeployments,
-			"deployments": KubernetesDeployments,
+			"po":          Pods,
+			"pod":         Pods,
+			"deployment":  Deployments,
+			"deployments": Deployments,
 		}
 
 		for input, expectedName := range expectations {

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:a6e8221d as golang
+FROM gcr.io/runconduit/go-deps:ff0dc047 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:a6e8221d as golang
+FROM gcr.io/runconduit/go-deps:ff0dc047 as golang
 ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web


### PR DESCRIPTION
public-api and and tap were both using their own implementations of
the Kubernetes Informer/Lister APIs.

This change factors out all Informer/Lister usage into the Lister
module. This also introduces a new `Lister.GetObjects` method.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>