### PR TITLE
Indicate failed pods in ServiceMesh page

### DIFF
--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -157,10 +157,11 @@ export default class ServiceMesh extends React.Component {
       return {
         name: title,
         pods: _.map(matchingPods, p => {
+          let isRunning = parseInt(p.runningPodCount, 10) > 0;
+          let isFailed = parseInt(p.failedPodCount, 10) !== 0;
           return {
             name: p.resource.name,
-            // we need an endpoint to return the k8s status of these pods
-            value: _.size(matchingPods) > 0 ? "good" : "neutral"
+            value: isFailed ? "poor" : isRunning ? "good" : "neutral"
           };
         })
       };


### PR DESCRIPTION
Now that the API returns the number of failed pods, use this info to indicate failed pods in the ServiceMesh page. The bars will turn red if there are any failed pods present in the namespace. They'll be green if they have non-zero pods meshed, and grey otherwise.

<img width="774" alt="screen shot 2018-05-08 at 4 23 56 pm" src="https://user-images.githubusercontent.com/549258/39788030-3e31b692-52dd-11e8-8c7c-b439c0d774ca.png">
