### PR TITLE
proxy: Do not run tests in proxy Dockerfile

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -337,7 +337,7 @@ bin/go-run controller/cmd/proxy-api
 The `bin/docker-build-proxy` script builds the proxy:
 
 ```bash
-DOCKER_TRACE=1 PROXY_UNOPTIMIZED=1 PROXY_SKIP_TESTS=1 bin/docker-build-proxy
+DOCKER_TRACE=1 PROXY_UNOPTIMIZED=1 bin/docker-build-proxy
 ```
 
 It supports two environment variables:
@@ -345,8 +345,6 @@ It supports two environment variables:
 - `PROXY_UNOPTIMIZED` -- When set and non-empty, produces unoptimized build artifacts,
   which reduces build times at the expense of runtime performance. Changing this will
   likely invalidate a substantial portion of Docker's cache.
-- `PROXY_SKIP_TESTS` -- When set and non-empty, prevents the proxy's tests from being run
-  during the build. Changing this setting will not invalidate Docker's cache.
 
 # Dependencies
 

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,5 +14,4 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 docker_build proxy "$(head_root_tag)" $rootdir/proxy/Dockerfile \
-    --build-arg="PROXY_SKIP_TESTS=${PROXY_SKIP_TESTS:-}" \
     --build-arg="PROXY_UNOPTIMIZED=${PROXY_UNOPTIMIZED:-}"

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -3,9 +3,6 @@
 # When PROXY_UNOPTIMIZED is set and not empty, unoptimized rust artifacts are produced.
 # This reduces build time and produces binaries with debug symbols, at the expense of
 # runtime perforamnce.
-#
-# When PROXY_SKIP_TESTS is set and not empty, tests are not run. Otherwise, tests are run
-# against either unoptimized or optimized proxy code, according to PROXY_UNOPTIMIZED.
 
 ARG RUST_IMAGE=rust:1.25.0
 ARG RUNTIME_IMAGE=gcr.io/runconduit/base:2017-10-30.01
@@ -56,13 +53,7 @@ RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
     then cargo build -p conduit-proxy --bin conduit-proxy --frozen ; \
     else cargo build -p conduit-proxy --bin conduit-proxy --frozen --release ; \
     fi
-ARG PROXY_SKIP_TESTS
-RUN if [ -n "$PROXY_SKIP_TESTS" ]; \
-    then echo "tests skipped" ; \
-    elif [ -n "$PROXY_UNOPTIMIZED" ]; \
-    then (cd proxy && cargo test --frozen --no-default-features) ; \
-    else (cd proxy && cargo test --frozen --release --no-default-features) ; \
-    fi
+
 RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
     then mv target/debug/conduit-proxy   target/conduit-proxy ; \
     else mv target/release/conduit-proxy target/conduit-proxy ; \


### PR DESCRIPTION
The proxy Dockerfile includes test execution. While the intentions of
this are good, it has unintended consequences: we can ship code linked
with test dependencies.

Because we have other means for testing proxy code (cargo, locally; and
CI runs tests outside of Docker), it is fine to remove these tests.