### PR TITLE
proxy: Remove Arcs from metric labels

### DIFF
--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -40,7 +40,7 @@ pub struct ResponseLabels {
 }
 
 /// Labels describing a TCP connection
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TransportLabels {
     /// Was the transport opened in the inbound or outbound direction?
     direction: Direction,
@@ -48,11 +48,11 @@ pub struct TransportLabels {
     peer: Peer,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Peer { Src, Dst }
 
 /// Labels describing the end of a TCP connection
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TransportCloseLabels {
     /// Labels describing the TCP connection that closed.
     pub(super) transport: TransportLabels,

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -20,7 +20,7 @@ pub struct RequestLabels {
 
     /// The value of the `:authority` (HTTP/2) or `Host` (HTTP/1.1) header of
     /// the request.
-    authority: String,
+    authority: Option<http::uri::Authority>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -90,8 +90,7 @@ impl<'a> RequestLabels {
 
         let authority = req.uri
             .authority_part()
-            .map(http::uri::Authority::to_string)
-            .unwrap_or_else(String::new);
+            .cloned();
 
         RequestLabels {
             direction,
@@ -103,7 +102,12 @@ impl<'a> RequestLabels {
 
 impl fmt::Display for RequestLabels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "authority=\"{}\",{}", self.authority, self.direction)?;
+        match self.authority {
+            Some(ref authority) =>
+                write!(f, "authority=\"{}\",{}", authority, self.direction),
+            None =>
+                write!(f, "authority=\"\",{}", self.direction),
+        }?;
 
         if let Some(ref outbound) = self.outbound_labels {
             // leading comma added between the direction label and the

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -70,7 +70,7 @@ struct Metrics {
     request_total: Metric<Counter, RequestLabels>,
 
     response_total: Metric<Counter, ResponseLabels>,
-    response_latency: Metric<Histogram<latency::Ms>,  ResponseLabels>,
+    response_latency: Metric<Histogram<latency::Ms>, ResponseLabels>,
 
     tcp: TcpMetrics,
 

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -67,10 +67,10 @@ pub use self::record::Record;
 
 #[derive(Debug, Clone)]
 struct Metrics {
-    request_total: Metric<Counter, Arc<RequestLabels>>,
+    request_total: Metric<Counter, RequestLabels>,
 
-    response_total: Metric<Counter, Arc<ResponseLabels>>,
-    response_latency: Metric<Histogram<latency::Ms>, Arc<ResponseLabels>>,
+    response_total: Metric<Counter, ResponseLabels>,
+    response_latency: Metric<Histogram<latency::Ms>,  ResponseLabels>,
 
     tcp: TcpMetrics,
 
@@ -127,17 +127,17 @@ impl Metrics {
             )
             .as_secs();
 
-        let request_total = Metric::<Counter, Arc<RequestLabels>>::new(
+        let request_total = Metric::<Counter, RequestLabels>::new(
             "request_total",
             "A counter of the number of requests the proxy has received.",
         );
 
-        let response_total = Metric::<Counter, Arc<ResponseLabels>>::new(
+        let response_total = Metric::<Counter, ResponseLabels>::new(
             "response_total",
             "A counter of the number of responses the proxy has received.",
         );
 
-        let response_latency = Metric::<Histogram<latency::Ms>, Arc<ResponseLabels>>::new(
+        let response_latency = Metric::<Histogram<latency::Ms>, ResponseLabels>::new(
             "response_latency_ms",
             "A histogram of the total latency of a response. This is measured \
             from when the request headers are received to when the response \
@@ -154,26 +154,26 @@ impl Metrics {
     }
 
     fn request_total(&mut self,
-                     labels: &Arc<RequestLabels>)
+                     labels: RequestLabels)
                      -> &mut Counter {
         self.request_total.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Counter::default)
     }
 
     fn response_latency(&mut self,
-                        labels: &Arc<ResponseLabels>)
+                        labels: ResponseLabels)
                         -> &mut Histogram<latency::Ms> {
         self.response_latency.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Histogram::default)
     }
 
     fn response_total(&mut self,
-                      labels: &Arc<ResponseLabels>)
+                      labels: ResponseLabels)
                       -> &mut Counter {
         self.response_total.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Counter::default)
     }
 

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -79,14 +79,14 @@ struct Metrics {
 
 #[derive(Debug, Clone)]
 struct TcpMetrics {
-    open_total: Metric<Counter, Arc<TransportLabels>>,
-    close_total: Metric<Counter, Arc<TransportCloseLabels>>,
+    open_total: Metric<Counter, TransportLabels>,
+    close_total: Metric<Counter, TransportCloseLabels>,
 
-    connection_duration: Metric<Histogram<latency::Ms>, Arc<TransportCloseLabels>>,
-    open_connections: Metric<Gauge, Arc<TransportLabels>>,
+    connection_duration: Metric<Histogram<latency::Ms>, TransportCloseLabels>,
+    open_connections: Metric<Gauge, TransportLabels>,
 
-    write_bytes_total: Metric<Counter, Arc<TransportLabels>>,
-    read_bytes_total: Metric<Counter, Arc<TransportLabels>>,
+    write_bytes_total: Metric<Counter, TransportLabels>,
+    read_bytes_total: Metric<Counter, TransportLabels>,
 }
 
 #[derive(Debug, Clone)]
@@ -198,32 +198,32 @@ impl fmt::Display for Metrics {
 
 impl TcpMetrics {
     pub fn new() -> TcpMetrics {
-        let open_total = Metric::<Counter, Arc<TransportLabels>>::new(
+        let open_total = Metric::<Counter, TransportLabels>::new(
             "tcp_open_total",
             "A counter of the total number of transport connections.",
         );
 
-        let close_total = Metric::<Counter, Arc<TransportCloseLabels>>::new(
+        let close_total = Metric::<Counter, TransportCloseLabels>::new(
             "tcp_close_total",
             "A counter of the total number of transport connections.",
         );
 
-        let connection_duration = Metric::<Histogram<latency::Ms>, Arc<TransportCloseLabels>>::new(
+        let connection_duration = Metric::<Histogram<latency::Ms>, TransportCloseLabels>::new(
             "tcp_connection_duration_ms",
             "A histogram of the duration of the lifetime of connections, in milliseconds",
         );
 
-        let open_connections = Metric::<Gauge, Arc<TransportLabels>>::new(
+        let open_connections = Metric::<Gauge, TransportLabels>::new(
             "tcp_open_connections",
             "A gauge of the number of transport connections currently open.",
         );
 
-        let read_bytes_total = Metric::<Counter, Arc<TransportLabels>>::new(
+        let read_bytes_total = Metric::<Counter, TransportLabels>::new(
             "tcp_read_bytes_total",
             "A counter of the total number of recieved bytes."
         );
 
-        let write_bytes_total = Metric::<Counter, Arc<TransportLabels>>::new(
+        let write_bytes_total = Metric::<Counter, TransportLabels>::new(
             "tcp_write_bytes_total",
             "A counter of the total number of sent bytes."
         );
@@ -238,39 +238,39 @@ impl TcpMetrics {
         }
     }
 
-    fn open_total(&mut self, labels: &Arc<TransportLabels>) -> &mut Counter {
+    fn open_total(&mut self, labels: TransportLabels) -> &mut Counter {
         self.open_total.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Default::default)
     }
 
-    fn close_total(&mut self, labels: &Arc<TransportCloseLabels>) -> &mut Counter {
+    fn close_total(&mut self, labels: TransportCloseLabels) -> &mut Counter {
         self.close_total.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Counter::default)
     }
 
-    fn connection_duration(&mut self, labels: &Arc<TransportCloseLabels>) -> &mut Histogram<latency::Ms> {
+    fn connection_duration(&mut self, labels: TransportCloseLabels) -> &mut Histogram<latency::Ms> {
         self.connection_duration.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Histogram::default)
     }
 
-    fn open_connections(&mut self, labels: &Arc<TransportLabels>) -> &mut Gauge {
+    fn open_connections(&mut self, labels: TransportLabels) -> &mut Gauge {
         self.open_connections.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Gauge::default)
     }
 
-    fn write_bytes_total(&mut self, labels: &Arc<TransportLabels>) -> &mut Counter {
+    fn write_bytes_total(&mut self, labels: TransportLabels) -> &mut Counter {
         self.write_bytes_total.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Counter::default)
     }
 
-    fn read_bytes_total(&mut self, labels: &Arc<TransportLabels>) -> &mut Counter {
+    fn read_bytes_total(&mut self, labels: TransportLabels) -> &mut Counter {
         self.read_bytes_total.values
-            .entry(labels.clone())
+            .entry(labels)
             .or_insert_with(Counter::default)
     }
 }

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -53,10 +53,7 @@ impl Record {
 
             Event::StreamResponseEnd(ref res, ref end) => {
                 self.update(|metrics| {
-                    let labels = ResponseLabels::new(
-                        res,
-                        end.grpc_status,
-                    );
+                    let labels = ResponseLabels::new(res, end.grpc_status);
                     metrics.response_total(labels.clone()).incr();
                     metrics.response_latency(labels).add(end.since_request_open);
                 });

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -40,56 +40,54 @@ impl Record {
             },
 
             Event::StreamRequestFail(ref req, _) => {
-                let labels = Arc::new(RequestLabels::new(req));
                 self.update(|metrics| {
-                    metrics.request_total(&labels).incr();
+                    metrics.request_total(RequestLabels::new(req)).incr();
                 })
             },
 
             Event::StreamRequestEnd(ref req, _) => {
-                let labels = Arc::new(RequestLabels::new(req));
                 self.update(|metrics| {
-                    metrics.request_total(&labels).incr();
+                    metrics.request_total(RequestLabels::new(req)).incr();
                 })
             },
 
             Event::StreamResponseEnd(ref res, ref end) => {
-                let labels = Arc::new(ResponseLabels::new(
-                    res,
-                    end.grpc_status,
-                ));
                 self.update(|metrics| {
-                    metrics.response_total(&labels).incr();
-                    metrics.response_latency(&labels).add(end.since_request_open);
+                    let labels = ResponseLabels::new(
+                        res,
+                        end.grpc_status,
+                    );
+                    metrics.response_total(labels.clone()).incr();
+                    metrics.response_latency(labels).add(end.since_request_open);
                 });
             },
 
             Event::StreamResponseFail(ref res, ref fail) => {
-                // TODO: do we care about the failure's error code here?
-                let labels = Arc::new(ResponseLabels::fail(res));
                 self.update(|metrics| {
-                    metrics.response_total(&labels).incr();
-                    metrics.response_latency(&labels).add(fail.since_request_open);
+                    // TODO: do we care about the failure's error code here?
+                    let labels = ResponseLabels::fail(res);
+                    metrics.response_total(labels.clone()).incr();
+                    metrics.response_latency(labels).add(fail.since_request_open);
                 });
             },
 
             Event::TransportOpen(ref ctx) => {
-                let labels = Arc::new(TransportLabels::new(ctx));
+                let labels = TransportLabels::new(ctx);
                 self.update(|metrics| {
-                    metrics.tcp().open_total(&labels).incr();
-                    metrics.tcp().open_connections(&labels).incr();
+                    metrics.tcp().open_total(labels).incr();
+                    metrics.tcp().open_connections(labels).incr();
                 })
             },
 
             Event::TransportClose(ref ctx, ref close) => {
-                let labels = Arc::new(TransportLabels::new(ctx));
-                let close_labels = Arc::new(TransportCloseLabels::new(ctx, close));
+                let labels = TransportLabels::new(ctx);
+                let close_labels = TransportCloseLabels::new(ctx, close);
                 self.update(|metrics| {
-                    *metrics.tcp().write_bytes_total(&labels) += close.tx_bytes as u64;
-                    *metrics.tcp().read_bytes_total(&labels) += close.rx_bytes as u64;
+                    *metrics.tcp().write_bytes_total(labels) += close.tx_bytes as u64;
+                    *metrics.tcp().read_bytes_total(labels) += close.rx_bytes as u64;
 
-                    metrics.tcp().connection_duration(&close_labels).add(close.duration);
-                    metrics.tcp().close_total(&close_labels).incr();
+                    metrics.tcp().connection_duration(close_labels).add(close.duration);
+                    metrics.tcp().close_total(close_labels).incr();
 
                     let metrics = metrics.tcp().open_connections.values.get_mut(&labels);
                     debug_assert!(metrics.is_some());


### PR DESCRIPTION
This PR removes the `Arc`s from the various label types in the proxy's 
`metrics` modules. This should make the write side of the metrics code
much more efficient (and makes the code much simpler! :D).

This change was particularly easy to implement for the TCP `TransportLabels`
and `TransportCloseLabels`, which consisted of only `struct`s and `enum`s,
and could easily be changed to derive `Copy`. 

For protocol-level `RequestLabels`, the request's authority was a `String`,
which still needs to be reference-counted, as the overhead of cloning `String`s
is almost certainly worse than that added by ref-counting. However, rather than
adding an additional `Arc<str>`, I changed `RequestLabels` to store the 
authority as a `http::uri::Authority`, which is backed by a `ByteStr` and thus
already ref-counted. Now, when constructing `RequestLabels`, we just take 
another reference to the `Authority` already stored in the request context.
Since `Authority` implements `fmt::Display` already, formatting the labels 
still works.

`ResponseLabels` already store the `DstLabels` string in an `Arc`, so no
additional changes there were necessary. By removing the outer `Arc` around
`ResponseLabels`, we now only have to ref-count the portion of the label type
that would actually be inefficient to clone.

@olix0r ran the benchmarks from #874 against this branch, and it seems to be 
a small but noticeable improvement:
```
test record_many_dsts        ... bench:     151,076 ns/iter (+/- 182,151)
test record_one_conn_request ... bench:       1,599 ns/iter (+/- 209)
test record_response_end     ... bench:         676 ns/iter (+/- 144)
```

before:
```
test record_many_dsts        ... bench:     158,403 ns/iter (+/- 130,241)
test record_one_conn_request ... bench:       1,823 ns/iter (+/- 1,408)
test record_response_end     ... bench:         547 ns/iter (+/- 70)
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>