### PR TITLE
Fix bug where GetPodsFor(pod) was returning all pods in a namespace

### DIFF
--- a/controller/k8s/lister.go
+++ b/controller/k8s/lister.go
@@ -145,7 +145,7 @@ func (l *Lister) GetPodsFor(obj runtime.Object) ([]*apiv1.Pod, error) {
 
 	case *apiv1.Pod:
 		namespace = typed.Namespace
-		selector = labels.Everything()
+		selector = labels.Set(typed.Labels).AsSelector()
 
 	default:
 		return nil, fmt.Errorf("Cannot get object selector: %v", obj)

--- a/controller/k8s/lister.go
+++ b/controller/k8s/lister.go
@@ -121,6 +121,8 @@ func (l *Lister) GetObjects(namespace, restype, name string) ([]runtime.Object, 
 func (l *Lister) GetPodsFor(obj runtime.Object) ([]*apiv1.Pod, error) {
 	var namespace string
 	var selector labels.Selector
+	var pods []*apiv1.Pod
+	var err error
 
 	switch typed := obj.(type) {
 	case *apiv1.Namespace:
@@ -144,16 +146,26 @@ func (l *Lister) GetPodsFor(obj runtime.Object) ([]*apiv1.Pod, error) {
 		selector = labels.Set(typed.Spec.Selector).AsSelector()
 
 	case *apiv1.Pod:
+		// Special case for pods:
+		// GetPodsFor a pod should just return the pod itself
 		namespace = typed.Namespace
-		selector = labels.Set(typed.Labels).AsSelector()
+		pod, err := l.Pod.Pods(typed.Namespace).Get(typed.Name)
+		if err != nil {
+			return nil, err
+		}
+		pods = []*apiv1.Pod{pod}
 
 	default:
 		return nil, fmt.Errorf("Cannot get object selector: %v", obj)
 	}
 
-	pods, err := l.Pod.Pods(namespace).List(selector)
-	if err != nil {
-		return nil, err
+	// if obj.(type) is Pod, we've already retrieved it and put it in pods
+	// for the other types, pods will still be empty
+	if len(pods) == 0 {
+		pods, err = l.Pod.Pods(namespace).List(selector)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	allPods := []*apiv1.Pod{}


### PR DESCRIPTION
*Problem*
In `lister.GetPodsFor`, when the input object was a pod, we would return all the pods in the namespace. I would expect `GetPodsFor(pod)` to return only one pod - the pod itself.

*Cause*
The cause of this is that when the object type was `pod` we were setting the selector to `selector = labels.Everything()` which gets all the pods in the namespace. 

*Fix*
I changed the selector when the input object is a pod to be the pod's labels. Now we don't return all pods in a namespace when `GetPodsFor` is called on a pod.

Fixes #860
