### PR TITLE
Start polling for new resource type immediately after switching tabs

### DIFF
--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -30,7 +30,7 @@ export default class ResourceList extends React.Component {
   }
 
   componentDidMount() {
-    this.startServerPolling();
+    this.startServerPolling(this.props.resource);
   }
 
   componentWillReceiveProps(newProps) {
@@ -46,7 +46,7 @@ export default class ResourceList extends React.Component {
 
   startServerPolling(resource) {
     this.loadFromServer(resource);
-    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval, resource);
   }
 
   stopServerPolling() {
@@ -55,7 +55,6 @@ export default class ResourceList extends React.Component {
   }
 
   loadFromServer(resource) {
-    resource = resource || this.props.resource;
     if (this.state.pendingRequests) {
       return; // don't make more requests if the ones we sent haven't completed
     }


### PR DESCRIPTION
Fix issue where we were waiting for the next polling interval when switching tabs.
When we switch tabs, we update the Props of the ResourceList component, but we weren't 
resetting how we poll the server. This meant we'd wait until the end of the current polling interval (2s) to get the data for the tab we just switched to. 

I've added `stopServerPolling` and `startServerPolling` methods so that we can cancel the resource requests of the page we're leaving and immediately start polling for new data if the resource type changes.
