### PR TITLE
Make TapByResource output destination pod

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -145,9 +145,15 @@ func writeTapEventsToBuffer(tapClient pb.Api_TapClient, w *tabwriter.Writer) err
 }
 
 func renderTapEvent(event *common.TapEvent) string {
+	dst := util.AddressToString(event.GetDestination())
+	dstPod := event.GetDestinationMeta().GetLabels()["pod"]
+	if dstPod != "" {
+		dst = dstPod
+	}
+
 	flow := fmt.Sprintf("src=%s dst=%s",
 		util.AddressToString(event.GetSource()),
-		util.AddressToString(event.GetDestination()),
+		dst,
 	)
 
 	http := event.GetHttp()

--- a/cli/cmd/tap_by_resource_test.go
+++ b/cli/cmd/tap_by_resource_test.go
@@ -30,36 +30,42 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		event1 := createEvent(&common.TapEvent_Http{
-			Event: &common.TapEvent_Http_RequestInit_{
-				RequestInit: &common.TapEvent_Http_RequestInit{
-					Id: &common.TapEvent_Http_StreamId{
-						Base: 1,
+		event1 := createEvent(
+			&common.TapEvent_Http{
+				Event: &common.TapEvent_Http_RequestInit_{
+					RequestInit: &common.TapEvent_Http_RequestInit{
+						Id: &common.TapEvent_Http_StreamId{
+							Base: 1,
+						},
+						Authority: authority,
+						Path:      path,
 					},
-					Authority: authority,
-					Path:      path,
 				},
 			},
-		})
-		event2 := createEvent(&common.TapEvent_Http{
-			Event: &common.TapEvent_Http_ResponseEnd_{
-				ResponseEnd: &common.TapEvent_Http_ResponseEnd{
-					Id: &common.TapEvent_Http_StreamId{
-						Base: 1,
+			map[string]string{"pod": "my-pod"},
+		)
+		event2 := createEvent(
+			&common.TapEvent_Http{
+				Event: &common.TapEvent_Http_ResponseEnd_{
+					ResponseEnd: &common.TapEvent_Http_ResponseEnd{
+						Id: &common.TapEvent_Http_StreamId{
+							Base: 1,
+						},
+						Eos: &common.Eos{
+							End: &common.Eos_GrpcStatusCode{GrpcStatusCode: 666},
+						},
+						SinceRequestInit: &google_protobuf.Duration{
+							Seconds: 10,
+						},
+						SinceResponseInit: &google_protobuf.Duration{
+							Seconds: 100,
+						},
+						ResponseBytes: 1337,
 					},
-					Eos: &common.Eos{
-						End: &common.Eos_GrpcStatusCode{GrpcStatusCode: 666},
-					},
-					SinceRequestInit: &google_protobuf.Duration{
-						Seconds: 10,
-					},
-					SinceResponseInit: &google_protobuf.Duration{
-						Seconds: 100,
-					},
-					ResponseBytes: 1337,
 				},
 			},
-		})
+			map[string]string{},
+		)
 		mockApiClient := &public.MockConduitApiClient{}
 		mockApiClient.Api_TapByResourceClientToReturn = &public.MockApi_TapByResourceClient{
 			TapEventsToReturn: []common.TapEvent{event1, event2},

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -29,36 +29,42 @@ func TestRequestTapFromApi(t *testing.T) {
 		targetIp := "123.123.123.123"
 		mockApiClient := &public.MockConduitApiClient{}
 
-		event1 := createEvent(&common.TapEvent_Http{
-			Event: &common.TapEvent_Http_RequestInit_{
-				RequestInit: &common.TapEvent_Http_RequestInit{
-					Id: &common.TapEvent_Http_StreamId{
-						Base: 1,
+		event1 := createEvent(
+			&common.TapEvent_Http{
+				Event: &common.TapEvent_Http_RequestInit_{
+					RequestInit: &common.TapEvent_Http_RequestInit{
+						Id: &common.TapEvent_Http_StreamId{
+							Base: 1,
+						},
+						Authority: authority,
+						Path:      path,
 					},
-					Authority: authority,
-					Path:      path,
 				},
 			},
-		})
-		event2 := createEvent(&common.TapEvent_Http{
-			Event: &common.TapEvent_Http_ResponseEnd_{
-				ResponseEnd: &common.TapEvent_Http_ResponseEnd{
-					Id: &common.TapEvent_Http_StreamId{
-						Base: 1,
+			map[string]string{"pod": "my-pod"},
+		)
+		event2 := createEvent(
+			&common.TapEvent_Http{
+				Event: &common.TapEvent_Http_ResponseEnd_{
+					ResponseEnd: &common.TapEvent_Http_ResponseEnd{
+						Id: &common.TapEvent_Http_StreamId{
+							Base: 1,
+						},
+						Eos: &common.Eos{
+							End: &common.Eos_GrpcStatusCode{GrpcStatusCode: 666},
+						},
+						SinceRequestInit: &google_protobuf.Duration{
+							Seconds: 10,
+						},
+						SinceResponseInit: &google_protobuf.Duration{
+							Seconds: 100,
+						},
+						ResponseBytes: 1337,
 					},
-					Eos: &common.Eos{
-						End: &common.Eos_GrpcStatusCode{GrpcStatusCode: 666},
-					},
-					SinceRequestInit: &google_protobuf.Duration{
-						Seconds: 10,
-					},
-					SinceResponseInit: &google_protobuf.Duration{
-						Seconds: 100,
-					},
-					ResponseBytes: 1337,
 				},
 			},
-		})
+			map[string]string{},
+		)
 		mockApiClient.Api_TapClientToReturn = &public.MockApi_TapClient{
 			TapEventsToReturn: []common.TapEvent{event1, event2},
 		}
@@ -335,7 +341,7 @@ func TestEventToString(t *testing.T) {
 	})
 }
 
-func createEvent(event_http *common.TapEvent_Http) common.TapEvent {
+func createEvent(event_http *common.TapEvent_Http, dstMeta map[string]string) common.TapEvent {
 	event := common.TapEvent{
 		Source: &common.TcpAddress{
 			Ip: &common.IPAddress{
@@ -353,6 +359,9 @@ func createEvent(event_http *common.TapEvent_Http) common.TapEvent {
 		},
 		Event: &common.TapEvent_Http_{
 			Http: event_http,
+		},
+		DestinationMeta: &common.TapEvent_EndpointMeta{
+			Labels: dstMeta,
 		},
 	}
 	return event

--- a/cli/cmd/testdata/tap_busy_output.golden
+++ b/cli/cmd/testdata/tap_busy_output.golden
@@ -1,2 +1,2 @@
-req id=1:0 src=0.0.0.1:0 dst=0.0.0.9:0 :method=GET :authority=localhost :path=/some/path
+req id=1:0 src=0.0.0.1:0 dst=my-pod :method=GET :authority=localhost :path=/some/path
 end id=1:0 src=0.0.0.1:0 dst=0.0.0.9:0 grpc-status=Code(666) duration=0µs response-length=1337B


### PR DESCRIPTION
The TapByResource command now has access to destination labels from the
proxy, but was not outputting them on the cli.

Modify the TapByResource output to print the destination pod label,
rather than the ip, when available.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Note the `dst` output on `StreamResponseEnd` events:

```bash
$ bin/go-run cli tapByResource -n emojivoto deploy/web
req id=0:6725 src=10.1.7.237:35304 dst=10.1.7.236:80 :method=GET :authority=web-svc.emojivoto:80 :path=/api/list
req id=0:6726 src=10.1.7.236:60826 dst=10.1.7.238:8080 :method=POST :authority=emoji-svc.emojivoto:8080 :path=/emojivoto.v1.EmojiService/ListAll
rsp id=0:6726 src=10.1.7.236:60826 dst=10.1.7.238:8080 :status=200 latency=68100µs

end id=0:6726 src=10.1.7.236:60826 dst=emoji-55d5fbd844-slc7f grpc-status=OK duration=309µs response-length=2161B

rsp id=0:6725 src=10.1.7.237:35304 dst=10.1.7.236:80 :status=200 latency=138496µs
end id=0:6725 src=10.1.7.237:35304 dst=10.1.7.236:80 duration=590µs response-length=4558B
req id=0:6727 src=10.1.7.237:35304 dst=10.1.7.236:80 :method=GET :authority=web-svc.emojivoto:80 :path=/api/vote
req id=0:6728 src=10.1.7.236:60826 dst=10.1.7.238:8080 :method=POST :authority=emoji-svc.emojivoto:8080 :path=/emojivoto.v1.EmojiService/FindByShortcode
rsp id=0:6728 src=10.1.7.236:60826 dst=10.1.7.238:8080 :status=200 latency=2360µs

end id=0:6728 src=10.1.7.236:60826 dst=emoji-55d5fbd844-slc7f grpc-status=OK duration=30µs response-length=24B
```