### PR TITLE
proxy: Do not build Arbitrary types in Docker

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -42,8 +42,8 @@ COPY proto/proxy proto/proxy
 COPY proto/common proto/common
 COPY proxy/controller-grpc proxy/controller-grpc
 RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
-    then cargo build -p conduit-proxy-controller-grpc --features=arbitrary --frozen ; \
-    else cargo build -p conduit-proxy-controller-grpc --features=arbitrary --frozen --release ; \
+    then cargo build -p conduit-proxy-controller-grpc --frozen ; \
+    else cargo build -p conduit-proxy-controller-grpc --frozen --release ; \
     fi
 
 # Build the proxy binary using pre-built dependencies.


### PR DESCRIPTION
When the proxy's Dockerfile ran tests, it was necessary to build
Arbitrary types for quickchecking protobuf types.

Now that tests have been disabled, this optional set of dependencies is
no longer required.

Relates to 882.