### PR TITLE
Add unit tests for `metrics::record`

### DIFF
--- a/proxy/src/telemetry/metrics/histogram.rs
+++ b/proxy/src/telemetry/metrics/histogram.rs
@@ -128,25 +128,23 @@ impl<V: Into<u64>> Histogram<V> {
     #[cfg(test)]
     pub fn assert_lt_exactly(&self, value: u64, exactly: u64) -> &Self {
         for (i, &bucket) in self.bounds.0.iter().enumerate() {
-            if let Bucket::Le(ceiling) = bucket {
+            let ceiling = match bucket {
+                Bucket::Le(c) => c,
+                Bucket::Inf => break,
+            };
+            let next = self.bounds.0.get(i + 1)
+                .expect("Bucket::Le may not be the last in `bounds`!");
 
-                let next = self.bounds.0.get(i + 1)
-                    .expect("Bucket::Le may not be the last in `bounds`!");
-
-                if value <= ceiling || next >= &value  {
-                    break;
-                }
-
-                let count: u64 = self.buckets[i].into();
-                assert_eq!(
-                    count, exactly,
-                    "bucket={:?}; value={:?};",
-                    bucket, value,
-                );
-
-            } else {
+            if value <= ceiling || next >= &value  {
                 break;
             }
+
+            let count: u64 = self.buckets[i].into();
+            assert_eq!(
+                count, exactly,
+                "bucket={:?}; value={:?};",
+                bucket, value,
+            );
         }
         self
     }

--- a/proxy/src/telemetry/metrics/histogram.rs
+++ b/proxy/src/telemetry/metrics/histogram.rs
@@ -113,7 +113,7 @@ impl<V: Into<u64>> Histogram<V> {
 
     /// Assert the bucket containing `le` has a count of exactly `exactly`.
     #[cfg(test)]
-    pub fn assert_bucket_exactly(&self, le: u64, exactly: u64) {
+    pub fn assert_bucket_exactly(&self, le: u64, exactly: u64) -> &Self {
         for (&bucket, &count) in self {
             let is_le = if let Bucket::Le(ceiling) = bucket {
                 le <= ceiling
@@ -124,17 +124,19 @@ impl<V: Into<u64>> Histogram<V> {
                 let count: u64 = count.into();
                 assert_eq!(
                     count, exactly,
-                    "le={:?}; bucket={:?};", le, bucket
+                    "le={:?}; bucket={:?}; buckets={:#?};",
+                    le, bucket, self.buckets,
                 );
                 break;
             }
         }
+        self
     }
 
     /// Assert all buckets less than the one containing `value` have
     /// counts of exactly `exactly`.
     #[cfg(test)]
-    pub fn assert_lt_exactly(&self, value: u64, exactly: u64) {
+    pub fn assert_lt_exactly(&self, value: u64, exactly: u64) -> &Self {
         for (i, &bucket) in self.bounds.0.iter().enumerate() {
             if let Bucket::Le(ceiling) = bucket {
 
@@ -161,12 +163,13 @@ impl<V: Into<u64>> Histogram<V> {
                 break;
             }
         }
+        self
     }
 
     /// Assert all buckets greater than the one containing `value` have
     /// counts of exactly `exactly`.
     #[cfg(test)]
-    pub fn assert_gt_exactly(&self, value: u64, exactly: u64) {
+    pub fn assert_gt_exactly(&self, value: u64, exactly: u64) -> &Self {
         let mut past_le = false;
         for (&bucket, &count) in self {
             if let Bucket::Le(ceiling) = bucket {
@@ -189,6 +192,7 @@ impl<V: Into<u64>> Histogram<V> {
                 );
             }
         }
+        self
     }
 
 }
@@ -351,13 +355,13 @@ mod tests {
             let mut hist = Histogram::<u64>::new(&BOUNDS);
             hist.add(obs);
             // The bucket containing `obs` must have count 1.
-            hist.assert_bucket_exactly(obs, 1);
-            // All buckets less than the one containing `obs` must have
-            // counts of exactly 0.
-            hist.assert_lt_exactly(obs, 0);
-            // All buckets greater than the one containing `obs` must have
-            // counts of exactly 0.
-            hist.assert_gt_exactly(obs, 0);
+            hist.assert_bucket_exactly(obs, 1)
+                // All buckets less than the one containing `obs` must have
+                // counts of exactly 0.
+                .assert_lt_exactly(obs, 0)
+                // All buckets greater than the one containing `obs` must
+                // have counts of exactly 0.
+                .assert_gt_exactly(obs, 0);
             true
         }
 

--- a/proxy/src/telemetry/metrics/histogram.rs
+++ b/proxy/src/telemetry/metrics/histogram.rs
@@ -88,6 +88,109 @@ impl<V: Into<u64>> Histogram<V> {
         self.buckets[idx].incr();
         self.sum += value;
     }
+
+    // ===== Test-only methods to help with assertions about histograms. =====
+
+    /// Assert the bucket containing `le` has a count of at least `at_least`.
+    #[cfg(test)]
+    pub fn assert_bucket_at_least(&self, le: u64, at_least: u64) {
+        for (&bucket, &count) in self {
+            let is_le = if let Bucket::Le(ceiling) = bucket {
+                le <= ceiling
+            } else {
+                true
+            };
+            if is_le {
+                let count: u64 = count.into();
+                assert!(
+                    count >= at_least,
+                    "le={:?}; bucket={:?};", le, bucket
+                );
+                break;
+            }
+        }
+    }
+
+    /// Assert the bucket containing `le` has a count of exactly `exactly`.
+    #[cfg(test)]
+    pub fn assert_bucket_exactly(&self, le: u64, exactly: u64) {
+        for (&bucket, &count) in self {
+            let is_le = if let Bucket::Le(ceiling) = bucket {
+                le <= ceiling
+            } else {
+                true
+            };
+            if is_le {
+                let count: u64 = count.into();
+                assert_eq!(
+                    count, exactly,
+                    "le={:?}; bucket={:?};", le, bucket
+                );
+                break;
+            }
+        }
+    }
+
+    /// Assert all buckets less than the one containing `value` have
+    /// counts of exactly `exactly`.
+    #[cfg(test)]
+    pub fn assert_lt_exactly(&self, value: u64, exactly: u64) {
+        for (i, &bucket) in self.bounds.0.iter().enumerate() {
+            if let Bucket::Le(ceiling) = bucket {
+
+                let next = self.bounds.0.get(i + 1)
+                    .expect("Bucket::Le may not be the last in `bounds`!");
+                let le_next = if let &Bucket::Le(next_ceiling) = next {
+                    value <= next_ceiling
+                } else {
+                    true
+                };
+
+                if value <= ceiling || le_next {
+                    break;
+                }
+
+                let count: u64 = self.buckets[i].into();
+                assert_eq!(
+                    count, exactly,
+                    "bucket={:?}; value={:?}; le_next={:?};",
+                    bucket, value, le_next
+                );
+
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Assert all buckets greater than the one containing `value` have
+    /// counts of exactly `exactly`.
+    #[cfg(test)]
+    pub fn assert_gt_exactly(&self, value: u64, exactly: u64) {
+        let mut past_le = false;
+        for (&bucket, &count) in self {
+            if let Bucket::Le(ceiling) = bucket {
+                if value > ceiling {
+                    continue;
+                }
+
+                if value <= ceiling && !past_le {
+                    past_le = true;
+                    continue;
+                }
+            }
+
+            if past_le {
+                let count: u64 = count.into();
+                assert_eq!(
+                    count, exactly,
+                    "bucket={:?}; value={:?};",
+                    bucket, value,
+                );
+            }
+        }
+    }
+
 }
 
 impl<'a, V: Into<u64>> IntoIterator for &'a Histogram<V> {
@@ -193,7 +296,6 @@ mod tests {
     use std::u64;
     use std::collections::HashMap;
 
-    const NUM_BUCKETS: usize = 47;
     static BOUNDS: &'static Bounds = &Bounds(&[
         Bucket::Le(10),
         Bucket::Le(20),
@@ -248,17 +350,14 @@ mod tests {
         fn bucket_incremented(obs: u64) -> bool {
             let mut hist = Histogram::<u64>::new(&BOUNDS);
             hist.add(obs);
-            let incremented_bucket = &BOUNDS.0.iter()
-                .position(|bucket| match *bucket {
-                    Bucket::Le(ceiling) => obs <= ceiling,
-                    Bucket::Inf => true,
-                })
-                .unwrap();
-            for i in 0..NUM_BUCKETS {
-                let expected = if i == *incremented_bucket { 1 } else { 0 };
-                let count: u64 = hist.buckets[i].into();
-                assert_eq!(count, expected, "(for bucket <= {})", BOUNDS.0[i]);
-            }
+            // The bucket containing `obs` must have count 1.
+            hist.assert_bucket_exactly(obs, 1);
+            // All buckets less than the one containing `obs` must have
+            // counts of exactly 0.
+            hist.assert_lt_exactly(obs, 0);
+            // All buckets greater than the one containing `obs` must have
+            // counts of exactly 0.
+            hist.assert_gt_exactly(obs, 0);
             true
         }
 

--- a/proxy/src/telemetry/metrics/http.rs
+++ b/proxy/src/telemetry/metrics/http.rs
@@ -23,8 +23,8 @@ pub(super) type ResponseScopes = Scopes<ResponseLabels, Stamped<ResponseMetrics>
 
 #[derive(Debug, Default)]
 pub struct ResponseMetrics {
-    total: Counter,
-    latency: Histogram<latency::Ms>,
+    pub(super) total: Counter,
+    pub(super) latency: Histogram<latency::Ms>,
 }
 
 // ===== impl RequestScopes =====

--- a/proxy/src/telemetry/metrics/http.rs
+++ b/proxy/src/telemetry/metrics/http.rs
@@ -55,7 +55,6 @@ impl RequestMetrics {
         self.total.incr();
     }
 
-    /// Test-only accessor for `total`.
     #[cfg(test)]
     pub(super) fn total(&self) -> u64 {
         self.total.into()
@@ -98,13 +97,11 @@ impl ResponseMetrics {
         self.latency.add(duration);
     }
 
-    /// Test-only accessor for `total`.
     #[cfg(test)]
     pub(super) fn total(&self) -> u64 {
         self.total.into()
     }
 
-    /// Test-only accessor for `latency`.
     #[cfg(test)]
     pub(super) fn latency(&self) -> &Histogram<latency::Ms> {
         &self.latency

--- a/proxy/src/telemetry/metrics/http.rs
+++ b/proxy/src/telemetry/metrics/http.rs
@@ -16,7 +16,7 @@ pub(super) type RequestScopes = Scopes<RequestLabels, Stamped<RequestMetrics>>;
 
 #[derive(Debug, Default)]
 pub(super) struct RequestMetrics {
-    total: Counter,
+    pub(super) total: Counter,
 }
 
 pub(super) type ResponseScopes = Scopes<ResponseLabels, Stamped<ResponseMetrics>>;

--- a/proxy/src/telemetry/metrics/http.rs
+++ b/proxy/src/telemetry/metrics/http.rs
@@ -16,15 +16,15 @@ pub(super) type RequestScopes = Scopes<RequestLabels, Stamped<RequestMetrics>>;
 
 #[derive(Debug, Default)]
 pub(super) struct RequestMetrics {
-    pub(super) total: Counter,
+    total: Counter,
 }
 
 pub(super) type ResponseScopes = Scopes<ResponseLabels, Stamped<ResponseMetrics>>;
 
 #[derive(Debug, Default)]
 pub struct ResponseMetrics {
-    pub(super) total: Counter,
-    pub(super) latency: Histogram<latency::Ms>,
+    total: Counter,
+    latency: Histogram<latency::Ms>,
 }
 
 // ===== impl RequestScopes =====
@@ -53,6 +53,12 @@ impl fmt::Display for RequestScopes {
 impl RequestMetrics {
     pub fn end(&mut self) {
         self.total.incr();
+    }
+
+    /// Test-only accessor for `total`.
+    #[cfg(test)]
+    pub(super) fn total(&self) -> u64 {
+        self.total.into()
     }
 }
 
@@ -90,5 +96,17 @@ impl ResponseMetrics {
     pub fn end(&mut self, duration: Duration) {
         self.total.incr();
         self.latency.add(duration);
+    }
+
+    /// Test-only accessor for `total`.
+    #[cfg(test)]
+    pub(super) fn total(&self) -> u64 {
+        self.total.into()
+    }
+
+    /// Test-only accessor for `latency`.
+    #[cfg(test)]
+    pub(super) fn latency(&self) -> &Histogram<latency::Ms> {
+        &self.latency
     }
 }

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -87,7 +87,7 @@ impl Record {
 mod test {
     use telemetry::{
         event,
-        metrics::{self, histogram, labels},
+        metrics::{self, labels},
         Event,
     };
     use ctx::{self, test_util::* };
@@ -134,17 +134,12 @@ mod test {
                 .get(&labels)
                 .expect("scope should be some after event");
 
-            assert_eq!(u64::from(scope.total), 1);
+            let total: u64 = scope.total.into();
+            assert_eq!(total, 1);
 
-            for (le, count) in &scope.latency {
-                if let &histogram::Bucket::Le(le) = le {
-                    if le >= 300 {
-                        assert_eq!(u64::from(count), 1);
-                    } else {
-                        assert_eq!(u64::from(count), 0);
-                    }
-                }
-            }
+            scope.latency.assert_bucket_exactly(300, 1);
+            scope.latency.assert_lt_exactly(300, 0);
+            scope.latency.assert_gt_exactly(300, 0);
         }
 
     }

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -134,12 +134,11 @@ mod test {
                 .get(&labels)
                 .expect("scope should be some after event");
 
-            let total: u64 = scope.total.into();
-            assert_eq!(total, 1);
+            assert_eq!(scope.total(), 1);
 
-            scope.latency.assert_bucket_exactly(300, 1);
-            scope.latency.assert_lt_exactly(300, 0);
-            scope.latency.assert_gt_exactly(300, 0);
+            scope.latency().assert_bucket_exactly(300, 1);
+            scope.latency().assert_lt_exactly(300, 0);
+            scope.latency().assert_gt_exactly(300, 0);
         }
 
     }
@@ -235,21 +234,21 @@ mod test {
                 .expect("lock");
 
             // === request scope ====================================
-            let request_total: Option<u64> = lock
-                .requests.scopes
-                .get(&req_labels)
-                .map(|scope| scope.total.into());
-            assert_eq!(request_total, Some(1));
+            assert_eq!(
+                lock.requests.scopes
+                    .get(&req_labels)
+                    .map(|scope| scope.total()),
+                Some(1)
+            );
 
             // === response scope ===================================
             let response_scope = lock
                 .responses.scopes
                 .get(&rsp_labels)
                 .expect("response scope missing");
-            let response_total: u64 = response_scope.total.into();
-            assert_eq!(response_total, 1);
+            assert_eq!(response_scope.total(), 1);
 
-            response_scope.latency
+            response_scope.latency()
                 .assert_bucket_exactly(300, 1)
                 .assert_gt_exactly(300, 0)
                 .assert_lt_exactly(300, 0);
@@ -259,30 +258,18 @@ mod test {
                 .transports.scopes
                 .get(&srv_open_labels)
                 .expect("server transport scope missing");
-            let srv_tcp_open_total: u64 = srv_transport_scope
-                .open_total.into();
-            assert_eq!(srv_tcp_open_total, 1);
-            let srv_tcp_write_total: u64 = srv_transport_scope
-                .write_bytes_total.into();
-            assert_eq!(srv_tcp_write_total, 4321);
-            let srv_tcp_read_total: u64 = srv_transport_scope
-                .read_bytes_total.into();
-            assert_eq!(srv_tcp_read_total, 4321);
+            assert_eq!(srv_transport_scope.open_total(), 1);
+            assert_eq!(srv_transport_scope.write_bytes_total(), 4321);
+            assert_eq!(srv_transport_scope.read_bytes_total(), 4321);
 
             // === client transport open scope ======================
             let client_transport_scope = lock
                 .transports.scopes
                 .get(&client_open_labels)
                 .expect("client transport scope missing");
-            let client_tcp_open_total: u64 = client_transport_scope
-                .open_total.into();
-            assert_eq!(client_tcp_open_total, 1);
-            let client_tcp_write_total: u64 = client_transport_scope
-                .write_bytes_total.into();
-            assert_eq!(client_tcp_write_total, 4321);
-            let client_tcp_read_total: u64 = client_transport_scope
-                .read_bytes_total.into();
-            assert_eq!(client_tcp_read_total, 4321);
+            assert_eq!(client_transport_scope.open_total(), 1);
+            assert_eq!(client_transport_scope.write_bytes_total(), 4321);
+            assert_eq!(client_transport_scope.read_bytes_total(), 4321);
 
             let transport_duration: u64 = 30_000 * 1_000;
 
@@ -291,10 +278,8 @@ mod test {
                 .transport_closes.scopes
                 .get(&srv_close_labels)
                 .expect("server transport close scope missing");
-            let srv_tcp_close_total: u64 = srv_transport_close_scope
-                .close_total.into();
-            assert_eq!(srv_tcp_close_total, 1);
-            srv_transport_close_scope.connection_duration
+            assert_eq!(srv_transport_close_scope.close_total(), 1);
+            srv_transport_close_scope.connection_duration()
                 .assert_bucket_exactly(transport_duration, 1)
                 .assert_gt_exactly(transport_duration, 0)
                 .assert_lt_exactly(transport_duration, 0);
@@ -304,10 +289,8 @@ mod test {
                 .transport_closes.scopes
                 .get(&client_close_labels)
                 .expect("client transport close scope missing");
-            let client_tcp_close_total: u64 = client_transport_close_scope
-                .close_total.into();
-            assert_eq!(client_tcp_close_total, 1);
-            client_transport_close_scope.connection_duration
+            assert_eq!(client_transport_close_scope.close_total(), 1);
+            client_transport_close_scope.connection_duration()
                 .assert_bucket_exactly(transport_duration, 1)
                 .assert_gt_exactly(transport_duration, 0)
                 .assert_lt_exactly(transport_duration, 0);

--- a/proxy/src/telemetry/metrics/transport.rs
+++ b/proxy/src/telemetry/metrics/transport.rs
@@ -17,18 +17,18 @@ pub(super) type OpenScopes = Scopes<TransportLabels, Stamped<OpenMetrics>>;
 
 #[derive(Debug, Default)]
 pub(super) struct OpenMetrics {
-    pub open_total: Counter,
-    pub open_connections: Gauge,
-    pub write_bytes_total: Counter,
-    pub read_bytes_total: Counter,
+    open_total: Counter,
+    open_connections: Gauge,
+    write_bytes_total: Counter,
+    read_bytes_total: Counter,
 }
 
 pub(super) type CloseScopes = Scopes<TransportCloseLabels, Stamped<CloseMetrics>>;
 
 #[derive(Debug, Default)]
 pub(super) struct CloseMetrics {
-    pub close_total: Counter,
-    pub connection_duration: Histogram<latency::Ms>,
+    close_total: Counter,
+    connection_duration: Histogram<latency::Ms>,
 }
 
 // ===== impl OpenScopes =====
@@ -77,6 +77,24 @@ impl OpenMetrics {
         self.read_bytes_total += rx;
         self.write_bytes_total += tx;
     }
+
+    /// Test-only accessor for `open_total`.
+    #[cfg(test)]
+    pub(super) fn open_total(&self) -> u64 {
+        self.open_total.into()
+    }
+
+    /// Test-only accessor for `read_bytes_total`.
+    #[cfg(test)]
+    pub(super) fn read_bytes_total(&self) -> u64 {
+        self.read_bytes_total.into()
+    }
+
+    /// Test-only accessor for `write_bytes_total`.
+    #[cfg(test)]
+    pub(super) fn write_bytes_total(&self) -> u64 {
+        self.write_bytes_total.into()
+    }
 }
 
 // ===== impl CloseScopes =====
@@ -110,5 +128,18 @@ impl CloseMetrics {
     pub(super) fn close(&mut self, duration: Duration) {
         self.close_total.incr();
         self.connection_duration.add(duration);
+    }
+
+
+    /// Test-only accessor for `close_total`.
+    #[cfg(test)]
+    pub(super) fn close_total(&self) -> u64 {
+        self.close_total.into()
+    }
+
+    /// Test-only accessor for `connection_duration`.
+    #[cfg(test)]
+    pub(super) fn connection_duration(&self) -> &Histogram<latency::Ms> {
+        &self.connection_duration
     }
 }

--- a/proxy/src/telemetry/metrics/transport.rs
+++ b/proxy/src/telemetry/metrics/transport.rs
@@ -78,19 +78,16 @@ impl OpenMetrics {
         self.write_bytes_total += tx;
     }
 
-    /// Test-only accessor for `open_total`.
     #[cfg(test)]
     pub(super) fn open_total(&self) -> u64 {
         self.open_total.into()
     }
 
-    /// Test-only accessor for `read_bytes_total`.
     #[cfg(test)]
     pub(super) fn read_bytes_total(&self) -> u64 {
         self.read_bytes_total.into()
     }
 
-    /// Test-only accessor for `write_bytes_total`.
     #[cfg(test)]
     pub(super) fn write_bytes_total(&self) -> u64 {
         self.write_bytes_total.into()
@@ -130,14 +127,11 @@ impl CloseMetrics {
         self.connection_duration.add(duration);
     }
 
-
-    /// Test-only accessor for `close_total`.
     #[cfg(test)]
     pub(super) fn close_total(&self) -> u64 {
         self.close_total.into()
     }
 
-    /// Test-only accessor for `connection_duration`.
     #[cfg(test)]
     pub(super) fn connection_duration(&self) -> &Histogram<latency::Ms> {
         &self.connection_duration

--- a/proxy/src/telemetry/metrics/transport.rs
+++ b/proxy/src/telemetry/metrics/transport.rs
@@ -17,18 +17,18 @@ pub(super) type OpenScopes = Scopes<TransportLabels, Stamped<OpenMetrics>>;
 
 #[derive(Debug, Default)]
 pub(super) struct OpenMetrics {
-    open_total: Counter,
-    open_connections: Gauge,
-    write_bytes_total: Counter,
-    read_bytes_total: Counter,
+    pub open_total: Counter,
+    pub open_connections: Gauge,
+    pub write_bytes_total: Counter,
+    pub read_bytes_total: Counter,
 }
 
 pub(super) type CloseScopes = Scopes<TransportCloseLabels, Stamped<CloseMetrics>>;
 
 #[derive(Debug, Default)]
 pub(super) struct CloseMetrics {
-    close_total: Counter,
-    connection_duration: Histogram<latency::Ms>,
+    pub close_total: Counter,
+    pub connection_duration: Histogram<latency::Ms>,
 }
 
 // ===== impl OpenScopes =====


### PR DESCRIPTION
This PR adds unit tests for `metrics::record`, based on the benchmarks for the
same function. Currently, there is a test that fires a single response end event
and asserts that the metrics state is correct afterward, and a test that fires
all the events to simulate a full connection lifetime, and asserts that the
metrics state is correct afterward. I'd like to also add a test that simulates
multiple events with different labels, but I'll add that in a subsequent PR,

In order to add these tests, it was necessary to make some fields in metrics
structs `pub` so that the test can access them. These fields should only be
exposed within the metrics module, however. I also added some test-only
functions to `metrics::Histogram`s, to make them easier to make assertions
about.