### PR TITLE
bin/conduit: Extract CLI binaries into a tag-specific dir

### DIFF
--- a/bin/conduit
+++ b/bin/conduit
@@ -19,11 +19,19 @@ fi
 . $bindir/_tag.sh
 
 tag="$(head_root_tag)"
-bin="$rootdir/target/cli/${OS}/conduit"
+bin="$rootdir/target/cli-${tag}/${OS}/conduit"
 
 # build conduit executable if it does not exist
 if [ ! -f $bin ]; then
   CLI_EXPORT=1 CLI_OS="$OS" $bindir/docker-build-cli-bin >/dev/null
 fi
+
+for d in $(ls -d $rootdir/target/cli-*) ; do
+  if [ -d "$d" ]; then
+    if [ "$d" != "$rootdir/target/cli-${tag}" ]; then
+      rm -rf "$d"
+    fi
+  fi
+done
 
 exec $bin "$@"

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -47,7 +47,7 @@ if [ -n "${CLI_EXPORT:-}" ]; then
     IMG=$(docker_repo "$name"):$tag
     ID=$(docker create "$IMG")
 
-    DIR="$rootdir/target/cli/$OS"
+    DIR="$rootdir/target/cli-${tag}/$OS"
     mkdir -p "$DIR"
 
     if docker cp "$ID:/out/conduit-${OS}" "$DIR/conduit" ; then


### PR DESCRIPTION
bin/conduit extracts CLI binaries out of a docker image, but it's easy
for cached versions of the binary to hide updates.

This change causes extracted images to be placed in tag-specific
directories so that bin/conduit reliably uses the most up-to-date
version of the CLI.

bin/conduit deletes unused directories.