### PR TITLE
proxy: Update to Rust 1.26.0

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,7 +4,7 @@
 # This reduces build time and produces binaries with debug symbols, at the expense of
 # runtime perforamnce.
 
-ARG RUST_IMAGE=rust:1.25.0
+ARG RUST_IMAGE=rust:1.26.0
 ARG RUNTIME_IMAGE=gcr.io/runconduit/base:2017-10-30.01
 
 ## Builds the proxy as incrementally as possible.


### PR DESCRIPTION
[Rust 1.26.0](https://blog.rust-lang.org/2018/05/10/Rust-1.26.html) is now available.

Notably, this release adds support for `impl Trait`.