### PR TITLE
rfc: proxy: Prevent active services from being evicted 

### DIFF
--- a/proxy/router/src/cache.rs
+++ b/proxy/router/src/cache.rs
@@ -4,6 +4,8 @@ use std::{hash::Hash, ops::{Deref, DerefMut}, time::{Duration, Instant}};
 // Reexported so IndexMap isn't exposed.
 pub use indexmap::Equivalent;
 
+use Retain;
+
 /// An LRU cache
 ///
 /// ## Assumptions
@@ -23,10 +25,11 @@ pub use indexmap::Equivalent;
 /// The underlying datastructure could be improved somewhat so that `reserve` can evict
 /// unused nodes more efficiently. Given that eviction is intended to be rare, this is
 /// probably not a very high priority.
-pub struct Cache<K: Hash + Eq, V, N: Now = ()> {
+pub struct Cache<K: Hash + Eq, V, R: Retain<K, V> = (), N: Now = ()> {
     vals: IndexMap<K, Node<V>>,
     capacity: usize,
     max_idle_age: Duration,
+    retain: R,
 
     /// The time source.
     now: N,
@@ -70,18 +73,19 @@ pub struct CapacityExhausted {
 
 // ===== impl Cache =====
 
-impl<K: Hash + Eq, V> Cache<K, V, ()> {
+impl<K: Hash + Eq, V> Cache<K, V, (), ()> {
     pub fn new(capacity: usize, max_idle_age: Duration) -> Self {
         Self {
             capacity,
             vals: IndexMap::default(),
             max_idle_age,
+            retain: (),
             now: (),
         }
     }
 }
 
-impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
+impl<K: Hash + Eq, V, R: Retain<K, V>, N: Now> Cache<K, V, R, N> {
     /// Accesses a route.
     ///
     /// A mutable reference to the route is wrapped in the returned `Access` to
@@ -105,12 +109,19 @@ impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
             // Only whole seconds are used to determine whether a node should be retained.
             // This is intended to prevent the need for repetitive reservations when
             // entries are clustered in tight time ranges.
-            let max_age = self.max_idle_age.as_secs();
-            let now = self.now.now();
-            self.vals.retain(|_, n| {
-                let age = now - n.last_access();
-                age.as_secs() <= max_age
-            });
+            {
+                let max_age = self.max_idle_age.as_secs();
+                let now = self.now.now();
+                let retain = &self.retain;
+                self.vals.retain(|ref k, ref mut n| {
+                    let age = now - n.last_access();
+                    if age.as_secs() <= max_age {
+                        true
+                    } else {
+                        retain.retain(k, n)
+                    }
+                });
+            }
 
             if self.vals.len() == self.capacity {
                 return Err(CapacityExhausted {
@@ -125,14 +136,25 @@ impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
         })
     }
 
+    pub fn with_retain<S: Retain<K, V>>(self, retain: S) -> Cache<K, V, S, N> {
+        Cache {
+            retain,
+            capacity: self.capacity,
+            vals: self.vals,
+            max_idle_age: self.max_idle_age,
+            now: self.now,
+        }
+    }
+
     /// Overrides the time source for tests.
     #[cfg(test)]
-    fn with_clock<M: Now>(self, now: M) -> Cache<K, V, M> {
+    fn with_clock<M: Now>(self, now: M) -> Cache<K, V, R, M> {
         Cache {
             now,
             vals: self.vals,
             capacity: self.capacity,
             max_idle_age: self.max_idle_age,
+            retain: self.retain,
         }
     }
 }

--- a/proxy/router/src/cache.rs
+++ b/proxy/router/src/cache.rs
@@ -48,7 +48,7 @@ pub trait Now {
 
 /// Wraps cache values so that each tracks its last access time.
 #[derive(Debug, PartialEq)]
-pub struct Node<T> {
+struct Node<T> {
     value: T,
     last_access: Instant,
 }

--- a/proxy/router/src/cache.rs
+++ b/proxy/router/src/cache.rs
@@ -115,11 +115,7 @@ impl<K: Hash + Eq, V, R: Retain<K, V>, N: Now> Cache<K, V, R, N> {
                 let retain = &self.retain;
                 self.vals.retain(|ref k, ref mut n| {
                     let age = now - n.last_access();
-                    if age.as_secs() <= max_age {
-                        true
-                    } else {
-                        retain.retain(k, n)
-                    }
+                    (age.as_secs() <= max_age) || retain.retain(k, n)
                 });
             }
 

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -96,7 +96,8 @@ pub type Stack<B> = Reconnect<NormalizeUri<NewHttp<B>>>;
 
 pub type NewHttp<B> = sensor::NewHttp<Client<B>, B, HttpBody>;
 
-pub type HttpResponse = http::Response<sensor::http::ResponseBody<HttpBody>>;
+pub type HttpResponseBody = sensor::http::ResponseBody<HttpBody>;
+pub type HttpResponse = http::Response<HttpResponseBody>;
 
 pub type HttpRequest<B> = http::Request<sensor::http::RequestBody<B>>;
 

--- a/proxy/src/http_active.rs
+++ b/proxy/src/http_active.rs
@@ -6,38 +6,54 @@ use tower_service::Service;
 
 use conduit_proxy_router::Retain;
 
-/// Keeps an account of how many HTTP requests are active
+/// Keeps account of how many HTTP requests are active.
+///
+/// This service wraps any HTTP service and adds an extension to both requests and
+/// responses so that, as long as the message is held in memory, the service is considered
+/// active. This is intended to count long-lived streams in ways that, for instance,
+/// `InFlightLimit` cannot.
+///
+/// ### TODO
+/// - audit inner services to ensure that messages are not dropped before bodies.
+#[derive(Debug)]
 pub struct HttpActive<S, A, B>
 where
     S: Service<Request = http::Request<A>, Response = http::Response<B>>,
 {
+    /// An underlying HTTP service.
     inner: S,
-    gauge: Gauge,
+    meter: Meter,
 }
 
+/// `HttpActive`'s response future.
+///
+/// Ensures that the response is tracked.
+#[derive(Debug)]
 pub struct Respond<F, B>
 where
     F: Future<Item = http::Response<B>>,
 {
     inner: F,
-    gauge: Gauge,
+    meter: Meter,
 }
 
-pub struct RetainActive<K, S, A, B> {
+/// An implementation of `Retain` for `HttpActive` values.
+#[derive(Debug)]
+pub struct RetainHttpActive<K, S, A, B> {
     _p: PhantomData<(K, S, A, B)>,
 }
 
-/// Counts the number of active messages to determine gaugeness.
-#[derive(Debug, Default, Clone)]
-struct Gauge(Arc<AtomicUsize>);
+/// Counts the number of active messages to determine active-ness.
+#[derive(Clone, Debug, Default)]
+struct Meter(Arc<AtomicUsize>);
 
 /// A handle that decrements the number of active messages on drop.
 #[derive(Debug)]
 struct Active(Option<Arc<AtomicUsize>>);
 
-// ===== impl RetainActive =====
+// ===== impl RetainHttpActive =====
 
-impl<K, S, A, B> Default for RetainActive<K, S, A, B>
+impl<K, S, A, B> Default for RetainHttpActive<K, S, A, B>
 where
     S: Service<Request = http::Request<A>, Response = http::Response<B>>,
 {
@@ -46,21 +62,21 @@ where
     }
 }
 
-impl<K, S, A, B> Retain<K, HttpActive<S, A, B>> for RetainActive<K, S, A, B>
+impl<K, S, A, B> Retain<K, HttpActive<S, A, B>> for RetainHttpActive<K, S, A, B>
 where
     S: Service<Request = http::Request<A>, Response = http::Response<B>>,
 {
-    /// Retains active endpoints
+    /// Returns true iff `svc` has active requests.
     fn retain(&self, _: &K, svc: &mut HttpActive<S, A, B>) -> bool {
-        svc.gauge.is_active()
+        svc.meter.count() > 0
     }
 }
 
-// ===== impl Gauge =====
+// ===== impl Meter =====
 
-impl Gauge {
-    fn is_active(&self) -> bool {
-        self.0.load(Ordering::Acquire) > 0
+impl Meter {
+    fn count(&self) -> usize {
+        self.0.load(Ordering::Acquire)
     }
 
     pub fn active(&mut self) -> Active {
@@ -73,23 +89,21 @@ impl Gauge {
 
 impl Drop for Active {
     fn drop(&mut self) {
-        if let Some(active) = self.0.take() {
-            active.fetch_sub(1, Ordering::AcqRel);
+        if let Some(meter) = self.0.take() {
+            meter.fetch_sub(1, Ordering::AcqRel);
         }
     }
 }
 
 // ===== impl HttpActive =====
 
-impl<S, A, B> From<S> for HttpActive<S, A, B>
+impl<S, A, B> HttpActive<S, A, B>
 where
     S: Service<Request = http::Request<A>, Response = http::Response<B>>,
 {
-    fn from(inner: S) -> Self {
-        Self {
-            inner,
-            gauge: Gauge::default(),
-        }
+    pub fn new(inner: S) -> Self {
+        let meter = Meter::default();
+        Self { inner, meter }
     }
 }
 
@@ -107,10 +121,10 @@ where
     }
 
     fn call(&mut self, mut req: Self::Request) -> Self::Future {
-        req.extensions_mut().insert(self.gauge.active());
+        req.extensions_mut().insert(self.meter.active());
         Respond {
             inner: self.inner.call(req),
-            gauge: self.gauge.clone(),
+            meter: self.meter.clone(),
         }
     }
 }
@@ -126,30 +140,108 @@ where
 
     fn poll(&mut self) -> Poll<http::Response<B>, Self::Error> {
         let mut rsp = try_ready!(self.inner.poll());
-        rsp.extensions_mut().insert(self.gauge.active());
+        rsp.extensions_mut().insert(self.meter.active());
         Ok(rsp.into())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use futures::{future, Poll};
+    use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+    use tower_service::Service;
     use super::*;
 
     #[test]
-    fn gauge_activity() {
-        let mut gauge = Gauge::default();
-        assert!(!gauge.is_active());
+    fn meter_activity() {
+        let mut meter = Meter::default();
+        assert_eq!(meter.count(), 0);
 
-        let act0 = gauge.active();
-        assert!(gauge.is_active());
+        let act0 = meter.active();
+        assert_eq!(meter.count(), 1);
 
-        let act1 = gauge.active();
-        assert!(gauge.is_active());
+        let act1 = meter.active();
+        assert_eq!(meter.count(), 2);
 
         drop(act0);
-        assert!(gauge.is_active());
+        assert_eq!(meter.count(), 1);
 
         drop(act1);
-        assert!(!gauge.is_active());
+        assert_eq!(meter.count(), 0);
     }
+
+    #[test]
+    fn http_active() {
+        let svc = Svc::default();
+        let reqs = svc.0.clone();
+
+        let mut active = HttpActive::new(svc);
+        assert_eq!(active.meter.count(), 0);
+
+        let rsp0 = active.call_ok(Request::new(()));
+        assert_eq!(active.meter.count(), 2);
+
+        drop((*reqs.borrow_mut()).pop_front());
+        assert_eq!(active.meter.count(), 1);
+
+        let rsp1 = active.call_ok(Request::new(()));
+        assert_eq!(active.meter.count(), 3);
+
+        drop(rsp1);
+        assert_eq!(active.meter.count(), 2);
+
+        drop(rsp0);
+        assert_eq!(active.meter.count(), 1);
+
+        drop((*reqs.borrow_mut()).pop_front());
+        assert_eq!(active.meter.count(), 0);
+    }
+
+    #[test]
+    fn retain_http_active() {
+        let svc = Svc::default();
+        let reqs = svc.0.clone();
+
+        let mut active = HttpActive::new(svc);
+        let retain = RetainHttpActive::default();
+        assert_eq!(retain.retain(&(), &mut active), false);
+
+        let rsp0 = active.call_ok(Request::new(()));
+        assert_eq!(retain.retain(&(), &mut active), true);
+
+        drop((*reqs.borrow_mut()).pop_front());
+        assert_eq!(retain.retain(&(), &mut active), true);
+
+        drop(rsp0);
+        assert_eq!(retain.retain(&(), &mut active), false);
+    }
+
+    impl HttpActive<Svc, (), ()> {
+        fn call_ok(&mut self, req: Request) -> Response {
+            self.call(req).wait().expect("should serve")
+        }
+    }
+
+    type Request = http::Request<()>;
+    type Response = http::Response<()>;
+
+    #[derive(Debug, Default)]
+    struct Svc(Rc<RefCell<VecDeque<Request>>>);
+
+    impl Service for Svc {
+        type Request = http::Request<()>;
+        type Response = http::Response<()>;
+        type Error = ();
+        type Future = future::FutureResult<Self::Response, Self::Error>;
+
+        fn poll_ready(&mut self) -> Poll<(), ()> {
+            Ok(().into())
+        }
+
+        fn call(&mut self, req: Self::Request) -> Self::Future {
+            (*self.0.borrow_mut()).push_back(req);
+            future::ok(http::Response::new(()))
+        }
+    }
+
 }

--- a/proxy/src/http_active.rs
+++ b/proxy/src/http_active.rs
@@ -1,0 +1,155 @@
+use std::marker::PhantomData;
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+use futures::{Future, Poll};
+use http;
+use tower_service::Service;
+
+use conduit_proxy_router::Retain;
+
+/// Keeps an account of how many HTTP requests are active
+pub struct HttpActive<S, A, B>
+where
+    S: Service<Request = http::Request<A>, Response = http::Response<B>>,
+{
+    inner: S,
+    gauge: Gauge,
+}
+
+pub struct Respond<F, B>
+where
+    F: Future<Item = http::Response<B>>,
+{
+    inner: F,
+    gauge: Gauge,
+}
+
+pub struct RetainActive<K, S, A, B> {
+    _p: PhantomData<(K, S, A, B)>,
+}
+
+/// Counts the number of active messages to determine gaugeness.
+#[derive(Debug, Default, Clone)]
+struct Gauge(Arc<AtomicUsize>);
+
+/// A handle that decrements the number of active messages on drop.
+#[derive(Debug)]
+struct Active(Option<Arc<AtomicUsize>>);
+
+// ===== impl RetainActive =====
+
+impl<K, S, A, B> Default for RetainActive<K, S, A, B>
+where
+    S: Service<Request = http::Request<A>, Response = http::Response<B>>,
+{
+    fn default() -> Self {
+        Self { _p :PhantomData }
+    }
+}
+
+impl<K, S, A, B> Retain<K, HttpActive<S, A, B>> for RetainActive<K, S, A, B>
+where
+    S: Service<Request = http::Request<A>, Response = http::Response<B>>,
+{
+    /// Retains active endpoints
+    fn retain(&self, _: &K, svc: &mut HttpActive<S, A, B>) -> bool {
+        svc.gauge.is_active()
+    }
+}
+
+// ===== impl Gauge =====
+
+impl Gauge {
+    fn is_active(&self) -> bool {
+        self.0.load(Ordering::Acquire) > 0
+    }
+
+    pub fn active(&mut self) -> Active {
+        self.0.fetch_add(1, Ordering::AcqRel);
+        Active(Some(self.0.clone()))
+    }
+}
+
+// ===== impl Active =====
+
+impl Drop for Active {
+    fn drop(&mut self) {
+        if let Some(active) = self.0.take() {
+            active.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
+
+// ===== impl HttpActive =====
+
+impl<S, A, B> From<S> for HttpActive<S, A, B>
+where
+    S: Service<Request = http::Request<A>, Response = http::Response<B>>,
+{
+    fn from(inner: S) -> Self {
+        Self {
+            inner,
+            gauge: Gauge::default(),
+        }
+    }
+}
+
+impl<S, A, B> Service for HttpActive<S, A, B>
+where
+    S: Service<Request = http::Request<A>, Response = http::Response<B>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Respond<S::Future, B>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, mut req: Self::Request) -> Self::Future {
+        req.extensions_mut().insert(self.gauge.active());
+        Respond {
+            inner: self.inner.call(req),
+            gauge: self.gauge.clone(),
+        }
+    }
+}
+
+// ===== impl Respond =====
+
+impl<F, B> Future for Respond<F, B>
+where
+    F: Future<Item = http::Response<B>>,
+{
+    type Item = http::Response<B>;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<http::Response<B>, Self::Error> {
+        let mut rsp = try_ready!(self.inner.poll());
+        rsp.extensions_mut().insert(self.gauge.active());
+        Ok(rsp.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gauge_activity() {
+        let mut gauge = Gauge::default();
+        assert!(!gauge.is_active());
+
+        let act0 = gauge.active();
+        assert!(gauge.is_active());
+
+        let act1 = gauge.active();
+        assert!(gauge.is_active());
+
+        drop(act0);
+        assert!(gauge.is_active());
+
+        drop(act1);
+        assert!(!gauge.is_active());
+    }
+}

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -95,7 +95,7 @@ where
         let binding = self.bind.new_binding(&endpoint, proto);
         Buffer::new(binding, self.bind.executor())
             .map(|buffer| {
-                HttpActive::from(InFlightLimit::new(buffer, MAX_IN_FLIGHT))
+                HttpActive::new(InFlightLimit::new(buffer, MAX_IN_FLIGHT))
             })
             .map_err(|_| bind::BufferSpawnError::Inbound)
     }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -57,7 +57,7 @@ use indexmap::IndexSet;
 use tokio_core::reactor::{Core, Handle};
 use tower_service::NewService;
 use tower_fn::*;
-use conduit_proxy_router::{Recognize, Router, Error as RouteError};
+use conduit_proxy_router::{Recognize, Retain, Router, Error as RouteError};
 
 pub mod app;
 mod bind;
@@ -67,6 +67,7 @@ pub mod control;
 pub mod ctx;
 mod dns;
 mod drain;
+mod http_active;
 mod inbound;
 mod logging;
 mod map_err;
@@ -231,6 +232,7 @@ where
                 Inbound::new(default_addr, bind),
                 config.inbound_router_capacity,
                 config.inbound_router_max_idle_age,
+                http_active::RetainActive::default(),
             );
             let fut = serve(
                 inbound_listener,
@@ -256,6 +258,7 @@ where
                 Outbound::new(bind, control, config.bind_timeout),
                 config.outbound_router_capacity,
                 config.outbound_router_max_idle_age,
+                http_active::RetainActive::default(),
             );
             let fut = serve(
                 outbound_listener,
@@ -333,9 +336,9 @@ where
     }
 }
 
-fn serve<R, B, E, F, G>(
+fn serve<R, K, B, E, F, G>(
     bound_port: BoundPort,
-    router: Router<R>,
+    router: Router<R, K>,
     tcp_connect_timeout: Duration,
     disable_protocol_detection_ports: IndexSet<u16>,
     proxy_ctx: Arc<ctx::Proxy>,
@@ -355,6 +358,7 @@ where
         RouteError = F,
     >
         + 'static,
+    K: Retain<R::Key, R::Service> + 'static,
     G: GetOriginalDst + 'static,
 {
     let stack = Arc::new(NewServiceFn::new(move || {

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -232,7 +232,7 @@ where
                 Inbound::new(default_addr, bind),
                 config.inbound_router_capacity,
                 config.inbound_router_max_idle_age,
-                http_active::RetainActive::default(),
+                http_active::RetainHttpActive::default(),
             );
             let fut = serve(
                 inbound_listener,
@@ -258,7 +258,7 @@ where
                 Outbound::new(bind, control, config.bind_timeout),
                 config.outbound_router_capacity,
                 config.outbound_router_max_idle_age,
-                http_active::RetainActive::default(),
+                http_active::RetainHttpActive::default(),
             );
             let fut = serve(
                 outbound_listener,

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -18,6 +18,7 @@ use bind::{self, Bind, Protocol};
 use control::{self, discovery};
 use control::discovery::Bind as BindTrait;
 use ctx;
+use http_active::HttpActive;
 use timeout::Timeout;
 use transparency::h1;
 use transport::{DnsNameAndPort, Host, HostAndPort};
@@ -75,10 +76,14 @@ where
     type Error = <Self::Service as tower::Service>::Error;
     type Key = (Destination, Protocol);
     type RouteError = bind::BufferSpawnError;
-    type Service = InFlightLimit<Timeout<Buffer<Balance<
-        load::WithPendingRequests<Discovery<B>>,
-        choose::PowerOfTwoChoices<rand::ThreadRng>
-    >>>>;
+    type Service = HttpActive<
+        InFlightLimit<Timeout<Buffer<Balance<
+            load::WithPendingRequests<Discovery<B>>,
+            choose::PowerOfTwoChoices<rand::ThreadRng>,
+        >>>>,
+        B,
+        bind::HttpResponseBody,
+    >;
 
     fn recognize(&self, req: &Self::Request) -> Option<Self::Key> {
         let proto = bind::Protocol::detect(req);
@@ -164,7 +169,7 @@ where
 
         let timeout = Timeout::new(buffer, self.bind_timeout, handle);
 
-        Ok(InFlightLimit::new(timeout, MAX_IN_FLIGHT))
+        Ok(HttpActive::from(InFlightLimit::new(timeout, MAX_IN_FLIGHT)))
 
     }
 }

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -169,7 +169,7 @@ where
 
         let timeout = Timeout::new(buffer, self.bind_timeout, handle);
 
-        Ok(HttpActive::from(InFlightLimit::new(timeout, MAX_IN_FLIGHT)))
+        Ok(HttpActive::new(InFlightLimit::new(timeout, MAX_IN_FLIGHT)))
 
     }
 }


### PR DESCRIPTION
It's possible for there to be services that are not accessed by the
router but have active streams (e.g. downloads, long-lived streams).
It's not appropriate to evict services that are busy doing work.

This change adds a `Retain` trait to the router, encapsulating the
decision of whether an idle node may be evicted.

The proxy then provides an implementation of `Retain`,
`RetainHttpActive`, that ensures services with in-flight requests
are not evicted. This is achieved by installing HTTP message
extensions that allow the service to know how many messages are
currently being held in memory (via the `HttpActive` middleware).
The `RetainHttpActive` implementation is specific to services
wrapped by `HttpActive`.
