### PR TITLE
Add destination labels to all relevant tap events

### DIFF
--- a/proxy/src/control/pb.rs
+++ b/proxy/src/control/pb.rs
@@ -77,10 +77,16 @@ impl event::StreamResponseFail {
             eos: Some(self.error.into()),
         };
 
+        let destination_meta = ctx.dst_labels()
+            .and_then(|b| b.borrow().clone())
+            .map(|d| tap_event::EndpointMeta {
+                labels: d.as_map().clone(),
+            });
+
         common::TapEvent {
             source: Some((&ctx.server.remote).into()),
             destination: Some((&ctx.client.remote).into()),
-            destination_meta: None,
+            destination_meta,
             event: Some(tap_event::Event::Http(tap_event::Http {
                 event: Some(tap_event::http::Event::ResponseEnd(end)),
             })),
@@ -103,10 +109,16 @@ impl event::StreamRequestFail {
             eos: Some(self.error.into()),
         };
 
+        let destination_meta = ctx.dst_labels()
+            .and_then(|b| b.borrow().clone())
+            .map(|d| tap_event::EndpointMeta {
+                labels: d.as_map().clone(),
+            });
+
         common::TapEvent {
             source: Some((&ctx.server.remote).into()),
             destination: Some((&ctx.client.remote).into()),
-            destination_meta: None,
+            destination_meta,
             event: Some(tap_event::Event::Http(tap_event::Http {
                 event: Some(tap_event::http::Event::ResponseEnd(end)),
             })),
@@ -137,10 +149,16 @@ impl<'a> TryFrom<&'a Event> for common::TapEvent {
                     path: ctx.uri.path().into(),
                 };
 
+                let destination_meta = ctx.dst_labels()
+                    .and_then(|b| b.borrow().clone())
+                    .map(|d| tap_event::EndpointMeta {
+                        labels: d.as_map().clone(),
+                    });
+
                 common::TapEvent {
                     source: Some((&ctx.server.remote).into()),
                     destination: Some((&ctx.client.remote).into()),
-                    destination_meta: None,
+                    destination_meta,
                     event: Some(tap_event::Event::Http(tap_event::Http {
                         event: Some(tap_event::http::Event::RequestInit(init)),
                     })),
@@ -158,10 +176,16 @@ impl<'a> TryFrom<&'a Event> for common::TapEvent {
                     http_status: u32::from(ctx.status.as_u16()),
                 };
 
+                let destination_meta = ctx.request.dst_labels()
+                    .and_then(|b| b.borrow().clone())
+                    .map(|d| tap_event::EndpointMeta {
+                        labels: d.as_map().clone(),
+                    });
+
                 common::TapEvent {
                     source: Some((&ctx.request.server.remote).into()),
                     destination: Some((&ctx.request.client.remote).into()),
-                    destination_meta: None,
+                    destination_meta,
                     event: Some(tap_event::Event::Http(tap_event::Http {
                         event: Some(tap_event::http::Event::ResponseInit(init)),
                     })),


### PR DESCRIPTION
The proxy incorrectly only added labels to response events. Destination
labels should be added to all tap events sent by the proxy.