### PR TITLE
proxy: Upgrade tower dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,6 @@ dependencies = [
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -155,6 +154,7 @@ dependencies = [
  "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
  "tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
  "trust-dns-resolver 0.8.2 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)",
 ]
@@ -183,7 +183,7 @@ version = "0.3.0"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
@@ -958,48 +958,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
-dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tower-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-discover"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#57d976aca89c13838b946dca9b666a995ec10690"
+source = "git+https://github.com/tower-rs/tower-grpc#8c238944c772e31ced155410f91206e1423c01f0"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1007,15 +999,14 @@ dependencies = [
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
- "tower-ready-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#57d976aca89c13838b946dca9b666a995ec10690"
+source = "git+https://github.com/tower-rs/tower-grpc#8c238944c772e31ced155410f91206e1423c01f0"
 dependencies = [
  "codegen 0.1.0 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1025,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#26453f5f0afe2928b47af38713f880ecf27fa85f"
+source = "git+https://github.com/tower-rs/tower-h2#1ce770cdda5e9665759ea543992ecc5e40140ae3"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1035,46 +1026,43 @@ dependencies = [
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-in-flight-limit"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-ready-service 0.1.0 (git+https://github.com/tower-rs/tower)",
-]
-
-[[package]]
-name = "tower-ready-service"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
-dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-reconnect"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.1.0"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+dependencies = [
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#11b591b6e037ae671bc8da755cfb3095a3f83568"
+source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-ready-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
@@ -1351,7 +1339,6 @@ dependencies = [
 "checksum tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9532748772222bf70297ec0e2ad0f17213b4a7dd0e6afb68e0a0768f69f4e4f"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-signal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e8f46863230f9a05cf52d173721ec391b9c5782a2465f593029922b8782b9ffe"
-"checksum tower 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
@@ -1359,8 +1346,8 @@ dependencies = [
 "checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
 "checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
 "checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-ready-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum trust-dns-proto 0.3.3 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)" = "<none>"
 "checksum trust-dns-resolver 0.8.2 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)" = "<none>"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -41,7 +41,7 @@ trust-dns-resolver = { version = "0.8.2", default-features = false, git = "https
 #futures-watch   = { git = "https://github.com/carllerche/better-future" }
 
 tokio-connect         = { git = "https://github.com/carllerche/tokio-connect" }
-tower                 = { git = "https://github.com/tower-rs/tower" }
+tower-service         = { git = "https://github.com/tower-rs/tower" }
 tower-balance         = { git = "https://github.com/tower-rs/tower" }
 tower-buffer          = { git = "https://github.com/tower-rs/tower" }
 tower-discover        = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/router/Cargo.toml
+++ b/proxy/router/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [dependencies]
 futures = "0.1"
 indexmap = "1.0.0"
-tower = { git = "https://github.com/tower-rs/tower" }
+tower-service = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate futures;
 extern crate indexmap;
-extern crate tower;
+extern crate tower_service;
 
 use futures::{Future, Poll};
 use indexmap::IndexMap;
-use tower::Service;
+use tower_service::Service;
 
 use std::{error, fmt, mem};
 use std::convert::AsRef;

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -9,7 +9,7 @@ use futures::{Future, Poll};
 use futures::future::Map;
 use http::{self, uri};
 use tokio_core::reactor::Handle;
-use tower;
+use tower_service as tower;
 use tower_h2;
 use tower_reconnect::Reconnect;
 

--- a/proxy/src/control/discovery.rs
+++ b/proxy/src/control/discovery.rs
@@ -10,7 +10,7 @@ use futures::sync::mpsc;
 use futures_watch;
 use http;
 use tokio_core::reactor::Handle;
-use tower::Service;
+use tower_service::Service;
 use tower_h2::{HttpService, BoxBody, RecvBody};
 use tower_discover::{Change, Discover};
 use tower_grpc as grpc;

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -12,7 +12,7 @@ use tokio_core::reactor::{
     //       renaming import is not necessary.
     Timeout as ReactorTimeout
 };
-use tower::Service;
+use tower_service::Service;
 use tower_h2;
 use tower_reconnect::{Error as ReconnectError, Reconnect};
 

--- a/proxy/src/control/observe.rs
+++ b/proxy/src/control/observe.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::{future, Poll, Stream};
 use futures_mpsc_lossy;
+use http::HeaderMap;
 use indexmap::IndexMap;
 use tower_grpc::{self as grpc, Response};
 
@@ -48,7 +49,10 @@ impl server::Tap for Observe {
 
     fn observe(&mut self, req: grpc::Request<ObserveRequest>) -> Self::ObserveFuture {
         if self.next_id.load(Ordering::Acquire) == ::std::usize::MAX {
-            return future::err(grpc::Error::Grpc(grpc::Status::INTERNAL));
+            return future::err(grpc::Error::Grpc(
+                grpc::Status::INTERNAL,
+                HeaderMap::new(),
+            ));
         }
 
         let req = req.into_inner();
@@ -59,6 +63,7 @@ impl server::Tap for Observe {
             None => {
                 return future::err(grpc::Error::Grpc(
                     grpc::Status::INVALID_ARGUMENT,
+                    HeaderMap::new(),
                 ));
             }
         };
@@ -70,7 +75,10 @@ impl server::Tap for Observe {
                 tap_id
             }
             Err(_) => {
-                return future::err(grpc::Error::Grpc(grpc::Status::INTERNAL));
+                return future::err(grpc::Error::Grpc(
+                    grpc::Status::INTERNAL,
+                    HeaderMap::new(),
+                ));
             }
         };
 

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -2,7 +2,7 @@ use std::net::{SocketAddr};
 use std::sync::Arc;
 
 use http;
-use tower;
+use tower_service as tower;
 use tower_buffer::{self, Buffer};
 use tower_in_flight_limit::{self, InFlightLimit};
 use tower_h2;

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -31,13 +31,13 @@ extern crate rand;
 extern crate tokio_connect;
 extern crate tokio_core;
 extern crate tokio_io;
-extern crate tower;
 extern crate tower_balance;
 extern crate tower_buffer;
 extern crate tower_discover;
 extern crate tower_grpc;
 extern crate tower_h2;
 extern crate tower_reconnect;
+extern crate tower_service;
 extern crate conduit_proxy_router;
 extern crate tower_util;
 extern crate tower_in_flight_limit;
@@ -54,7 +54,7 @@ use std::time::Duration;
 
 use indexmap::IndexSet;
 use tokio_core::reactor::{Core, Handle};
-use tower::NewService;
+use tower_service::NewService;
 use tower_fn::*;
 use conduit_proxy_router::{Recognize, Router, Error as RouteError};
 

--- a/proxy/src/map_err.rs
+++ b/proxy/src/map_err.rs
@@ -5,7 +5,7 @@ use futures::{Future, Poll};
 use h2;
 use http;
 use http::header::CONTENT_LENGTH;
-use tower::Service;
+use tower_service::Service;
 
 /// Map an HTTP service's error to an appropriate 500 response.
 pub struct MapErr<T, E, F> {

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use http;
 use futures::{Async, Poll};
 use rand;
-use tower;
+use tower_service as tower;
 use tower_balance::{self, choose, load, Balance};
 use tower_buffer::Buffer;
 use tower_discover::{Change, Discover};

--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use tower::{NewService, Service};
+use tower_service::{NewService, Service};
 use tower_h2::{client, Body};
 
 use ctx;

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -6,7 +6,7 @@ use futures_mpsc_lossy::Sender;
 use http::{Request, Response};
 use tokio_connect;
 use tokio_io::{AsyncRead, AsyncWrite};
-use tower::NewService;
+use tower_service::NewService;
 use tower_h2::{client, Body};
 
 use ctx;

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio_connect::Connect;
 use tokio_core::reactor::{Timeout as ReactorTimeout, Handle};
 use tokio_io;
-use tower::Service;
+use tower_service::Service;
 
 /// A timeout that wraps an underlying operation.
 #[derive(Debug, Clone)]

--- a/proxy/src/tower_fn.rs
+++ b/proxy/src/tower_fn.rs
@@ -1,5 +1,5 @@
 use futures::future::{self, FutureResult};
-use tower::{NewService, Service};
+use tower_service::{NewService, Service};
 
 pub struct NewServiceFn<T> {
     f: T,

--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -4,7 +4,7 @@ use http;
 use hyper;
 use tokio_connect::Connect;
 use tokio_core::reactor::Handle;
-use tower::{Service, NewService};
+use tower_service::{Service, NewService};
 use tower_h2::{self, Body};
 
 use bind;

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -10,7 +10,7 @@ use h2;
 use http;
 use hyper;
 use tokio_connect::Connect;
-use tower::{Service, NewService};
+use tower_service::{Service, NewService};
 use tower_h2;
 
 use ctx::transport::{Server as ServerCtx};

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -9,7 +9,7 @@ use hyper;
 use indexmap::IndexSet;
 use tokio_core::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};
-use tower::NewService;
+use tower_service::NewService;
 use tower_h2;
 
 use connection::{Connection, PeekFuture};

--- a/proxy/tests/support/controller.rs
+++ b/proxy/tests/support/controller.rs
@@ -68,7 +68,7 @@ impl Stream for DstReceiver {
     type Item = pb::Update;
     type Error = grpc::Error;
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.0.poll().map_err(|_| grpc::Error::Grpc(grpc::Status::INTERNAL))
+        self.0.poll().map_err(|_| grpc::Error::Grpc(grpc::Status::INTERNAL, HeaderMap::new()))
     }
 }
 
@@ -101,7 +101,7 @@ impl pb::server::Destination for Controller {
             }
         }
 
-        future::err(grpc::Error::Grpc(grpc::Status::INTERNAL))
+        future::err(grpc::Error::Grpc(grpc::Status::INTERNAL, HeaderMap::new()))
     }
 }
 

--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -35,9 +35,9 @@ pub use self::http::{HeaderMap, Request, Response, StatusCode};
 use self::tokio_connect::Connect;
 use self::tokio_core::net::{TcpListener, TcpStream};
 use self::tokio_core::reactor::{Core, Handle};
-use self::tower::{NewService, Service};
 use self::tower_h2::{Body, RecvBody};
 use self::tower_grpc as grpc;
+use self::tower_service::{NewService, Service};
 
 /// Environment variable for overriding the test patience.
 pub const ENV_TEST_PATIENCE_MS: &'static str = "RUST_TEST_PATIENCE_MS";

--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -17,9 +17,9 @@ extern crate prost;
 extern crate tokio_connect;
 extern crate tokio_core;
 pub extern crate tokio_io;
-extern crate tower;
 extern crate tower_h2;
 extern crate tower_grpc;
+extern crate tower_service;
 extern crate log;
 pub extern crate env_logger;
 


### PR DESCRIPTION
In order to pick up https://github.com/tower-rs/tower-grpc/pull/60,
upgrade tower dependencies. This will reduce the cost of updating
for upcoming tower-h2 improvements.