### PR TITLE
Fix compile errors in `reserve()`

### DIFF
--- a/proxy/router/src/cache.rs
+++ b/proxy/router/src/cache.rs
@@ -104,9 +104,12 @@ impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
             // Only whole seconds are used to determine whether a node should be retained.
             // This is intended to prevent the need for repetitive reservations when
             // entries are clustered in tight time ranges.
+            // NOTE: the `as_secs()` could be removed if we *know* `self.max_idle_age`
+            //       is always a whole number of seconds.
+            let max_idle_secs = self.max_idle_age.as_secs();
             self.vals.retain(|_, n| {
                 let since_last_access = n.last_access().elapsed().as_secs();
-                since_last_access <= self.max_idle_age.as_secs()
+                since_last_access <= max_idle_secs
             });
 
             if self.vals.len() == self.capacity {

--- a/proxy/router/src/cache.rs
+++ b/proxy/router/src/cache.rs
@@ -104,8 +104,10 @@ impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
             // Only whole seconds are used to determine whether a node should be retained.
             // This is intended to prevent the need for repetitive reservations when
             // entries are clustered in tight time ranges.
-            let epoch = (self.now.now() - self.max_idle_age).as_secs();
-            self.vals.retain(|_, n| epoch <= n.last_access().as_secs());
+            self.vals.retain(|_, n| {
+                let since_last_access = n.last_access().elapsed().as_secs();
+                since_last_access <= self.max_idle_age.as_secs()
+            });
 
             if self.vals.len() == self.capacity {
                 return Err(CapacityExhausted {


### PR DESCRIPTION
This fixes the compile errors in `reserve()` relating to `std::time::Instant` being an opaque type that can't be converted to a duration. 

Rather than calculating an `epoch` from the current time minus the maximum idle age and then testing that the `last_access` timestamp for each value is within the `epoch`, I've modified the code to simply test whether the time _elapsed_ since each timestamp (a `Duration`, which we _can_ round to whole seconds) is less than or equal to the max age. This should have the same behaviour as the original implementation intended, but with the advantage of actually compiling :)