### PR TITLE
proxy: Limit Router cache size

### DIFF
--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -163,7 +163,7 @@ where T: Recognize,
             }
 
             Some(Reuse::Reusable(key)) => {
-                // First, try to load a cached rute for `key`.
+                // First, try to load a cached route for `key`.
                 if let Some(service) = inner.routes.get_mut(&key) {
                     return ResponseFuture::new(service.call(request));
                 }

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -11,13 +11,19 @@ use std::convert::AsRef;
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
-/// Routes requests
+/// Routes requests based on a configurable `Key`.
 pub struct Router<T>
 where T: Recognize,
 {
     inner: Arc<Mutex<Inner<T>>>,
 }
 
+/// Provides a strategy for routing a Request to a Service.
+///
+/// Implementors must provide a `Key` type that identifies each unique route. The
+/// `recognize()` method is used to determine the key for a given request. This key is
+/// used to look up a route in a cache (i.e. in `Router`), or can be passed to
+/// `bind_service` to instantiate the identified route.
 pub trait Recognize {
     /// Requests handled by the discovered services
     type Request;

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -147,7 +147,7 @@ where T: Recognize,
 
     /// Routes the request through an underlying service.
     ///
-    /// The response fails when the request cannot be routed.
+    /// The response fails if the request cannot be routed.
     fn call(&mut self, request: Self::Request) -> Self::Future {
         let inner = &mut *self.inner.lock().expect("lock router cache");
 

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -423,24 +423,13 @@ mod tests {
     }
 
     #[test]
-    fn single_use_not_cached() {
-        let mut router = Router::new(Recognize, 2);
+    fn single_use_not_cached_or_limited_by_capacity() {
+        let mut router = Router::new(Recognize, 1);
 
         let rsp = router.call_ok(Request::Reusable(2));
         assert_eq!(rsp, 2);
 
         let rsp = router.call_ok(Request::SingleUse(2));
         assert_eq!(rsp, 2);
-    }
-
-    #[test]
-    fn single_use_not_limited_by_capacity() {
-        let mut router = Router::new(Recognize, 1);
-
-        let rsp = router.call_ok(Request::Reusable(2));
-        assert_eq!(rsp, 2);
-
-        let rsp = router.call_ok(Request::SingleUse(7));
-        assert_eq!(rsp, 7);
     }
 }

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -426,7 +426,7 @@ mod tests {
     fn single_use_not_cached() {
         let mut router = Router::new(Recognize, 2);
 
-        let rsp = router.call_ok(Request::SingleUse(2));
+        let rsp = router.call_ok(Request::Reusable(2));
         assert_eq!(rsp, 2);
 
         let rsp = router.call_ok(Request::SingleUse(2));

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -69,6 +69,7 @@ pub enum Error<T, U> {
     Inner(T),
     Route(U),
     NotRecognized,
+    OutOfCapacity,
 }
 
 pub struct ResponseFuture<T: Recognize> {
@@ -211,6 +212,7 @@ impl<T: Recognize> Future for ResponseFuture<T> {
                 }
             }
             NotRecognized => Err(Error::NotRecognized),
+            OutOfCapacity => Err(Error::OutOfCapacity),
             Invalid => panic!(),
         }
     }
@@ -229,6 +231,7 @@ where
             Error::Route(ref why) =>
                 write!(f, "route recognition failed: {}", why),
             Error::NotRecognized => f.pad("route not recognized"),
+            Error::OutOfCapacity => f.pad("router out of capacity"),
         }
     }
 }
@@ -251,6 +254,7 @@ where
             Error::Inner(_) => "inner service error",
             Error::Route(_) => "route recognition failed",
             Error::NotRecognized => "route not recognized",
