### PR TITLE
docker: Make cli-bin only build binaries for a single OS

### DIFF
--- a/bin/conduit
+++ b/bin/conduit
@@ -8,17 +8,22 @@ rootdir="$( cd $bindir/.. && pwd )"
 system=$(uname -s)
 
 if [ "$system" = "Darwin" ]; then
-  bin=$rootdir/target/cli/darwin/conduit
+  OS="darwin"
 elif [ "$system" = "Linux" ]; then
-  bin=$rootdir/target/cli/linux/conduit
+  OS="linux"
 else
   echo "unknown system: $system" >&2
   exit 1
 fi
 
+. $bindir/_tag.sh
+
+tag="$(head_root_tag)"
+bin="$rootdir/target/cli/${OS}/conduit"
+
 # build conduit executable if it does not exist
 if [ ! -f $bin ]; then
-  $bindir/docker-build-cli-bin >/dev/null
+  CLI_EXPORT=1 CLI_OS="$OS" $bindir/docker-build-cli-bin >/dev/null
 fi
 
 exec $bin "$@"

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -12,7 +12,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $bindir/docker-build-controller
 $bindir/docker-build-web
 $bindir/docker-build-proxy-init
-$bindir/docker-build-cli-bin
 $bindir/docker-build-grafana
 
 $bindir/docker-build-proxy

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -31,7 +31,7 @@ else
     elif [ "$sys" = "Linux" ]; then
         OS="linux"
     else
-        echo "unknown OS: $OS" >&2
+        echo "unknown OS: $sys" >&2
         exit 1
     fi
 fi

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -22,14 +22,32 @@ validate_go_deps_tag $dockerfile
     $bindir/docker-build-go-deps
 ) >/dev/null
 
-tag="$(head_root_tag)"
-docker_build cli-bin $tag $dockerfile --build-arg CONDUIT_VERSION=$tag
-IMG=$(docker_repo cli-bin):$tag
-ID=$(docker create "$IMG")
+if [ -n "${CLI_OS:-}" ]; then
+  OS="${CLI_OS}"
+else
+    sys=$(uname -s)
+    if [ "$sys" = "Darwin" ]; then
+        OS="darwin"
+    elif [ "$sys" = "Linux" ]; then
+        OS="linux"
+    else
+        echo "unknown OS: $OS" >&2
+        exit 1
+    fi
+fi
 
-# copy the newly built conduit cli binaries to the local system
-for OS in darwin linux windows ; do
-    DIR="${rootdir}/target/cli/${OS}"
+name="cli-bin-${OS}"
+tag="$(head_root_tag)"
+
+docker_build "$name" "$tag" $dockerfile \
+    --build-arg CLI_OS="$OS" \
+    --build-arg CONDUIT_VERSION="$tag"
+
+if [ -n "${CLI_EXPORT:-}" ]; then
+    IMG=$(docker_repo "$name"):$tag
+    ID=$(docker create "$IMG")
+
+    DIR="$rootdir/target/cli/$OS"
     mkdir -p "$DIR"
 
     if docker cp "$ID:/out/conduit-${OS}" "$DIR/conduit" ; then
@@ -38,6 +56,6 @@ for OS in darwin linux windows ; do
         docker rm "$ID" >/dev/null
         exit 1
     fi
-done
 
-docker rm "$ID" >/dev/null
+    docker rm "$ID" >/dev/null
+fi

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -16,7 +16,7 @@ docker_image() {
 
 tag=$(head_root_tag)
 
-for img in cli-bin controller grafana proxy proxy-init web  ; do
+for img in controller grafana proxy proxy-init web  ; do
     docker_image "$img" "$tag"
 done
 

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -13,6 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-for img in cli-bin controller grafana proxy proxy-init web  ; do
+for img in controller grafana proxy proxy-init web  ; do
     docker_pull "$img" "$tag"
 done

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -13,6 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-for img in cli-bin controller grafana proxy proxy-init web  ; do
+for img in controller grafana proxy proxy-init web  ; do
     docker_push "$img" "$tag"
 done

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -13,6 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-for img in cli-bin controller grafana proxy proxy-init web  ; do
+for img in controller grafana proxy proxy-init web  ; do
     docker_retag "$img" "$from" "$to"
 done

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -10,15 +10,12 @@ COPY pkg pkg
 RUN mkdir -p /out
 
 # Cache builds without version info
-RUN CGO_ENABLED=0 GOOS=darwin  go build -installsuffix cgo -o /out/conduit-darwin  ./cli
-RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux   ./cli
-RUN CGO_ENABLED=0 GOOS=windows go build -installsuffix cgo -o /out/conduit-windows ./cli
+ARG CLI_OS="linux"
+RUN CGO_ENABLED=0 GOOS="$CLI_OS" go build -installsuffix cgo -o "/out/conduit-${CLI_OS}" ./cli
 
 ARG CONDUIT_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/runconduit/conduit/pkg/version.Version=${CONDUIT_VERSION}"
-RUN CGO_ENABLED=0 GOOS=darwin  go build -installsuffix cgo -o /out/conduit-darwin  -ldflags "${GO_LDFLAGS}" ./cli
-RUN CGO_ENABLED=0 GOOS=linux   go build -installsuffix cgo -o /out/conduit-linux   -ldflags "${GO_LDFLAGS}" ./cli
-RUN CGO_ENABLED=0 GOOS=windows go build -installsuffix cgo -o /out/conduit-windows -ldflags "${GO_LDFLAGS}" ./cli
+RUN CGO_ENABLED=0 GOOS="$CLI_OS" go build -installsuffix cgo -o "/out/conduit-${CLI_OS}"  -ldflags "${GO_LDFLAGS}" ./cli
 
 ## export without sources & dependencies
 FROM scratch


### PR DESCRIPTION
Currently cli/Dockerfile-bin builds binaries for Darwin, Linux, and
Windows.  In the typical case this is 3x as much work as is necessary.

The following changes have been made:

- bin/docker-build-cli-bin may now produce one of 3 images:
  cli-bin-{darwin,linux,windows}

- By default, only images for the local OS are built. This may be
  overridden with the `CLI_OS` environment variable.

- By default, bin/docker-build-cli-bin does NOT export binaries into the
  local filesystem unless the `CLI_EXPORT` env var is set and not empty.

- cli-bin-* images are no longer published to the registry, since they are
  entirely unused outside of the release process

- Furthermore, cli-bin images are **not** built as a part of bin/docker-build.
  In this vast majority of cases this is wasted work.

As a followup, we'll need to document the release process (i.e. setting CLI_EXPORT and CLI_OS for each target os).