### PR TITLE
proxy/router: Implement LRU cache eviction

### DIFF
--- a/proxy/router/src/cache.rs
+++ b/proxy/router/src/cache.rs
@@ -1,29 +1,59 @@
 use indexmap::IndexMap;
-use std::hash::Hash;
+use std::{hash::Hash, ops::{Deref, DerefMut}, time::{Duration, Instant}};
 
 // Reexported so IndexMap isn't exposed.
 pub use indexmap::Equivalent;
 
-/// A cache for routes
+/// An LRU cache
 ///
 /// ## Assumptions
 ///
 /// - `access` is common;
 /// - `store` is less common;
-/// - `capacity` is large enough..
+/// - `capacity` is large enough that idle vals need not be removed frequently.
 ///
 /// ## Complexity
 ///
 /// - `access` computes in O(1) time (amortized average).
 /// - `store` computes in O(1) time (average).
-// TODO LRU
-pub struct Cache<K: Hash + Eq, V> {
-    vals: IndexMap<K, V>,
+/// - `reserve` computes in O(n) time (average) when capacity is not available,
+pub struct Cache<K: Hash + Eq, V, N: Now = ()> {
+    vals: IndexMap<K, Node<V>>,
     capacity: usize,
+    max_idle_age: Duration,
+
+    /// The time source.
+    now: N,
 }
 
-pub struct Reserve<'a, K: Hash + Eq + 'a, V: 'a> {
-    vals: &'a mut IndexMap<K, V>,
+/// Provides the current time within the module. Useful for testing.
+pub trait Now {
+    fn now(&self) -> Instant;
+}
+
+/// Wraps values
+#[derive(Debug, PartialEq)]
+pub struct Node<T> {
+    value: T,
+    last_access: Instant,
+}
+
+/// A smart pointer that updates an access time when dropped.
+///
+/// Wraps a mutable reference to a `V`-typed value.
+///
+/// When the guard is dropped, the value's `last_access` time is updated with the provided
+/// time source.
+#[derive(Debug)]
+pub struct Access<'a, T: 'a, N: Now + 'a = ()> {
+    node: &'a mut Node<T>,
+    now: &'a N,
+}
+
+#[derive(Debug)]
+pub struct Reserve<'a, K: Hash + Eq + 'a, V: 'a, N: 'a> {
+    vals: &'a mut IndexMap<K, Node<V>>,
+    now: &'a N,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -31,58 +61,179 @@ pub struct CapacityExhausted {
     pub capacity: usize,
 }
 
