### PR TITLE
Modify the Stat API to handle requests for resource type "all"

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -202,23 +202,28 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 		}
 	}
 
-	for resourceType, stats := range statTables {
+	if len(statTables) == 0 {
+		fmt.Fprintln(os.Stderr, "No traffic found.")
+		os.Exit(0)
+	}
 
+	lastDisplayedStat := true // don't print a newline after the final stat
+	for resourceType, stats := range statTables {
+		if !lastDisplayedStat {
+
+			fmt.Fprint(w, "\n")
+		}
+		lastDisplayedStat = false
 		if reqResourceType == k8s.All {
 			printStatTable(stats, resourceType, w, maxNameLength, maxNamespaceLength)
 		} else {
 			printStatTable(stats, "", w, maxNameLength, maxNamespaceLength)
 		}
-		fmt.Fprint(w, "\n")
+
 	}
 }
 
 func printStatTable(stats map[string]*row, resourceType string, w *tabwriter.Writer, maxNameLength int, maxNamespaceLength int) {
-	if len(stats) == 0 {
-		fmt.Fprintln(os.Stderr, "No traffic found.")
-		os.Exit(0)
-	}
-
 	headers := make([]string, 0)
 	if allNamespaces {
 		headers = append(headers,

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -212,7 +212,6 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 	lastDisplayedStat := true // don't print a newline after the final stat
 	for resourceType, stats := range statTables {
 		if !lastDisplayedStat {
-
 			fmt.Fprint(w, "\n")
 		}
 		lastDisplayedStat = false
@@ -221,7 +220,6 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 		} else {
 			printStatTable(stats, "", w, maxNameLength, maxNamespaceLength)
 		}
-
 	}
 }
 

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -39,6 +39,7 @@ var statCmd = &cobra.Command{
   * deploy/my-deploy
   * deploy my-deploy
   * ns/my-ns
+  * all
 
 Valid resource types include:
 
@@ -47,6 +48,7 @@ Valid resource types include:
   * pods
   * replicationcontrollers
   * services (only supported if a "--from" is also specified, or as a "--to")
+  * all (all resource types, not supported in --from or --to)
 
 This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases.
 If no resource name is specified, displays stats about all resources of the specified RESOURCETYPE`,

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -151,14 +151,13 @@ type row struct {
 }
 
 var (
-	nameHeader         = "NAME"
-	namespaceHeader    = "NAMESPACE"
-	maxNameLength      = len(nameHeader)
-	maxNamespaceLength = len(namespaceHeader)
+	nameHeader      = "NAME"
+	namespaceHeader = "NAMESPACE"
 )
 
 func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w *tabwriter.Writer) {
-
+	maxNameLength := len(nameHeader)
+	maxNamespaceLength := len(namespaceHeader)
 	statTables := make(map[string]map[string]*row)
 
 	for _, statTable := range resp.GetOk().StatTables {
@@ -206,15 +205,15 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 	for resourceType, stats := range statTables {
 
 		if reqResourceType == k8s.All {
-			printStatTable(stats, resourceType, w)
+			printStatTable(stats, resourceType, w, maxNameLength, maxNamespaceLength)
 		} else {
-			printStatTable(stats, "", w)
+			printStatTable(stats, "", w, maxNameLength, maxNamespaceLength)
 		}
 		fmt.Fprint(w, "\n")
 	}
 }
 
-func printStatTable(stats map[string]*row, resourceType string, w *tabwriter.Writer) {
+func printStatTable(stats map[string]*row, resourceType string, w *tabwriter.Writer, maxNameLength int, maxNamespaceLength int) {
 	if len(stats) == 0 {
 		fmt.Fprintln(os.Stderr, "No traffic found.")
 		os.Exit(0)

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -70,7 +70,7 @@ func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest
 
 	statTables := make([]*pb.StatTable, 0)
 
-	if req.Selector.Resource.Type == "all" {
+	if req.Selector.Resource.Type == k8s.All {
 		// request stats for all resourceTypes, in parallel
 		resultChan := make(chan resourceResult)
 

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -66,6 +66,16 @@ func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest
 				},
 			},
 		}, nil
+
+	switch req.Outbound.(type) {
+	case *pb.StatSummaryRequest_ToResource:
+		if req.Outbound.(*pb.StatSummaryRequest_ToResource).ToResource.Type == k8s.All {
+			return nil, status.Errorf(codes.InvalidArgument, "resource type 'all' is not supported as a filter")
+		}
+	case *pb.StatSummaryRequest_FromResource:
+		if req.Outbound.(*pb.StatSummaryRequest_FromResource).FromResource.Type == k8s.All {
+			return nil, status.Errorf(codes.InvalidArgument, "resource type 'all' is not supported as a filter")
+		}
 	}
 
 	statTables := make([]*pb.StatTable, 0)

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -223,6 +223,16 @@ spec:
       - image: buoyantio/emojivoto-emoji-svc:v3
 `, `
 apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  namespace: emojivoto
+spec:
+  clusterIP: None
+  selector:
+    app: emoji-svc
+`, `
+apiVersion: v1
 kind: Pod
 metadata:
   name: emojivoto-pod-1
@@ -281,13 +291,6 @@ status:
 								&pb.StatTable{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
-											Rows: []*pb.StatTable_PodGroup_Row{},
-										},
-									},
-								},
-								&pb.StatTable{
-									Table: &pb.StatTable_PodGroup_{
-										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
 												&pb.StatTable_PodGroup_Row{
 													Resource: &pb.Resource{
@@ -319,6 +322,24 @@ status:
 														Namespace: "emojivoto",
 														Type:      "pods",
 														Name:      "emojivoto-pod-2",
+													},
+													TimeWindow:      "1m",
+													MeshedPodCount:  1,
+													RunningPodCount: 1,
+												},
+											},
+										},
+									},
+								},
+								&pb.StatTable{
+									Table: &pb.StatTable_PodGroup_{
+										PodGroup: &pb.StatTable_PodGroup{
+											Rows: []*pb.StatTable_PodGroup_Row{
+												&pb.StatTable_PodGroup_Row{
+													Resource: &pb.Resource{
+														Namespace: "emojivoto",
+														Type:      "services",
+														Name:      "emoji-svc",
 													},
 													TimeWindow:      "1m",
 													MeshedPodCount:  1,

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -98,9 +98,13 @@ func BuildStatSummaryRequest(p StatSummaryRequestParams) (*pb.StatSummaryRequest
 		window = p.TimeWindow
 	}
 
-	resourceType, err := k8s.CanonicalKubernetesNameFromFriendlyName(p.ResourceType)
-	if err != nil {
-		return nil, err
+	resourceType := p.ResourceType
+	var err error
+	if resourceType != "all" {
+		resourceType, err = k8s.CanonicalKubernetesNameFromFriendlyName(p.ResourceType)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	statRequest := &pb.StatSummaryRequest{

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -100,7 +100,7 @@ func BuildStatSummaryRequest(p StatSummaryRequestParams) (*pb.StatSummaryRequest
 
 	resourceType := p.ResourceType
 	var err error
-	if resourceType != "all" {
+	if resourceType != k8s.All {
 		resourceType, err = k8s.CanonicalKubernetesNameFromFriendlyName(p.ResourceType)
 		if err != nil {
 			return nil, err
@@ -194,7 +194,13 @@ func BuildResource(namespace string, args ...string) (pb.Resource, error) {
 }
 
 func buildResource(namespace string, resType string, name string) (pb.Resource, error) {
-	canonicalType, err := k8s.CanonicalKubernetesNameFromFriendlyName(resType)
+	canonicalType := resType
+	var err error
+
+	if canonicalType != k8s.All {
+		canonicalType, err = k8s.CanonicalKubernetesNameFromFriendlyName(resType)
+	}
+
 	if err != nil {
 		return pb.Resource{}, err
 	}

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -98,13 +98,9 @@ func BuildStatSummaryRequest(p StatSummaryRequestParams) (*pb.StatSummaryRequest
 		window = p.TimeWindow
 	}
 
-	resourceType := p.ResourceType
-	var err error
-	if resourceType != k8s.All {
-		resourceType, err = k8s.CanonicalKubernetesNameFromFriendlyName(p.ResourceType)
-		if err != nil {
-			return nil, err
-		}
+	resourceType, err := k8s.CanonicalKubernetesNameFromFriendlyName(p.ResourceType)
+	if err != nil {
+		return nil, err
 	}
 
 	statRequest := &pb.StatSummaryRequest{
@@ -194,12 +190,7 @@ func BuildResource(namespace string, args ...string) (pb.Resource, error) {
 }
 
 func buildResource(namespace string, resType string, name string) (pb.Resource, error) {
-	canonicalType := resType
-	var err error
-
-	if canonicalType != k8s.All {
-		canonicalType, err = k8s.CanonicalKubernetesNameFromFriendlyName(resType)
-	}
+	canonicalType, err := k8s.CanonicalKubernetesNameFromFriendlyName(resType)
 
 	if err != nil {
 		return pb.Resource{}, err

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -191,7 +191,6 @@ func BuildResource(namespace string, args ...string) (pb.Resource, error) {
 
 func buildResource(namespace string, resType string, name string) (pb.Resource, error) {
 	canonicalType, err := k8s.CanonicalKubernetesNameFromFriendlyName(resType)
-
 	if err != nil {
 		return pb.Resource{}, err
 	}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -80,6 +80,8 @@ func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error
 		return ReplicationControllers, nil
 	case "svc", "service", "services":
 		return Services, nil
+	case "all":
+		return All, nil
 	}
 
 	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -86,3 +86,22 @@ func CanonicalKubernetesNameFromFriendlyName(friendlyName string) (string, error
 
 	return "", fmt.Errorf("cannot find Kubernetes canonical name from friendly name [%s]", friendlyName)
 }
+
+// Return a the shortest name for a k8s canonical name.
+// Essentially the reverse of CanonicalKubernetesNameFromFriendlyName
+func ShortNameFromCanonicalKubernetesName(canonicalName string) string {
+	switch canonicalName {
+	case Deployments:
+		return "deploy"
+	case Namespaces:
+		return "ns"
+	case Pods:
+		return "po"
+	case ReplicationControllers:
+		return "rc"
+	case Services:
+		return "svc"
+	default:
+		return ""
+	}
+}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -14,6 +14,7 @@ const (
 	Pods                   = "pods"
 	ReplicationControllers = "replicationcontrollers"
 	Services               = "services"
+	All                    = "all"
 )
 
 // ResourceTypesToProxyLabels maps Kubernetes resource type names to keys


### PR DESCRIPTION
Allow the `Stat` endpoint in the `public-api` to accept requests for resourceType "all".
Currently, this queries Pods, Deployments, RCs and Services, but can be modified to query other things as well.

Both the CLI and web endpoints now work if you set resourceType to `all`.

Examples:

```
http://localhost:8084/api/stat?resource_type=all&namespace=emojivoto
```

```
$ go run cli/main.go stat all -n emojivoto --api-addr localhost:8085
NAME                           MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
po/emoji-5f6854bc96-kmwqv         1/1   100.00%   0.3rps           5ms          10ms          10ms
po/emoji-5f6854bc96-r842n         1/1   100.00%   0.5rps           5ms          10ms          10ms
po/vote-bot-6659cc85cb-dldds      1/1         -        -             -             -             -
po/voting-844b495b9d-jj2vl        1/1         -        -             -             -             -
po/voting-844b495b9d-tplzn        1/1         -        -             -             -             -
po/web-77fdc7bc7d-k5lbt           1/1   100.00%   0.1rps           7ms          28ms          30ms
po/web-77fdc7bc7d-t9d7f           1/1         -        -             -             -             -

NAME                           MESHED   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
svc/emoji-svc                     2/2         -     -             -             -             -
svc/voting-svc                    2/2         -     -             -             -             -
svc/web-svc                       2/2         -     -             -             -             -

NAME                           MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
deploy/emoji                      2/2   100.00%   0.9rps           5ms          10ms          10ms
deploy/vote-bot                   1/1         -        -             -             -             -
deploy/voting                     2/2         -        -             -             -             -
deploy/web                        2/2   100.00%   0.1rps           7ms          28ms          30ms
```