### PR TITLE
proxy: Fix assertions in `metrics_compression` test

### DIFF
--- a/proxy/tests/telemetry.rs
+++ b/proxy/tests/telemetry.rs
@@ -1148,7 +1148,7 @@ fn metrics_compression() {
 
     for &encoding in encodings {
         assert_contains!(do_scrape(encoding),
-            "request_duration_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\"} 1");
+            "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",classification=\"success\",status_code=\"200\"} 1");
     }
 
     info!("client.get(/)");
@@ -1156,6 +1156,6 @@ fn metrics_compression() {
 
     for &encoding in encodings {
         assert_contains!(do_scrape(encoding),
-            "request_duration_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\"} 2");
+            "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",classification=\"success\",status_code=\"200\"} 2");
     }
 }


### PR DESCRIPTION
Fixes #846 

The proxy `metrics_compression` test contained an assertion that a compressed scrape contained the `request_duration_ms_count` metric. This was chosen completely arbitrarily, and was only intended as an assertion that metrics were updated between compressed scrapes. Unfortunately, that metric was removed in d9112abc933035ba48eabc1e9e5a81b4da0e367f, so when #665 merged to master, this test broke. CI didn't catch this since we don't build merges for PRs --- we should probably (re)enable this in Travis?

This PR fixes the test to assert on a metric that wasn't removed. Sorry for the ❌s!