### PR TITLE
proxy: Make each metric type responsible for formatting

### DIFF
--- a/proxy/src/telemetry/metrics/counter.rs
+++ b/proxy/src/telemetry/metrics/counter.rs
@@ -1,5 +1,8 @@
-use std::{fmt, ops};
+use std::fmt::{self, Display};
 use std::num::Wrapping;
+use std::ops;
+
+use super::FmtMetric;
 
 /// A Prometheus counter is represented by a `Wrapping` unsigned 64-bit int.
 ///
@@ -53,8 +56,26 @@ impl ops::AddAssign<u64> for Counter {
     }
 }
 
-impl fmt::Display for Counter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+impl ops::AddAssign<Self> for Counter {
+    fn add_assign(&mut self, Counter(rhs): Self) {
+        (*self).0 += rhs
+    }
+}
+
+impl FmtMetric for Counter {
+    fn fmt_metric<N: Display>(&self, f: &mut fmt::Formatter, name: N) -> fmt::Result {
+        writeln!(f, "{} {}", name, self.0)
+    }
+
+    fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
+    where
+        L: Display,
+        N: Display,
+    {
+        writeln!(f, "{name}{{{labels}}} {value}",
+            name = name,
+            labels = labels,
+            value = self.0,
+        )
     }
 }

--- a/proxy/src/telemetry/metrics/gauge.rs
+++ b/proxy/src/telemetry/metrics/gauge.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use std::fmt::{self, Display};
+
+use super::FmtMetric;
 
 /// An instaneous metric value.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -36,8 +38,20 @@ impl Into<u64> for Gauge {
     }
 }
 
-impl fmt::Display for Gauge {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+impl FmtMetric for Gauge {
+    fn fmt_metric<N: Display>(&self, f: &mut fmt::Formatter, name: N) -> fmt::Result {
+        writeln!(f, "{} {}", name, self.0)
+    }
+
+    fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
+    where
+        N: Display,
+        L: Display,
+    {
+        writeln!(f, "{name}{{{labels}}} {value}",
+            name = name,
+            labels = labels,
+            value = self.0,
+        )
     }
 }

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -57,9 +57,16 @@ pub use self::labels::DstLabels;
 pub use self::record::Record;
 pub use self::serve::Serve;
 
+/// Writes a metric in prometheus-formatted output.
+///
+/// This trait is implemented by `Counter`, `Gauge`, and `Histogram` to account for the
+/// differences in formatting each type of metric. Specifically, `Histogram` formats a
+/// counter for each bucket, as well as a count and total sum.
 trait FmtMetric {
+    /// Writes a metric with the given name and no labels.
     fn fmt_metric<N: Display>(&self, f: &mut fmt::Formatter, name: N) -> fmt::Result;
 
+    /// Writes a metric with the given name and labels.
     fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
     where
         N: Display,


### PR DESCRIPTION
In order to set up for a refactor that removes the `Metric` type, the
`FmtMetric` trait--implemented by `Counter`, `Gauge`, and
`Histogram`--is introduced to push prometheus formatting down into each
type.

With this change, the `Histogram` type now relies on `Counter` (and its
metric formatting) more heavily.