### PR TITLE
docker: Cache versionless builds before building versioned go binaries

### DIFF
--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,6 +1,5 @@
 ## compile binaries
 FROM gcr.io/runconduit/go-deps:e7d5fcae as golang
-ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
 COPY controller/k8s controller/k8s
@@ -9,6 +8,13 @@ COPY controller/gen controller/gen
 COPY controller/util controller/util
 COPY pkg pkg
 RUN mkdir -p /out
+
+# Cache builds without version info
+RUN CGO_ENABLED=0 GOOS=darwin  go build -installsuffix cgo -o /out/conduit-darwin  ./cli
+RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux   ./cli
+RUN CGO_ENABLED=0 GOOS=windows go build -installsuffix cgo -o /out/conduit-windows ./cli
+
+ARG CONDUIT_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}"
 RUN CGO_ENABLED=0 GOOS=darwin  go build -installsuffix cgo -o /out/conduit-darwin  -ldflags "${GO_LDFLAGS}" ./cli
 RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux   -ldflags "${GO_LDFLAGS}" ./cli

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,12 +1,17 @@
 ## compile controller services
 FROM gcr.io/runconduit/go-deps:e7d5fcae as golang
-ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen
 COPY pkg pkg
-RUN CGO_ENABLED=0 GOOS=linux go install -installsuffix cgo -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}" ./pkg/...
 COPY controller controller
+
+# Cache a build without version info
+RUN CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo ./pkg/...
+RUN CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo ./controller/cmd/...
+
+ARG CONDUIT_VERSION
 # use `install` so that we produce multiple binaries
+RUN CGO_ENABLED=0 GOOS=linux go install -installsuffix cgo -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}" ./pkg/...
 RUN CGO_ENABLED=0 GOOS=linux go install -installsuffix cgo -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}" ./controller/cmd/...
 
 ## package runtime

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,11 +13,15 @@ RUN $HOME/.yarn/bin/yarn webpack
 
 ## compile go server
 FROM gcr.io/runconduit/go-deps:e7d5fcae as golang
-ARG CONDUIT_VERSION
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller
 COPY pkg pkg
+
+# Cache a build without version info
+RUN CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o web/web ./web
+
+ARG CONDUIT_VERSION
 RUN CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -o web/web -ldflags "-X github.com/runconduit/conduit/pkg/version.Version=$CONDUIT_VERSION" ./web
 
 ## package it all up


### PR DESCRIPTION
The way that git-related version information is linked into Go binaries
busts Docker's cache such that every commit causes all binaries to be
rebuilt.

In order to ameliorate this, we can build each binary once without
version information first so that its artifacts are cached. When Go
sources are not changed and only the version information changes
builds are are now <90s, compared to 5+ minutes.

### On `master`

Branch off of master and build (mostly cached):

```
:; time DOCKER_TRACE=1 bin/docker-build
...
DOCKER_TRACE=1 bin/docker-build  9.10s user 6.30s system 5% cpu 4:26.47 total
```

Rebuild without changing anything (highly cached):

```
:; time DOCKER_TRACE=1 bin/docker-build
...
DOCKER_TRACE=1 bin/docker-build  9.23s user 6.04s system 47% cpu 32.017 total
```

Update only the git sha and rebuild:

```
:; git ci -am 'bump it' --allow-empty
[ver/eg 2749eb3] bump it
:; time DOCKER_TRACE=1 bin/docker-build
...
DOCKER_TRACE=1 bin/docker-build  8.55s user 6.08s system 4% cpu 5:22.25 total
```

### On this branch:

Rebuild without changing anything (highly cached):

```
:; time DOCKER_TRACE=1 bin/docker-build
...
DOCKER_TRACE=1 bin/docker-build  8.94s user 5.97s system 46% cpu 32.257 total
```

Update only the git sha and rebuild:

```
:; git ci -am 'bump it' --allow-empty
[ver/go-docker-cache-versionless 77a80b5] bump it
:; time DOCKER_TRACE=1 bin/docker-build
DOCKER_TRACE=1 bin/docker-build  9.24s user 6.16s system 20% cpu 1:15.36 total
```