### PR TITLE
router: Store `recognize` outside of lock

### DIFF
--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -30,6 +30,7 @@ use self::discovery::{Background as DiscoBg, Discovery, Watch};
 pub use self::discovery::Bind;
 pub use self::observe::Observe;
 
+#[derive(Clone)]
 pub struct Control {
     disco: Discovery,
 }

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -31,6 +31,18 @@ impl<B> Inbound<B> {
     }
 }
 
+impl<B> Clone for Inbound<B>
+where
+    B: tower_h2::Body + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bind: self.bind.clone(),
+            default_addr: self.default_addr.clone(),
+        }
+    }
+}
+
 impl<B> Recognize for Inbound<B>
 where
     B: tower_h2::Body + 'static,

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -31,18 +31,6 @@ impl<B> Inbound<B> {
     }
 }
 
-impl<B> Clone for Inbound<B>
-where
-    B: tower_h2::Body + 'static,
-{
-    fn clone(&self) -> Self {
-        Self {
-            bind: self.bind.clone(),
-            default_addr: self.default_addr.clone(),
-        }
-    }
-}
-
 impl<B> Recognize for Inbound<B>
 where
     B: tower_h2::Body + 'static,

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -82,7 +82,7 @@ where
     ///
     /// Buffering is currently unbounded and does not apply timeouts. This must be
     /// changed.
-    fn bind_service(&mut self, key: &Self::Key) -> Result<Self::Service, Self::RouteError> {
+    fn bind_service(&self, key: &Self::Key) -> Result<Self::Service, Self::RouteError> {
         let &(ref addr, ref proto) = key;
         debug!("building inbound {:?} client to {}", proto, addr);
 

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -32,6 +32,12 @@ pub struct Outbound<B> {
 
 const MAX_IN_FLIGHT: usize = 10_000;
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Destination {
+    Hostname(DnsNameAndPort),
+    ImplicitOriginalDst(SocketAddr),
+}
+
 // ===== impl Outbound =====
 
 impl<B> Outbound<B> {
@@ -47,10 +53,17 @@ impl<B> Outbound<B> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Destination {
-    Hostname(DnsNameAndPort),
-    ImplicitOriginalDst(SocketAddr),
+impl<B> Clone for Outbound<B>
+where
+    B: tower_h2::Body + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bind: self.bind.clone(),
+            discovery: self.discovery.clone(),
+            bind_timeout: self.bind_timeout.clone(),
+        }
+    }
 }
 
 impl<B> Recognize for Outbound<B>

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -132,7 +132,7 @@ where
     /// Buffering is currently unbounded and does not apply timeouts. This must be
     /// changed.
     fn bind_service(
-        &mut self,
+        &self,
         key: &Self::Key,
     ) -> Result<Self::Service, Self::RouteError> {
         let &(ref dest, ref protocol) = key;

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -32,12 +32,6 @@ pub struct Outbound<B> {
 
 const MAX_IN_FLIGHT: usize = 10_000;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Destination {
-    Hostname(DnsNameAndPort),
-    ImplicitOriginalDst(SocketAddr),
-}
-
 // ===== impl Outbound =====
 
 impl<B> Outbound<B> {
@@ -51,6 +45,12 @@ impl<B> Outbound<B> {
             bind_timeout,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Destination {
+    Hostname(DnsNameAndPort),
+    ImplicitOriginalDst(SocketAddr),
 }
 
 impl<B> Recognize for Outbound<B>

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -53,19 +53,6 @@ impl<B> Outbound<B> {
     }
 }
 
-impl<B> Clone for Outbound<B>
-where
-    B: tower_h2::Body + 'static,
-{
-    fn clone(&self) -> Self {
-        Self {
-            bind: self.bind.clone(),
-            discovery: self.discovery.clone(),
-            bind_timeout: self.bind_timeout.clone(),
-        }
-    }
-}
-
 impl<B> Recognize for Outbound<B>
 where
     B: tower_h2::Body + 'static,


### PR DESCRIPTION
The router stores its cache and `Recognize` implementation within a `Mutex`,
but there is no need for the recognizer to be locked.

This change creates a new `Cache` type that is locked independently of
`Recognize`. In order to accomplish this, `Recognize::bind_service` has
been changed to take an immutable reference to its `self`.

The (unused) `Single` type has been removed because it relied on
`bind_service` being mutable.