### PR TITLE
proxy: add `bench` tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,12 @@ jobs:
         - (cd proxy && cargo test --locked --no-default-features)
 
     - language: rust
-      # Run proxy benchmarks. Requires nightly. Failures are non-fatal
+      # Run proxy benchmarks in development mode. Requires nightly.
+      # Failures are not fatal.
       rust: nightly
       cache: cargo
       script:
-        - (cd proxy && cargo bench --locked --no-default-features)
+        - (cd proxy && cargo test --benches --locked --no-default-features)
 
     - language: go
       # Quote the version number to avoid parsing issues like

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,7 @@ jobs:
 
   allow_failures:
     - rust: nightly
-
+  fast_finish: true
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ jobs:
       rust: stable
       cache: cargo
       script:
-        - (cd proxy && cargo test --locked --no-default-features --release)
+        - (cd proxy && cargo test --locked --no-default-features)
 
-    # Compile the application and run tests.
     - language: rust
+      # Run proxy benchmarks. Requires nightly. Failures are non-fatal
       rust: nightly
       cache: cargo
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       rust: nightly
       cache: cargo
       script:
-        - (cd proxy && rustup run nightly cargo bench --locked --no-default-features)
+        - (cd proxy && cargo bench --locked --no-default-features)
 
     - language: go
       # Quote the version number to avoid parsing issues like

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,14 @@ jobs:
       rust: stable
       cache: cargo
       script:
-        - (cd proxy && cargo test --locked --no-default-features)
+        - (cd proxy && cargo test --locked --no-default-features --release)
+
+    # Compile the application and run tests.
+    - language: rust
+      rust: nightly
+      cache: cargo
+      script:
+        - (cd proxy && rustup run nightly cargo bench --locked --no-default-features)
 
     - language: go
       # Quote the version number to avoid parsing issues like
@@ -128,6 +135,10 @@ jobs:
         - bin/docker-retag-all $CONDUIT_TAG master && bin/docker-push master
         - target/cli/linux/conduit install --conduit-version=$CONDUIT_TAG |tee conduit.yml
         - kubectl -n conduit apply -f conduit.yml --prune --selector='conduit.io/control-plane-component'
+
+  allow_failures:
+    - rust: nightly
+
 
 notifications:
   email:

--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -155,8 +155,6 @@ fn record_many_dsts(b: &mut Bencher) {
     let server = server(&proxy);
     let server_transport = Arc::new(ctx::transport::Ctx::Server(server.clone()));
 
-    panic!("fail test intentionally");
-
     use Event::*;
     let mut events = Vec::new();
     events.push(TransportOpen(server_transport.clone()));

--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -155,6 +155,8 @@ fn record_many_dsts(b: &mut Bencher) {
     let server = server(&proxy);
     let server_transport = Arc::new(ctx::transport::Ctx::Server(server.clone()));
 
+    panic!("fail test intentionally");
+
     use Event::*;
     let mut events = Vec::new();
     events.push(TransportOpen(server_transport.clone()));


### PR DESCRIPTION
The new bench tests require Rust `nightly`, which can break on any given day.

This change adds `bench` tests to CI, but makes failures non-fatal.