### PR TITLE
CLI: Fix validation for service stats

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -89,7 +89,8 @@ If no resource name is specified, displays stats about all resources of the spec
 
 		output, err := requestStatsFromAPI(client, req)
 		if err != nil {
-			return err
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
 		}
 
 		_, err = fmt.Print(output)
@@ -112,7 +113,10 @@ func init() {
 func requestStatsFromAPI(client pb.ApiClient, req *pb.StatSummaryRequest) (string, error) {
 	resp, err := client.StatSummary(context.Background(), req)
 	if err != nil {
-		return "", fmt.Errorf("error calling stat with request: %v", err)
+		return "", fmt.Errorf("StatSummary API error: %v", err)
+	}
+	if e := resp.GetError(); e != nil {
+		return "", fmt.Errorf("StatSummary API error: %v", e.Error)
 	}
 
 	return renderStats(resp), nil

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -89,8 +89,7 @@ If no resource name is specified, displays stats about all resources of the spec
 
 		output, err := requestStatsFromAPI(client, req)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
+			return err
 		}
 
 		_, err = fmt.Print(output)
@@ -116,7 +115,7 @@ func requestStatsFromAPI(client pb.ApiClient, req *pb.StatSummaryRequest) (strin
 		return "", fmt.Errorf("StatSummary API error: %v", err)
 	}
 	if e := resp.GetError(); e != nil {
-		return "", fmt.Errorf("StatSummary API error: %v", e.Error)
+		return "", fmt.Errorf("StatSummary API response error: %v", e.Error)
 	}
 
 	return renderStats(resp), nil


### PR DESCRIPTION
This branch fixes an issue with the way that we were rejecting invalid requests for service stats. The current implementation panics with a nil pointer error:

```
$ conduit stat svc
panic: runtime error: invalid memory address or nil pointer dereference
```

With this change it returns the error from the server:

```
$ bin/conduit stat svc 
StatSummary API error: service only supported as a target on 'from' queries, or as a destination on 'to' queries
```

---

The previous implementation was also not validating that the `--from` resource is not a service, and I've added validation for that. Previously:

```
$ conduit stat pods --from svc/web
No traffic found.
```

With this change it's now rejected as invalid:

```
$ bin/conduit stat pods --from svc/web
StatSummary API error: service only supported as a target on 'from' queries, or as a destination on 'to' queries
```