+            Error::OutOfCapacity => "router out of capacity",
         }
     }
 }

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -426,7 +426,7 @@ mod tests {
     fn single_use_not_cached() {
         let mut router = Router::new(Recognize, 2);
 
-        let rsp = router.call_ok(Request::Reusable(2));
+        let rsp = router.call_ok(Request::SingleUse(2));
         assert_eq!(rsp, 2);
 
         let rsp = router.call_ok(Request::SingleUse(2));

--- a/proxy/router/src/lib.rs
+++ b/proxy/router/src/lib.rs
@@ -45,7 +45,7 @@ pub trait Recognize {
                          Response = Self::Response,
                             Error = Self::Error>;
 
-    /// Determines a route to handle the given request.
+    /// Determines the key for a route to handle the given request.
     fn recognize(&self, req: &Self::Request) -> Option<Reuse<Self::Key>>;
 
     /// Return a `Service` to handle requests.

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -167,8 +167,11 @@ const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
 const DEFAULT_PUBLIC_CONNECT_TIMEOUT_MS: u64 = 300;
 const DEFAULT_BIND_TIMEOUT_MS: u64 = 10_000; // ten seconds, as in Linkerd.
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
+
+/// It's assumed that a typical proxy can serve inbound traffic for up to 100 pod-local
+/// HTTP services and may communicate with up to 10K external HTTP domains.
 const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 100;
-const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 1_000;
+const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 10_000;
 
 // By default, we keep a list of known assigned ports of server-first protocols.
 //

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -167,8 +167,8 @@ const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
 const DEFAULT_PUBLIC_CONNECT_TIMEOUT_MS: u64 = 300;
 const DEFAULT_BIND_TIMEOUT_MS: u64 = 10_000; // ten seconds, as in Linkerd.
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
-const DEFAULT_INBOUND_ROUTER_CAPACITY = 100;
-const DEFAULT_OUTBOUND_ROUTER_CAPACITY = 1_000;
+const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 100;
+const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 1_000;
 
 // By default, we keep a list of known assigned ports of server-first protocols.
 //
@@ -197,7 +197,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let inbound_disable_ports = parse(strings, ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_set);
         let outbound_disable_ports = parse(strings, ENV_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_set);
         let inbound_router_capacity = parse(strings, ENV_INBOUND_ROUTER_CAPACITY, parse_number);
-        let inbound_router_capacity = parse(strings, ENV_OUTBOUND_ROUTER_CAPACITY, parse_number);
+        let outbound_router_capacity = parse(strings, ENV_OUTBOUND_ROUTER_CAPACITY, parse_number);
         let bind_timeout = parse(strings, ENV_BIND_TIMEOUT, parse_number);
         let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
         let event_buffer_capacity = parse(strings, ENV_EVENT_BUFFER_CAPACITY, parse_number);

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -44,6 +44,10 @@ pub struct Config {
 
     pub outbound_ports_disable_protocol_detection: IndexSet<u16>,
 
+    pub inbound_router_capacity: usize,
+
+    pub outbound_router_capacity: usize,
+
     /// The path to "/etc/resolv.conf"
     pub resolv_conf_path: PathBuf,
 
@@ -136,6 +140,12 @@ const ENV_PRIVATE_CONNECT_TIMEOUT: &str = "CONDUIT_PROXY_PRIVATE_CONNECT_TIMEOUT
 const ENV_PUBLIC_CONNECT_TIMEOUT: &str = "CONDUIT_PROXY_PUBLIC_CONNECT_TIMEOUT";
 pub const ENV_BIND_TIMEOUT: &str = "CONDUIT_PROXY_BIND_TIMEOUT";
 
+// Limits the number of HTTP routes that may be active in the proxy at any time. There is
+// an inbound route for each local port that receives connections. There is an outbound
+// route for each protocol and authority.
+pub const ENV_INBOUND_ROUTER_CAPACITY: &str = "CONDUIT_PROXY_INBOUND_ROUTER_CAPACITY";
+pub const ENV_OUTBOUND_ROUTER_CAPACITY: &str = "CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY";
+
 // These *disable* our protocol detection for connections whose SO_ORIGINAL_DST
 // has a port in the provided list.
 pub const ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION: &str = "CONDUIT_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION";
@@ -157,6 +167,8 @@ const DEFAULT_PRIVATE_CONNECT_TIMEOUT_MS: u64 = 20;
 const DEFAULT_PUBLIC_CONNECT_TIMEOUT_MS: u64 = 300;
 const DEFAULT_BIND_TIMEOUT_MS: u64 = 10_000; // ten seconds, as in Linkerd.
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
+const DEFAULT_INBOUND_ROUTER_CAPACITY = 100;
+const DEFAULT_OUTBOUND_ROUTER_CAPACITY = 1_000;
 
 // By default, we keep a list of known assigned ports of server-first protocols.
 //
@@ -184,6 +196,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let private_connect_timeout = parse(strings, ENV_PRIVATE_CONNECT_TIMEOUT, parse_number);
         let inbound_disable_ports = parse(strings, ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_set);
         let outbound_disable_ports = parse(strings, ENV_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_set);
+        let inbound_router_capacity = parse(strings, ENV_INBOUND_ROUTER_CAPACITY, parse_number);
+        let inbound_router_capacity = parse(strings, ENV_OUTBOUND_ROUTER_CAPACITY, parse_number);
         let bind_timeout = parse(strings, ENV_BIND_TIMEOUT, parse_number);
         let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
         let event_buffer_capacity = parse(strings, ENV_EVENT_BUFFER_CAPACITY, parse_number);
@@ -236,6 +250,12 @@ impl<'a> TryFrom<&'a Strings> for Config {
                 .unwrap_or_else(|| default_disable_ports_protocol_detection()),
             outbound_ports_disable_protocol_detection: outbound_disable_ports?
                 .unwrap_or_else(|| default_disable_ports_protocol_detection()),
+
+            inbound_router_capacity: inbound_router_capacity?
+                .unwrap_or(DEFAULT_INBOUND_ROUTER_CAPACITY),
+            outbound_router_capacity: outbound_router_capacity?
+                .unwrap_or(DEFAULT_OUTBOUND_ROUTER_CAPACITY),
+
             resolv_conf_path: resolv_conf_path?
                 .unwrap_or(DEFAULT_RESOLV_CONF.into())
                 .into(),

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -229,6 +229,7 @@ where
             let fut = serve(
                 inbound_listener,
                 Inbound::new(default_addr, bind),
+                100,
                 config.private_connect_timeout,
                 config.inbound_ports_disable_protocol_detection,
                 ctx,
@@ -250,6 +251,7 @@ where
             let fut = serve(
                 outbound_listener,
                 outgoing,
+                1_000,
                 config.public_connect_timeout,
                 config.outbound_ports_disable_protocol_detection,
                 ctx,
@@ -326,6 +328,7 @@ where
 fn serve<R, B, E, F, G>(
     bound_port: BoundPort,
     recognize: R,
+    router_capacity: usize,
     tcp_connect_timeout: Duration,
     disable_protocol_detection_ports: IndexSet<u16>,
     proxy_ctx: Arc<ctx::Proxy>,
@@ -347,7 +350,7 @@ where
         + 'static,
     G: GetOriginalDst + 'static,
 {
-    let router = Router::new(recognize);
+    let router = Router::new(recognize, router_capacity);
     let stack = Arc::new(NewServiceFn::new(move || {
         // Clone the router handle
         let router = router.clone();

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -371,6 +371,8 @@ where
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
                 RouteError::OutOfCapacity => {
+                    // TODO For H2 streams, we should probably signal a protocol-level
+                    // capacity change.
                     error!("turning router capacity exhaustion into 503");
                     http::StatusCode::SERVICE_UNAVAILABLE
                 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -370,10 +370,10 @@ where
                     error!("turning route not recognized error into 500");
                     http::StatusCode::INTERNAL_SERVER_ERROR
                 }
-                RouteError::OutOfCapacity => {
+                RouteError::NoCapacity(capacity) => {
                     // TODO For H2 streams, we should probably signal a protocol-level
                     // capacity change.
-                    error!("turning router capacity exhaustion into 503");
+                    error!("router at capacity ({}); returning a 503", capacity);
                     http::StatusCode::SERVICE_UNAVAILABLE
                 }
             }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -229,7 +229,7 @@ where
             let fut = serve(
                 inbound_listener,
                 Inbound::new(default_addr, bind),
-                100,
+                config.inbound_router_capacity,
                 config.private_connect_timeout,
                 config.inbound_ports_disable_protocol_detection,
                 ctx,
@@ -251,7 +251,7 @@ where
             let fut = serve(
                 outbound_listener,
                 outgoing,
-                1_000,
+                config.outbound_router_capacity,
                 config.public_connect_timeout,
                 config.outbound_ports_disable_protocol_detection,
                 ctx,
@@ -369,6 +369,10 @@ where
                 RouteError::NotRecognized => {
                     error!("turning route not recognized error into 500");
                     http::StatusCode::INTERNAL_SERVER_ERROR
+                }
+                RouteError::OutOfCapacity => {
+                    error!("turning router capacity exhaustion into 503");
+                    http::StatusCode::SERVICE_UNAVAILABLE
                 }
             }
         });


### PR DESCRIPTION
The proxy can currently store an unbounded number of routes, which can potentially lead
memory exhaustion panics for applications that expose or connect to an unbounded number of
endpoints. Note that applications like monitoring systems (like Prometheus) can exhibit
these sorts of behaviors in dynamically scheduled environments.

This change adds a hard upper limit to the number of HTTP endpoints a proxy (i.e. either
_inbound_ or _outbound_ directions) may route to.

In followup changes:
- An eviction policy should be put in place so that unused routes can be reaped to make
  space for new routes.
- Telemetry events should be added for router table modifications so diagnostics can be
  instrumented.
- Single-use routes should consume router capacity.