### PR TITLE
proxy: Fix Tap ID generation

### DIFF
--- a/proxy/src/control/observe.rs
+++ b/proxy/src/control/observe.rs
@@ -47,7 +47,7 @@ impl server::Tap for Observe {
     type ObserveFuture = future::FutureResult<Response<Self::ObserveStream>, grpc::Error>;
 
     fn observe(&mut self, req: grpc::Request<ObserveRequest>) -> Self::ObserveFuture {
-        if self.next_id.load(Ordering::SeqCst) == ::std::usize::MAX {
+        if self.next_id.load(Ordering::Acquire) == ::std::usize::MAX {
             return future::err(grpc::Error::Grpc(grpc::Status::INTERNAL));
         }
 
@@ -65,7 +65,7 @@ impl server::Tap for Observe {
 
         let tap_id = match self.taps.lock() {
             Ok(mut taps) => {
-                let tap_id = self.next_id.fetch_add(1, Ordering::SeqCst);
+                let tap_id = self.next_id.fetch_add(1, Ordering::AcqRel);
                 let _ = (*taps).insert(tap_id, tap);
                 tap_id
             }

--- a/proxy/src/control/observe.rs
+++ b/proxy/src/control/observe.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::{future, Poll, Stream};
 use futures_mpsc_lossy;
@@ -14,7 +15,7 @@ use telemetry::tap::{Tap, Taps};
 
 #[derive(Clone, Debug)]
 pub struct Observe {
-    next_id: usize,
+    next_id: Arc<AtomicUsize>,
     taps: Arc<Mutex<Taps>>,
     tap_capacity: usize,
 }
@@ -32,7 +33,7 @@ impl Observe {
         let taps = Arc::new(Mutex::new(Taps::default()));
 
         let observe = Observe {
-            next_id: 0,
+            next_id: Arc::new(AtomicUsize::new(0)),
             tap_capacity,
             taps: taps.clone(),
         };
@@ -46,7 +47,7 @@ impl server::Tap for Observe {
     type ObserveFuture = future::FutureResult<Response<Self::ObserveStream>, grpc::Error>;
 
     fn observe(&mut self, req: grpc::Request<ObserveRequest>) -> Self::ObserveFuture {
-        if self.next_id == ::std::usize::MAX {
+        if self.next_id.load(Ordering::SeqCst) == ::std::usize::MAX {
             return future::err(grpc::Error::Grpc(grpc::Status::INTERNAL));
         }
 
@@ -64,8 +65,7 @@ impl server::Tap for Observe {
 
         let tap_id = match self.taps.lock() {
             Ok(mut taps) => {
-                let tap_id = self.next_id;
-                self.next_id += 1;
+                let tap_id = self.next_id.fetch_add(1, Ordering::SeqCst);
                 let _ = (*taps).insert(tap_id, tap);
                 tap_id
             }


### PR DESCRIPTION
The proxy's tap server assigns a sequential numeric ID to each inbound
Tap request to assist tap lifecycle management.

The server implementation keeps a local counter to keep track of tap
IDs. However, this implementation is cloned for each individual tap
requests, so `0` the only tap ID ever used.

This change moves the Tap ID to be stored in a shared atomic integer.

In a followup, we might consider removing tap IDs entirely.