-impl<K: Hash + Eq, V> Cache<K, V> {
-    pub fn new(capacity: usize) -> Self {
+// ===== impl Cache =====
+
+impl<K: Hash + Eq, V> Cache<K, V, ()> {
+    pub fn new(capacity: usize, max_idle_age: Duration) -> Self {
         Self {
             capacity,
             vals: IndexMap::default(),
+            max_idle_age,
+            now: (),
         }
     }
+}
 
+impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
     /// Accesses a route.
-    // TODO track access times for each entry.
-    pub fn access<Q>(&mut self, key: &Q) -> Option<&mut V>
+    ///
+    /// A mutable reference to the route is wrapped in the returned `Access` to
+    /// ensure that the access-time is updated when the reference is released.
+    pub fn access<Q>(&mut self, key: &Q) -> Option<Access<V, N>>
     where
         Q: Hash + Equivalent<K>,
     {
-        self.vals.get_mut(key)
+        let v = self.vals.get_mut(key)?;
+        Some(v.access(&self.now))
     }
 
     /// Ensures that there is capacity to store an additional route.
     ///
+    /// Returns a handle that may be used to store an ite,. If there is no available
+    /// capacity, idle entries may be evicted to create capacity.
+    ///
     /// An error is returned if there is no available capacity.
-    // TODO evict old entries
-    pub fn reserve(&mut self) -> Result<Reserve<K, V>, CapacityExhausted> {
-        let avail = self.capacity - self.vals.len();
-        if avail == 0 {
-            // TODO If the cache is full, evict the oldest inactive route. If all
-            // routes are active, fail the request.
-            return Err(CapacityExhausted {
-                capacity: self.capacity,
-            });
+    pub fn reserve(&mut self) -> Result<Reserve<K, V, N>, CapacityExhausted> {
+        if self.vals.len() == self.capacity {
+            let epoch = self.now.now() - self.max_idle_age;
+            self.vals.retain(|_, n| epoch <= n.last_access());
+
+            if self.vals.len() == self.capacity {
+                return Err(CapacityExhausted {
+                    capacity: self.capacity,
+                });
+            }
         }
 
         Ok(Reserve {
             vals: &mut self.vals,
+            now: &self.now,
         })
+    }
+
+    /// Overrides the time source for tests.
+    #[cfg(test)]
+    fn with_clock<M: Now>(self, now: M) -> Cache<K, V, M> {
+        Cache {
+            now,
+            vals: self.vals,
+            capacity: self.capacity,
+            max_idle_age: self.max_idle_age,
+        }
     }
 }
 
-impl<'a, K: Hash + Eq + 'a, V: 'a> Reserve<'a, K, V> {
+// ===== impl Reserve =====
+
+impl<'a, K: Hash + Eq + 'a, V: 'a, N: Now + 'a> Reserve<'a, K, V, N> {
     /// Stores a route in the cache.
     pub fn store(self, key: K, val: V) {
-        self.vals.insert(key, val);
+        let node = Node::new(val.into(), self.now.now());
+        self.vals.insert(key, node);
+    }
+}
+
+// ===== impl Access =====
+
+impl<'a, T: 'a, N: Now + 'a> Deref for Access<'a, T, N> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+impl<'a, T: 'a, N: Now + 'a> DerefMut for Access<'a, T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.node
+    }
+}
+
+impl<'a, T: 'a, N: Now + 'a> Access<'a, T, N> {
+    #[cfg(test)]
+    fn last_access(&self) -> Instant {
+        self.node.last_access
+    }
+}
+
+impl<'a, T: 'a, N: Now + 'a> Drop for Access<'a, T, N> {
+    fn drop(&mut self) {
+        self.node.last_access = self.now.now();
+    }
+}
+
+// ===== impl Node =====
+
+impl<T> Node<T> {
+    pub fn new(value: T, last_access: Instant) -> Self {
+        Node { value, last_access }
+    }
+
+    pub fn access<'a, N: Now + 'a>(&'a mut self, now: &'a N) -> Access<'a, T, N> {
+        Access { now, node: self }
+    }
+
+    pub fn last_access(&self) -> Instant {
+        self.last_access
+    }
+}
+
+impl<T> Deref for Node<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for Node<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+// ===== impl Now =====
+
+/// Default source of time.
+impl Now for () {
+    fn now(&self) -> Instant {
+        Instant::now()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::Future;
+    use std::{cell::RefCell, rc::Rc, time::{Duration, Instant}};
     use test_util::MultiplyAndAssign;
+    use tower_service::Service;
+
+    /// A mocked instance of `Now` to drive tests.
+    #[derive(Clone)]
+    pub struct Clock(Rc<RefCell<Instant>>);
+
+    // ===== impl Clock =====
+
+    impl Default for Clock {
+        fn default() -> Clock {
+            Clock(Rc::new(RefCell::new(Instant::now())))
+        }
+    }
+
+    impl Clock {
+        pub fn advance(&mut self, d: Duration) {
+            *self.0.borrow_mut() += d;
+        }
+    }
+
+    impl Now for Clock {
+        fn now(&self) -> Instant {
+            self.0.borrow().clone()
+        }
+    }
 
     #[test]
     fn reserve_and_store() {
-        let mut cache = Cache::<_, MultiplyAndAssign>::new(2);
+        let mut cache = Cache::<_, MultiplyAndAssign>::new(2, Duration::from_secs(1));
 
         {
             let r = cache.reserve().expect("reserve");
@@ -105,7 +256,7 @@ mod tests {
 
     #[test]
     fn store_and_access() {
-        let mut cache = Cache::<_, MultiplyAndAssign>::new(2);
+        let mut cache = Cache::<_, MultiplyAndAssign>::new(2, Duration::from_secs(0));
 
         assert!(cache.access(&1).is_none());
         assert!(cache.access(&2).is_none());
@@ -123,5 +274,131 @@ mod tests {
         }
         assert!(cache.access(&1).is_some());
         assert!(cache.access(&2).is_some());
+    }
+
+    #[test]
+    fn reserve_does_nothing_when_capacity_exists() {
+        let mut cache = Cache::<_, MultiplyAndAssign, _>::new(2, Duration::from_secs(0));
+
+        // Create a route that goes idle immediately:
+        {
+            let r = cache.reserve().expect("capacity");
+            let mut service = MultiplyAndAssign::default();
+            service.call(1.into()).wait().unwrap();
+            r.store(1, service);
+        };
+        assert_eq!(cache.vals.len(), 1);
+
+        assert!(cache.reserve().is_ok());
+        assert_eq!(cache.vals.len(), 1);
+    }
+
+    #[test]
+    fn reserve_honors_max_idle_age() {
+        let mut clock = Clock::default();
+        let mut cache = Cache::<_, MultiplyAndAssign, _>::new(1, Duration::from_secs(2))
+            .with_clock(clock.clone());
+
+        // Touch `1` at 0s.
+        cache
+            .reserve()
+            .expect("capacity")
+            .store(1, MultiplyAndAssign::default());
+        assert_eq!(
+            cache.reserve().err(),
+            Some(CapacityExhausted { capacity: 1 })
+        );
+        assert_eq!(cache.vals.len(), 1);
+
+        // No capacity at 1s.
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(
+            cache.reserve().err(),
+            Some(CapacityExhausted { capacity: 1 })
+        );
+        assert_eq!(cache.vals.len(), 1);
+
+        // No capacity at 2s.
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(
+            cache.reserve().err(),
+            Some(CapacityExhausted { capacity: 1 })
+        );
+        assert_eq!(cache.vals.len(), 1);
+
+        // Capacity at >2s.
+        clock.advance(Duration::from_millis(1));
+        assert!(cache.reserve().is_ok());
+        assert_eq!(cache.vals.len(), 0);
+    }
+
+    #[test]
+    fn last_access() {
+        let mut clock = Clock::default();
+        let mut cache =
+            Cache::<_, MultiplyAndAssign>::new(1, Duration::from_secs(0)).with_clock(clock.clone());
+
+        let t0 = clock.now();
+        cache
+            .reserve()
+            .expect("capacity")
+            .store(333, MultiplyAndAssign::default());
+
+        clock.advance(Duration::from_secs(1));
+        let t1 = clock.now();
+        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t0));
+
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t1));
+    }
+
+    #[test]
+    fn last_access_wiped_on_evict() {
+        let mut clock = Clock::default();
+        let mut cache =
+            Cache::<_, MultiplyAndAssign>::new(1, Duration::from_secs(0)).with_clock(clock.clone());
+
+        let t0 = clock.now();
+        cache
+            .reserve()
+            .expect("capacity")
+            .store(333, MultiplyAndAssign::default());
+
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t0));
+
+        // Cause the router to evict the `333` route.
+        clock.advance(Duration::from_secs(1));
+        cache
+            .reserve()
+            .expect("capacity")
+            .store(444, MultiplyAndAssign::default());
+
+        clock.advance(Duration::from_secs(1));
+        let t1 = clock.now();
+        cache
+            .reserve()
+            .expect("capacity")
+            .store(333, MultiplyAndAssign::default());
+
+        clock.advance(Duration::from_secs(1));
+        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t1));
+    }
+
+    #[test]
+    fn node_access_updated_on_drop() {
+        let mut clock = Clock::default();
+        let t0 = clock.now();
+        let mut node = Node::new(123, t0);
+
+        clock.advance(Duration::from_secs(1));
+        {
+            let access = node.access(&clock);
+            assert_eq!(access.last_access(), t0);
+        }
+
+        let t1 = clock.now();
+        assert_eq!(node.last_access(), t1);
+        assert_ne!(t0, t1);
     }
 }


### PR DESCRIPTION
The router's cache has no means to evict unused entries when capacity is
reached.

This change does the following:

- Wraps cache values in a smart pointer that tracks the last time of
  access for each entry. The smart pointer updates the access time when
  the reference to entry is dropped.
- When capacity is not available, all nodes that have not been accessed
  within some minimal idle age are dropped.

Accesses and updates to the map are O(1) when capacity is available.
Reclaiming capacity is O(n), so it's expected that the router is
configured with enough capacity such that capacity need not be reclaimed
usually.