### PR TITLE
proxy: Upgrade Conduit to use the new version of Tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-signal 0.1.5 (git+https://github.com/alexcrichton/tokio-signal.git?rev=7ecaa90dfe21edb1afa48c0173cbee6c3c210130)",
+ "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -633,12 +633,12 @@ name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -705,7 +705,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -959,8 +959,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-signal"
-version = "0.1.5"
-source = "git+https://github.com/alexcrichton/tokio-signal.git?rev=7ecaa90dfe21edb1afa48c0173cbee6c3c210130#7ecaa90dfe21edb1afa48c0173cbee6c3c210130"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1374,7 +1374,7 @@ dependencies = [
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c22f20a157cb4af265c71e47db525852368feeb4a0013f0f8c68a7f4ef0d0fc1"
+"checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8b30dc85588cd02b9b76f5e386535db546d21dc68506cff2abebee0b6445e8e4"
@@ -1399,7 +1399,7 @@ dependencies = [
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31f98b200e7caca9efca50fc0aa69cd58a5ec81d5f6e75b2f3ecaad2e998972a"
-"checksum syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)" = "70f57ecb0ad755f810029917826394be7d5d3975e875028ff9d58ac71e640d80"
+"checksum syn 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)" = "505550dded6ff93eb63bd9d0ada380ffccd9f51c046a5e80a3078d53fcef0038"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
@@ -1411,7 +1411,7 @@ dependencies = [
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
 "checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
-"checksum tokio-signal 0.1.5 (git+https://github.com/alexcrichton/tokio-signal.git?rev=7ecaa90dfe21edb1afa48c0173cbee6c3c210130)" = "<none>"
+"checksum tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5783254b10c7c84a56f62c74766ef7e5b83d1f13053218c7cab8d3f2c826fa0e"
 "checksum tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535fed0ccee189f3d48447587697ba3fd234b3dbbb091f0ec4613ddfec0a7c4c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.6"
+name = "arrayvec"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -27,23 +35,23 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -52,32 +60,23 @@ name = "backtrace-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "build_const"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -85,35 +84,26 @@ name = "bytes"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.4"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "chrono"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "codegen"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/codegen#9b2f81859e91931871456ad06437643585d35866"
 dependencies = [
- "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -125,38 +115,38 @@ dependencies = [
  "conduit-proxy-router 0.3.0",
  "convert 0.3.0",
  "deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.3.0",
  "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future.git)",
  "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnet 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-signal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-signal 0.1.5 (git+https://github.com/alexcrichton/tokio-signal.git?rev=7ecaa90dfe21edb1afa48c0173cbee6c3c210130)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
+ "tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)",
  "tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
- "trust-dns-resolver 0.8.2 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)",
+ "trust-dns-resolver 0.8.1 (git+https://github.com/bluejekyll/trust-dns)",
 ]
 
 [[package]]
@@ -165,24 +155,24 @@ version = "0.3.0"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "convert 0.3.0",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.3.2 (git+https://github.com/danburkert/prost)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
+ "tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)",
 ]
 
 [[package]]
 name = "conduit-proxy-router"
 version = "0.3.0"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -192,10 +182,40 @@ version = "0.3.0"
 
 [[package]]
 name = "crc"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -213,13 +233,13 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "either"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -232,13 +252,13 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.5.3"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,7 +274,7 @@ name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,12 +282,12 @@ name = "failure"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -275,7 +295,7 @@ name = "flate2"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -289,7 +309,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -300,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -308,7 +328,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -316,7 +336,7 @@ dependencies = [
 name = "futures-mpsc-lossy"
 version = "0.3.0"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -325,7 +345,7 @@ version = "0.1.0"
 source = "git+https://github.com/carllerche/better-future.git#07baa13e91fefe7a51533dfde7b4e69e109ebe14"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -333,7 +353,7 @@ name = "gzip-header"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -342,16 +362,16 @@ name = "h2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -359,7 +379,7 @@ name = "heck"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -367,7 +387,7 @@ name = "hostname"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -386,27 +406,35 @@ version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "hyper"
-version = "0.11.22"
+name = "humantime"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper"
+version = "0.12.0-pre.0"
+source = "git+https://github.com/hyperium/hyper#bc6af88a32e29e5a4f3719d8abc664f9ab10dddd"
+dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -416,12 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -429,7 +457,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -439,7 +467,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -447,15 +475,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itertools"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -466,11 +494,6 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -484,7 +507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.36"
+version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -497,7 +520,7 @@ name = "log"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -518,16 +541,13 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.5"
+name = "memoffset"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -535,7 +555,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -543,9 +563,9 @@ name = "miniz_oxide_c_api"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -559,20 +579,21 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mio-uds"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -582,7 +603,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -594,54 +615,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "net2"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "num"
-version = "0.1.42"
+name = "nodrop"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -649,7 +646,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -659,15 +656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "petgraph"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.2.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -678,7 +675,7 @@ name = "prost"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -688,12 +685,12 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -702,13 +699,13 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.3.2"
-source = "git+https://github.com/danburkert/prost#3427352e7e750dbc8d8b4be63816b55b0590d8bb"
+source = "git+https://github.com/danburkert/prost#45f781b18f3da1fc211682482449ecd624788fc6"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,7 +725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quickcheck"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,10 +733,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -748,7 +745,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -786,16 +783,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "relay"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "remove_dir_all"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -812,17 +801,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "safemem"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.0"
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -831,12 +815,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "smallvec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "socket2"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -847,11 +836,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.12.10"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -861,12 +850,12 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -877,7 +866,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -893,12 +882,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -906,55 +912,112 @@ name = "tokio-connect"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/tokio-connect#f413067d873dcb27540af2f45c135618c4e42a17"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "tokio-core"
-version = "0.1.12"
+name = "tokio-executor"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "tokio-service"
-version = "0.1.0"
+name = "tokio-reactor"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-signal"
 version = "0.1.5"
+source = "git+https://github.com/alexcrichton/tokio-signal.git?rev=7ecaa90dfe21edb1afa48c0173cbee6c3c210130#7ecaa90dfe21edb1afa48c0173cbee6c3c210130"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tcp"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-threadpool"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-timer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-udp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -962,8 +1025,8 @@ name = "tower-balance"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -975,7 +1038,7 @@ name = "tower-buffer"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -984,29 +1047,29 @@ name = "tower-discover"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#8c238944c772e31ced155410f91206e1423c01f0"
+source = "git+https://github.com/tower-rs/tower-grpc#f222daa50fcf4e601e741b409aef879114b17dd4"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
+ "tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#8c238944c772e31ced155410f91206e1423c01f0"
+source = "git+https://github.com/tower-rs/tower-grpc#f222daa50fcf4e601e741b409aef879114b17dd4"
 dependencies = [
  "codegen 0.1.0 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,16 +1079,15 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#1ce770cdda5e9665759ea543992ecc5e40140ae3"
+source = "git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio#fde50d7e00f8ee8150435f28424060df06066929"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -1034,7 +1096,7 @@ name = "tower-in-flight-limit"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -1043,7 +1105,7 @@ name = "tower-reconnect"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
@@ -1053,7 +1115,7 @@ name = "tower-service"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1061,55 +1123,60 @@ name = "tower-util"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
 dependencies = [
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.3.3"
-source = "git+https://github.com/bluejekyll/trust-dns?branch=0.8_release#ce6952c9ba5a41fb0b7c5f90cf1870a5e8029e2d"
+version = "0.3.2"
+source = "git+https://github.com/bluejekyll/trust-dns#4b1c518f55625ece97006414f06a32bf7e3f54c4"
 dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.8.2"
-source = "git+https://github.com/bluejekyll/trust-dns?branch=0.8_release#ce6952c9ba5a41fb0b7c5f90cf1870a5e8029e2d"
+version = "0.8.1"
+source = "git+https://github.com/bluejekyll/trust-dns#4b1c518f55625ece97006414f06a32bf7e3f54c4"
 dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-proto 0.3.3 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)",
+ "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trust-dns-proto 0.3.2 (git+https://github.com/bluejekyll/trust-dns)",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicase"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -1121,12 +1188,12 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1158,14 +1225,19 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "version_check"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "want"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "widestring"
@@ -1237,34 +1309,36 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
-"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
-"checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
+"checksum backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea58cd16fd6c9d120b5bcb01d63883ae4cc7ba2aed35c1841b862a3c7ef6639"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
-"checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
-"checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
-"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
+"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum codegen 0.1.0 (git+https://github.com/carllerche/codegen)" = "<none>"
-"checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
+"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+"checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
+"checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
+"checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"
-"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
-"checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
+"checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
 "checksum error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faa976b4fd2e4c2b2f3f486874b19e61944d3de3de8b61c9fcf835d583871bcc"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
-"checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
+"checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum futures-watch 0.1.0 (git+https://github.com/carllerche/better-future.git)" = "<none>"
 "checksum gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9fcfe1c9ee125342355b2467bc29b9dfcb2124fcae27edb9cee6f4cc5ecd40"
@@ -1273,95 +1347,98 @@ dependencies = [
 "checksum hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "58fab6e177434b0bb4cd344a4dabaa5bd6d7a8d792b1885aebcae7af1091d1cb"
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.11.22 (registry+https://github.com/rust-lang/crates.io-index)" = "d595f999e90624f64d2c4bc74c72adb0f3e0f773dc5692ca91338363b3568fa0"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
+"checksum hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper)" = "<none>"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
-"checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
+"checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec4e18c0a0d4340870c14284293632d8421f419008371422dd327892b88877c"
-"checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"
-"checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"
+"checksum ipnet 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e116517123026c62ef3d9b8283028d3b6d29e9d49ab947e02225a63d5b83c75b"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
-"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-"checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa2d3ad070f428fffbd7d3ca2ea20bb0d8cffe9024405c44e1840bc1418b398"
 "checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
-"checksum mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1731a873077147b626d89cc6c2a0db6288d607496c5d10c0cfcf3adc697ec673"
+"checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
-"checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
-"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
-"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
+"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
+"checksum num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c22f20a157cb4af265c71e47db525852368feeb4a0013f0f8c68a7f4ef0d0fc1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
-"checksum proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1cb7aaaa4bf022ec2b14ff2f2ba1643a22f3cee88df014a85e14b392282c61d"
+"checksum petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8b30dc85588cd02b9b76f5e386535db546d21dc68506cff2abebee0b6445e8e4"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5a92e500b2c925e5a6638a9523ce84bee02a4f64a8a3a0fab6062cda21e6ae4"
 "checksum prost-build 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "835da55b61e69c87eeab48f15eb3fc0dfade71f0908bb1a64e731abc46b3184f"
 "checksum prost-derive 0.3.2 (git+https://github.com/danburkert/prost)" = "<none>"
 "checksum prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "49b4fc1adae913fff99daa455ca43750f90cbec6846369fb78b7ed8d3e727758"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
-"checksum quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13f4460d3daa06eb1c4b9a3c55dffe65cb030dd70cf1bfdd482532f48ab24f74"
-"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
+"checksum quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
-"checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
-"checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b086bb6a2659d6ba66e4aa21bde8a53ec03587cd5c80b83bdc3a330f35cab"
-"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
-"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
+"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
-"checksum socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a76b792959eba82f021c9028c8ecb6396f085268d6d46af2ed96a829cc758d7c"
+"checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
+"checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31f98b200e7caca9efca50fc0aa69cd58a5ec81d5f6e75b2f3ecaad2e998972a"
-"checksum syn 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7d12ebcea3f1027a817b98e91cfe30805634ea1f63e36015f765960a7782494d"
+"checksum syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)" = "70f57ecb0ad755f810029917826394be7d5d3975e875028ff9d58ac71e640d80"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
+"checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
-"checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
+"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d00555353b013e170ed8bc4e13f648a317d1fd12157dbcae13f7013f6cf29f5"
 "checksum tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)" = "<none>"
-"checksum tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "52b4e32d8edbf29501aabb3570f027c6ceb00ccef6538f4bddba0200503e74e8"
-"checksum tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9532748772222bf70297ec0e2ad0f17213b4a7dd0e6afb68e0a0768f69f4e4f"
-"checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum tokio-signal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e8f46863230f9a05cf52d173721ec391b9c5782a2465f593029922b8782b9ffe"
+"checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
+"checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
+"checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
+"checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
+"checksum tokio-signal 0.1.5 (git+https://github.com/alexcrichton/tokio-signal.git?rev=7ecaa90dfe21edb1afa48c0173cbee6c3c210130)" = "<none>"
+"checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
+"checksum tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5783254b10c7c84a56f62c74766ef7e5b83d1f13053218c7cab8d3f2c826fa0e"
+"checksum tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535fed0ccee189f3d48447587697ba3fd234b3dbbb091f0ec4613ddfec0a7c4c"
+"checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
 "checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
+"checksum tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)" = "<none>"
 "checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum trust-dns-proto 0.3.3 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)" = "<none>"
-"checksum trust-dns-resolver 0.8.2 (git+https://github.com/bluejekyll/trust-dns?branch=0.8_release)" = "<none>"
+"checksum trust-dns-proto 0.3.2 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum trust-dns-resolver 0.8.1 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
-"checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
+"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
  "tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -164,7 +164,7 @@ dependencies = [
  "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
 ]
 
 [[package]]
@@ -805,6 +805,11 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "scoped-tls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +919,24 @@ source = "git+https://github.com/carllerche/tokio-connect#f413067d873dcb27540af2
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1062,7 +1085,7 @@ dependencies = [
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)",
+ "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -1079,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio#fde50d7e00f8ee8150435f28424060df06066929"
+source = "git+https://github.com/tower-rs/tower-h2#d9b3140e543af7887893cbf2f4337afd28d15839"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1087,6 +1110,7 @@ dependencies = [
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
@@ -1394,6 +1418,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b086bb6a2659d6ba66e4aa21bde8a53ec03587cd5c80b83bdc3a330f35cab"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
+"checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
@@ -1407,6 +1432,7 @@ dependencies = [
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d00555353b013e170ed8bc4e13f648a317d1fd12157dbcae13f7013f6cf29f5"
 "checksum tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)" = "<none>"
+"checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
 "checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
@@ -1421,7 +1447,7 @@ dependencies = [
 "checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
 "checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-h2 0.1.0 (git+https://github.com/hawkw/tower-h2?branch=eliza/new-tokio)" = "<none>"
+"checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
 "checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
  "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper)",
+ "hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.12.0-pre.0"
-source = "git+https://github.com/hyperium/hyper#bc6af88a32e29e5a4f3719d8abc664f9ab10dddd"
+source = "git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd#bc6af88a32e29e5a4f3719d8abc664f9ab10dddd"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1372,7 +1372,7 @@ dependencies = [
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
-"checksum hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper)" = "<none>"
+"checksum hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd)" = "<none>"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -84,7 +84,7 @@ name = "bytes"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -233,7 +233,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -362,7 +362,7 @@ name = "h2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,7 +675,7 @@ name = "prost"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -705,7 +705,7 @@ dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1046,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "tower-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "tower-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "tower-discover"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "tower-in-flight-limit"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "tower-reconnect"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "tower-service"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "tower-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#295ae583d473c57a6d51d251b87c3e20266a60b1"
+source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1154,9 +1154,9 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.3.2"
-source = "git+https://github.com/bluejekyll/trust-dns#4b1c518f55625ece97006414f06a32bf7e3f54c4"
+source = "git+https://github.com/bluejekyll/trust-dns#2f22e5a76eaed85665b9bf34cdd057c785ff1c8b"
 dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.8.1"
-source = "git+https://github.com/bluejekyll/trust-dns#4b1c518f55625ece97006414f06a32bf7e3f54c4"
+source = "git+https://github.com/bluejekyll/trust-dns#2f22e5a76eaed85665b9bf34cdd057c785ff1c8b"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,7 +1340,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-"checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+"checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
 "checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
@@ -1424,7 +1424,7 @@ dependencies = [
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31f98b200e7caca9efca50fc0aa69cd58a5ec81d5f6e75b2f3ecaad2e998972a"
-"checksum syn 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)" = "505550dded6ff93eb63bd9d0ada380ffccd9f51c046a5e80a3078d53fcef0038"
+"checksum syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)" = "77961dcdac942fa8bc033c16f3a790b311c8a27d00811b878ebd8cf9b7ba39d5"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hyper"
 version = "0.12.0-pre.0"
-source = "git+https://github.com/hyperium/hyper#b5a888b0dfb4d6657e00a662257b571d56bda2e7"
+source = "git+https://github.com/hyperium/hyper#bc6af88a32e29e5a4f3719d8abc664f9ab10dddd"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,12 +132,12 @@ dependencies = [
  "h2 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd)",
+ "hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "hyper"
 version = "0.12.0-pre.0"
-source = "git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd#bc6af88a32e29e5a4f3719d8abc664f9ab10dddd"
+source = "git+https://github.com/hyperium/hyper#b5a888b0dfb4d6657e00a662257b571d56bda2e7"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1400,7 +1400,7 @@ dependencies = [
 "checksum hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "58fab6e177434b0bb4cd344a4dabaa5bd6d7a8d792b1885aebcae7af1091d1cb"
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd)" = "<none>"
+"checksum hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper)" = "<none>"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.10"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -35,23 +35,23 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -60,23 +60,23 @@ name = "backtrace-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.0.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "build_const"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -84,26 +84,35 @@ name = "bytes"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "codegen"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/codegen#9b2f81859e91931871456ad06437643585d35866"
 dependencies = [
- "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,7 +124,7 @@ dependencies = [
  "conduit-proxy-router 0.3.0",
  "convert 0.3.0",
  "deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.3.0",
@@ -124,13 +133,13 @@ dependencies = [
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd)",
- "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipnet 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +170,7 @@ dependencies = [
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.3.2 (git+https://github.com/danburkert/prost)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
@@ -172,7 +181,7 @@ name = "conduit-proxy-router"
 version = "0.3.0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 
@@ -182,10 +191,10 @@ version = "0.3.0"
 
 [[package]]
 name = "crc"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,7 +212,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -215,7 +224,7 @@ name = "crossbeam-utils"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -233,13 +242,13 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "either"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -252,13 +261,13 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.5.10"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -274,7 +283,7 @@ name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -282,12 +291,12 @@ name = "failure"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -309,7 +318,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -353,7 +362,7 @@ name = "gzip-header"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -362,12 +371,12 @@ name = "h2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -379,7 +388,7 @@ name = "heck"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -406,14 +415,6 @@ version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "humantime"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "hyper"
 version = "0.12.0-pre.0"
 source = "git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd#bc6af88a32e29e5a4f3719d8abc664f9ab10dddd"
@@ -427,7 +428,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -444,12 +445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -475,15 +476,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "1.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itertools"
-version = "0.7.8"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,7 +521,7 @@ name = "log"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -563,8 +564,8 @@ name = "miniz_oxide_c_api"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -589,10 +590,9 @@ dependencies = [
 
 [[package]]
 name = "mio-uds"
-version = "0.6.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -618,7 +618,7 @@ name = "net2"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -629,16 +629,43 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "num-traits"
-version = "0.1.43"
+name = "num"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.4"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -656,15 +683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "petgraph"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.8"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,7 +702,7 @@ name = "prost"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -685,12 +712,12 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -699,13 +726,13 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.3.2"
-source = "git+https://github.com/danburkert/prost#45f781b18f3da1fc211682482449ecd624788fc6"
+source = "git+https://github.com/danburkert/prost#3427352e7e750dbc8d8b4be63816b55b0590d8bb"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -725,7 +752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quickcheck"
-version = "0.6.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -733,10 +760,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -784,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -801,12 +828,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scoped-tls"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -829,7 +856,7 @@ name = "socket2"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -841,11 +868,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.10"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -855,12 +882,12 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termcolor"
-version = "0.3.6"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -887,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.40"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -931,7 +958,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -988,7 +1015,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1049,7 +1076,7 @@ version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1077,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#f222daa50fcf4e601e741b409aef879114b17dd4"
+source = "git+https://github.com/tower-rs/tower-grpc#8c238944c772e31ced155410f91206e1423c01f0"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1092,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#f222daa50fcf4e601e741b409aef879114b17dd4"
+source = "git+https://github.com/tower-rs/tower-grpc#8c238944c772e31ced155410f91206e1423c01f0"
 dependencies = [
  "codegen 0.1.0 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1102,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#d9b3140e543af7887893cbf2f4337afd28d15839"
+source = "git+https://github.com/tower-rs/tower-h2#1ce770cdda5e9665759ea543992ecc5e40140ae3"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1154,9 +1181,9 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.3.2"
-source = "git+https://github.com/bluejekyll/trust-dns#2f22e5a76eaed85665b9bf34cdd057c785ff1c8b"
+source = "git+https://github.com/bluejekyll/trust-dns#849453207c16e4f5639e321d213ac77595728981"
 dependencies = [
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,9 +1204,9 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.8.1"
-source = "git+https://github.com/bluejekyll/trust-dns#2f22e5a76eaed85665b9bf34cdd057c785ff1c8b"
+source = "git+https://github.com/bluejekyll/trust-dns#849453207c16e4f5639e321d213ac77595728981"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1212,12 +1239,12 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.7"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1334,30 +1361,31 @@ dependencies = [
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
-"checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
+"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
-"checksum backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea58cd16fd6c9d120b5bcb01d63883ae4cc7ba2aed35c1841b862a3c7ef6639"
+"checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
-"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-"checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
+"checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
-"checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
-"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum codegen 0.1.0 (git+https://github.com/carllerche/codegen)" = "<none>"
-"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+"checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
 "checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"
-"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
-"checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
+"checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
 "checksum error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faa976b4fd2e4c2b2f3f486874b19e61944d3de3de8b61c9fcf835d583871bcc"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
-"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+"checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -1371,14 +1399,13 @@ dependencies = [
 "checksum hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "58fab6e177434b0bb4cd344a4dabaa5bd6d7a8d792b1885aebcae7af1091d1cb"
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum hyper 0.12.0-pre.0 (git+https://github.com/hyperium/hyper?rev=bc6af88a32e29e5a4f3719d8abc664f9ab10dddd)" = "<none>"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
-"checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
+"checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec4e18c0a0d4340870c14284293632d8421f419008371422dd327892b88877c"
-"checksum ipnet 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e116517123026c62ef3d9b8283028d3b6d29e9d49ab947e02225a63d5b83c75b"
-"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
+"checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"
+"checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
@@ -1392,44 +1419,47 @@ dependencies = [
 "checksum miniz_oxide 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aaa2d3ad070f428fffbd7d3ca2ea20bb0d8cffe9024405c44e1840bc1418b398"
 "checksum miniz_oxide_c_api 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "92d98fdbd6145645828069b37ea92ca3de225e000d80702da25c20d3584b38a5"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
-"checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
+"checksum mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1731a873077147b626d89cc6c2a0db6288d607496c5d10c0cfcf3adc697ec673"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
+"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8b30dc85588cd02b9b76f5e386535db546d21dc68506cff2abebee0b6445e8e4"
-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
+"checksum proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1cb7aaaa4bf022ec2b14ff2f2ba1643a22f3cee88df014a85e14b392282c61d"
 "checksum prost 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5a92e500b2c925e5a6638a9523ce84bee02a4f64a8a3a0fab6062cda21e6ae4"
 "checksum prost-build 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "835da55b61e69c87eeab48f15eb3fc0dfade71f0908bb1a64e731abc46b3184f"
 "checksum prost-derive 0.3.2 (git+https://github.com/danburkert/prost)" = "<none>"
 "checksum prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "49b4fc1adae913fff99daa455ca43750f90cbec6846369fb78b7ed8d3e727758"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
-"checksum quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13f4460d3daa06eb1c4b9a3c55dffe65cb030dd70cf1bfdd482532f48ab24f74"
+"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b086bb6a2659d6ba66e4aa21bde8a53ec03587cd5c80b83bdc3a330f35cab"
-"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
-"checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31f98b200e7caca9efca50fc0aa69cd58a5ec81d5f6e75b2f3ecaad2e998972a"
-"checksum syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)" = "77961dcdac942fa8bc033c16f3a790b311c8a27d00811b878ebd8cf9b7ba39d5"
+"checksum syn 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7d12ebcea3f1027a817b98e91cfe30805634ea1f63e36015f765960a7782494d"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
+"checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
-"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d00555353b013e170ed8bc4e13f648a317d1fd12157dbcae13f7013f6cf29f5"
 "checksum tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)" = "<none>"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
@@ -1457,8 +1487,8 @@ dependencies = [
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
-"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
+"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
+"checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ members = [
 [patch.crates-io]
 prost-derive = { git = "https://github.com/danburkert/prost" }
 
+[patch."https://github.com/tower-rs/tower-h2"]
+tower-h2 = { git = "https://github.com/hawkw/tower-h2", branch = "eliza/new-tokio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ members = [
 [patch.crates-io]
 prost-derive = { git = "https://github.com/danburkert/prost" }
 
-[patch."https://github.com/tower-rs/tower-h2"]
-tower-h2 = { git = "https://github.com/hawkw/tower-h2", branch = "eliza/new-tokio" }
+# [patch."https://github.com/tower-rs/tower-h2"]
+# tower-h2 = { git = "https://github.com/hawkw/tower-h2", branch = "eliza/new-tokio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
 
 [patch.crates-io]
 prost-derive = { git = "https://github.com/danburkert/prost" }
-
-# [patch."https://github.com/tower-rs/tower-h2"]
-# tower-h2 = { git = "https://github.com/hawkw/tower-h2", branch = "eliza/new-tokio" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -23,7 +23,7 @@ futures-watch = { git = "https://github.com/carllerche/better-future.git" }
 h2 = "0.1.6"
 http = "0.1"
 httparse = "1.2"
-hyper = { version = "0.11.22", default-features = false, features = ["compat"] }
+hyper = { git = "https://github.com/hyperium/hyper" }
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "1.0.0"
@@ -32,14 +32,13 @@ rand = "0.4"
 # for config parsing
 regex = "1.0.0"
 
-tokio-core = "0.1"
-tokio-io = "0.1"
-tokio-signal = "0.1"
+tokio = "0.1.6"
+tokio-signal = { git = "https://github.com/alexcrichton/tokio-signal.git", rev = "7ecaa90dfe21edb1afa48c0173cbee6c3c210130"}
 
 prost = "0.3.0"
 prost-types = "0.3.0"
 
-trust-dns-resolver = { version = "0.8.2", default-features = false, git = "https://github.com/bluejekyll/trust-dns", branch = "0.8_release" }
+trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns", branch = "master" }
 
 #futures-watch   = { git = "https://github.com/carllerche/better-future" }
 
@@ -49,7 +48,7 @@ tower-balance         = { git = "https://github.com/tower-rs/tower" }
 tower-buffer          = { git = "https://github.com/tower-rs/tower" }
 tower-discover        = { git = "https://github.com/tower-rs/tower" }
 tower-grpc            = { git = "https://github.com/tower-rs/tower-grpc" }
-tower-h2              = { git = "https://github.com/tower-rs/tower-h2" }
+tower-h2              = { git = "https://github.com/tower-rs/tower-h2", branch = "eliza/new-tokio" }
 tower-reconnect       = { git = "https://github.com/tower-rs/tower" }
 tower-in-flight-limit = { git = "https://github.com/tower-rs/tower" }
 tower-util            = { git = "https://github.com/tower-rs/tower" }
@@ -61,3 +60,6 @@ libc = "0.2"
 quickcheck = { version = "0.6", default-features = false }
 conduit-proxy-controller-grpc = { path = "./controller-grpc" , features = ["arbitrary"] }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
+# `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
+# the `read` function.
+tokio-io = "0.1.6"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.4"
 regex = "1.0.0"
 
 tokio = "0.1.6"
-tokio-signal = { git = "https://github.com/alexcrichton/tokio-signal.git", rev = "7ecaa90dfe21edb1afa48c0173cbee6c3c210130"}
+tokio-signal = "0.2"
 
 prost = "0.3.0"
 prost-types = "0.3.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -23,7 +23,7 @@ futures-watch = { git = "https://github.com/carllerche/better-future.git" }
 h2 = "0.1.6"
 http = "0.1"
 httparse = "1.2"
-hyper = { git = "https://github.com/hyperium/hyper" }
+hyper = { git = "https://github.com/hyperium/hyper", rev = "bc6af88a32e29e5a4f3719d8abc664f9ab10dddd" }
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "1.0.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -20,7 +20,7 @@ deflate = {version = "0.7.18", features = ["gzip"] }
 env_logger = { version = "0.5", default-features = false }
 futures = "0.1"
 futures-watch = { git = "https://github.com/carllerche/better-future.git" }
-h2 = "0.1.6"
+h2 = "0.1.7"
 http = "0.1"
 httparse = "1.2"
 hyper = { git = "https://github.com/hyperium/hyper", rev = "bc6af88a32e29e5a4f3719d8abc664f9ab10dddd" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -48,7 +48,7 @@ tower-balance         = { git = "https://github.com/tower-rs/tower" }
 tower-buffer          = { git = "https://github.com/tower-rs/tower" }
 tower-discover        = { git = "https://github.com/tower-rs/tower" }
 tower-grpc            = { git = "https://github.com/tower-rs/tower-grpc" }
-tower-h2              = { git = "https://github.com/tower-rs/tower-h2", branch = "eliza/new-tokio" }
+tower-h2              = { git = "https://github.com/tower-rs/tower-h2" }
 tower-reconnect       = { git = "https://github.com/tower-rs/tower" }
 tower-in-flight-limit = { git = "https://github.com/tower-rs/tower" }
 tower-util            = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -23,7 +23,7 @@ futures-watch = { git = "https://github.com/carllerche/better-future.git" }
 h2 = "0.1.7"
 http = "0.1"
 httparse = "1.2"
-hyper = { git = "https://github.com/hyperium/hyper", rev = "bc6af88a32e29e5a4f3719d8abc664f9ab10dddd" }
+hyper = { git = "https://github.com/hyperium/hyper" }
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "1.0.0"

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -29,7 +29,6 @@ use transport;
 pub struct Bind<C, B> {
     ctx: C,
     sensors: telemetry::Sensors,
-    executor: Handle,
     req_ids: Arc<AtomicUsize>,
     _p: PhantomData<B>,
 }
@@ -139,9 +138,8 @@ impl Error for BufferSpawnError {
 }
 
 impl<B> Bind<(), B> {
-    pub fn new(executor: Handle) -> Self {
+    pub fn new() -> Self {
         Self {
-            executor,
             ctx: (),
             sensors: telemetry::Sensors::null(),
             req_ids: Default::default(),
@@ -160,7 +158,6 @@ impl<B> Bind<(), B> {
         Bind {
             ctx,
             sensors: self.sensors,
-            executor: self.executor,
             req_ids: self.req_ids,
             _p: PhantomData,
         }
@@ -172,17 +169,9 @@ impl<C: Clone, B> Clone for Bind<C, B> {
         Self {
             ctx: self.ctx.clone(),
             sensors: self.sensors.clone(),
-            executor: self.executor.clone(),
             req_ids: self.req_ids.clone(),
             _p: PhantomData,
         }
-    }
-}
-
-
-impl<C, B> Bind<C, B> {
-    pub fn executor(&self) -> &Handle {
-        &self.executor
     }
 }
 
@@ -208,7 +197,6 @@ where
         let client = transparency::Client::new(
             protocol,
             connect,
-            self.executor.clone()
         );
 
         let sensors = self.sensors.http(

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -380,7 +380,6 @@ impl<B: tower_h2::Body + 'static> tower::Service for Binding<B> {
 
 
 impl Protocol {
-
     pub fn detect<B>(req: &http::Request<B>) -> Self {
         if req.version() == http::Version::HTTP_2 {
             return Protocol::Http2

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -334,8 +334,6 @@ where
         if request.version() != http::Version::HTTP_2 &&
             // Skip normalizing the URI if it was received in
             // absolute form.
-            // TODO: we could probably skip this service altogether, if we
-            //       wrote some kind of `futures::Either` for services?
             !self.was_absolute_form
         {
             h1::normalize_our_view_of_uri(&mut request);

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -7,7 +7,6 @@ use std::sync::atomic::AtomicUsize;
 
 use futures::{Future, Poll, future};
 use http::{self, uri};
-use tokio_core::reactor::Handle;
 use tower_service as tower;
 use tower_h2;
 use tower_reconnect::Reconnect;
@@ -46,7 +45,11 @@ pub struct BindProtocol<C, B> {
 /// request.
 ///
 /// `Bound` serivces may be used to process an arbitrary number of requests.
-pub enum Binding<B: tower_h2::Body + 'static> {
+pub enum Binding<B>
+where
+    B: tower_h2::Body + Send + 'static,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
+{
     Bound(Stack<B>),
     BindsPerRequest {
         endpoint: Endpoint,
@@ -177,7 +180,8 @@ impl<C: Clone, B> Clone for Bind<C, B> {
 
 impl<B> Bind<Arc<ctx::Proxy>, B>
 where
-    B: tower_h2::Body + 'static,
+    B: tower_h2::Body + Send + 'static,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     fn bind_stack(&self, ep: &Endpoint, protocol: &Protocol) -> Stack<B> {
         debug!("bind_stack endpoint={:?}, protocol={:?}", ep, protocol);
@@ -190,7 +194,7 @@ where
 
         // Map a socket address to a connection.
         let connect = self.sensors.connect(
-            transport::Connect::new(addr, &self.executor),
+            transport::Connect::new(addr),
             &client_ctx,
         );
 
@@ -229,6 +233,12 @@ where
     }
 }
 
+// As a `Bind` instance does not actually contain a value of type `B` (it's
+// just `PhantomData<(B)>`, `Bind` can be `Send` or `Sync` as long as `C`
+// is `Send` or `Sync`, regardless of `B`.
+unsafe impl<C: Send, B> Send for Bind<C, B> {}
+unsafe impl<C: Sync, B> Sync for Bind<C, B> {}
+
 // ===== impl BindProtocol =====
 
 
@@ -243,7 +253,8 @@ impl<C, B> Bind<C, B> {
 
 impl<B> control::destination::Bind for BindProtocol<Arc<ctx::Proxy>, B>
 where
-    B: tower_h2::Body + 'static,
+    B: tower_h2::Body + Send + 'static,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Endpoint = Endpoint;
     type Request = http::Request<B>;
@@ -320,15 +331,25 @@ where
     }
 
     fn call(&mut self, mut request: S::Request) -> Self::Future {
-        if request.version() != http::Version::HTTP_2 {
-            h1::normalize_our_view_of_uri(&mut request, self.was_absolute_form);
+        if request.version() != http::Version::HTTP_2 &&
+            // Skip normalizing the URI if it was received in
+            // absolute form.
+            // TODO: we could probably skip this service altogether, if we
+            //       wrote some kind of `futures::Either` for services?
+            !self.was_absolute_form
+        {
+            h1::normalize_our_view_of_uri(&mut request);
         }
         self.inner.call(request)
     }
 }
 // ===== impl Binding =====
 
-impl<B: tower_h2::Body + 'static> tower::Service for Binding<B> {
+impl<B> tower::Service for Binding<B>
+where
+    B: tower_h2::Body + Send + 'static,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
+{
     type Request = <Stack<B> as tower::Service>::Request;
     type Response = <Stack<B> as tower::Service>::Response;
     type Error = <Stack<B> as tower::Service>::Error;

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -29,7 +29,7 @@ pub struct Bind<C, B> {
     ctx: C,
     sensors: telemetry::Sensors,
     req_ids: Arc<AtomicUsize>,
-    _p: PhantomData<B>,
+    _p: PhantomData<fn() -> B>,
 }
 
 /// Binds a `Service` from a `SocketAddr` for a pre-determined protocol.
@@ -232,12 +232,6 @@ where
         }
     }
 }
-
-// As a `Bind` instance does not actually contain a value of type `B` (it's
-// just `PhantomData<(B)>`, `Bind` can be `Send` or `Sync` as long as `C`
-// is `Send` or `Sync`, regardless of `B`.
-unsafe impl<C: Send, B> Send for Bind<C, B> {}
-unsafe impl<C: Sync, B> Sync for Bind<C, B> {}
 
 // ===== impl BindProtocol =====
 

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -101,9 +101,9 @@ impl BoundPort {
     // In the future it will also ensure that the connection is upgraded with
     // TLS when needed.
     pub fn listen_and_fold<T, F, Fut>(self, initial: T, f: F)
-        -> impl Future<Item = (), Error = io::Error> + Send + 'static
+        -> Box<Future<Item = (), Error = io::Error> + Send + 'static>
     where
-        F: Fn(T, (Connection, SocketAddr)) -> Fut + 'static,
+        F: Fn(T, (Connection, SocketAddr)) -> Fut + Send + 'static,
         T: Send + 'static,
         Fut: IntoFuture<Item = T, Error = std::io::Error> + Send + 'static,
         <Fut as IntoFuture>::Future: Send, {
@@ -111,6 +111,8 @@ impl BoundPort {
             .expect("TcpListener::FromStd") // TODO: get rid of this `expect()`.
             .incoming()
             .fold(initial, move |b, socket,| {
+                let remote_addr = socket.peer_addr()
+                    .expect("couldn't get remote addr!");
                 // TODO: On Linux and most other platforms it would be better
                 // to set the `TCP_NODELAY` option on the bound socket and
                 // then have the listening sockets inherit it. However, that
@@ -121,7 +123,7 @@ impl BoundPort {
                 f(b, (Connection::plain(socket), remote_addr))
             });
 
-        fut.map(|_| ())
+        Box::new(fut.map(|_| ()))
     }
 }
 

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -4,9 +4,11 @@ use std;
 use std::cmp;
 use std::io;
 use std::net::SocketAddr;
-use tokio_core::net::{TcpListener, TcpStreamNew, TcpStream};
-use tokio_core::reactor::Handle;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::{TcpListener, TcpStream, ConnectFuture},
+    reactor::Handle,
+};
 
 use config::Addr;
 use transport::GetOriginalDst;
@@ -19,12 +21,12 @@ pub struct BoundPort {
 }
 
 /// Initiates a client connection to the given address.
-pub fn connect(addr: &SocketAddr, executor: &Handle) -> Connecting {
-    Connecting(PlaintextSocket::connect(addr, executor))
+pub fn connect(addr: &SocketAddr) -> Connecting {
+    Connecting(PlaintextSocket::connect(addr))
 }
 
 /// A socket that is in the process of connecting.
-pub struct Connecting(TcpStreamNew);
+pub struct Connecting(ConnectFuture);
 
 /// Abstracts a plaintext socket vs. a TLS decorated one.
 ///
@@ -98,16 +100,17 @@ impl BoundPort {
     // This ensures that every incoming connection has the correct options set.
     // In the future it will also ensure that the connection is upgraded with
     // TLS when needed.
-    pub fn listen_and_fold<T, F, Fut>(self, executor: &Handle, initial: T, f: F)
-        -> Box<Future<Item = (), Error = io::Error> + 'static>
-        where
+    pub fn listen_and_fold<T, F, Fut>(self, initial: T, f: F)
+        -> impl Future<Item = (), Error = io::Error> + Send + 'static
+    where
         F: Fn(T, (Connection, SocketAddr)) -> Fut + 'static,
-        T: 'static,
-        Fut: IntoFuture<Item = T, Error = std::io::Error> + 'static {
-        let fut = TcpListener::from_listener(self.inner, &self.local_addr, &executor)
-            .expect("from_listener") // TODO: get rid of this `expect()`.
+        T: Send + 'static,
+        Fut: IntoFuture<Item = T, Error = std::io::Error> + Send + 'static,
+        <Fut as IntoFuture>::Future: Send, {
+        let fut = TcpListener::from_std(self.inner, &Handle::current())
+            .expect("TcpListener::FromStd") // TODO: get rid of this `expect()`.
             .incoming()
-            .fold(initial, move |b, (socket, remote_addr)| {
+            .fold(initial, move |b, socket,| {
                 // TODO: On Linux and most other platforms it would be better
                 // to set the `TCP_NODELAY` option on the bound socket and
                 // then have the listening sockets inherit it. However, that
@@ -118,7 +121,7 @@ impl BoundPort {
                 f(b, (Connection::plain(socket), remote_addr))
             });
 
-        Box::new(fut.map(|_| ()))
+        fut.map(|_| ())
     }
 }
 

--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -8,7 +8,6 @@ use std::fmt;
 use std::iter::IntoIterator;
 use std::net::SocketAddr;
 use std::time::Duration;
-use tokio_core::reactor::Handle;
 use tower_grpc as grpc;
 use tower_h2::{BoxBody, HttpService, RecvBody};
 
@@ -79,13 +78,13 @@ impl Config {
     }
 
     /// Bind this handle to start talking to the controller API.
-    pub fn process<T>(self, executor: &Handle) -> Process<T>
+    pub fn process<T>(self) -> Process<T>
     where
         T: HttpService<RequestBody = BoxBody, ResponseBody = RecvBody>,
         T::Error: fmt::Debug,
     {
         Process {
-            dns_resolver: dns::Resolver::new(self.dns_config, executor),
+            dns_resolver: dns::Resolver::new(self.dns_config),
             default_destination_namespace: self.default_destination_namespace,
             destinations: HashMap::new(),
             reconnects: VecDeque::new(),

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -66,7 +66,7 @@ impl Background {
         self,
         host_and_port: HostAndPort,
         dns_config: dns::Config,
-    ) -> impl Future<Item = (), Error = ()> {
+    ) -> Box<Future<Item = (), Error = ()>> {
         // Build up the Controller Client Stack
         let mut client = {
             let ctx = ("controller-client", format!("{:?}", host_and_port));
@@ -76,7 +76,6 @@ impl Background {
             let connect = Timeout::new(
                 LookupAddressAndConnect::new(host_and_port, dns_resolver),
                 Duration::from_secs(3),
-                &executor,
             );
 
             let h2_client = tower_h2::client::Connect::new(

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -6,17 +6,13 @@ use bytes::Bytes;
 use futures::{future, Async, Future, Poll};
 use h2;
 use http;
-use tokio_core::reactor::{
-    Handle,
-    // TODO: would rather just have Backoff in a separate file so this
-    //       renaming import is not necessary.
-    Timeout as ReactorTimeout
-};
+use tokio::timer::Delay;
 use tower_service::Service;
 use tower_h2;
 use tower_reconnect::{Error as ReconnectError, Reconnect};
 
 use dns;
+use task::LazyExecutor;
 use transport::{DnsNameAndPort, HostAndPort, LookupAddressAndConnect};
 use timeout::{Timeout, TimeoutError};
 
@@ -70,16 +66,15 @@ impl Background {
         self,
         host_and_port: HostAndPort,
         dns_config: dns::Config,
-        executor: &Handle,
-    ) -> Box<Future<Item = (), Error = ()>> {
+    ) -> impl Future<Item = (), Error = ()> {
         // Build up the Controller Client Stack
         let mut client = {
             let ctx = ("controller-client", format!("{:?}", host_and_port));
             let scheme = http::uri::Scheme::from_shared(Bytes::from_static(b"http")).unwrap();
             let authority = http::uri::Authority::from(&host_and_port);
-            let dns_resolver = dns::Resolver::new(dns_config, &executor);
+            let dns_resolver = dns::Resolver::new(dns_config);
             let connect = Timeout::new(
-                LookupAddressAndConnect::new(host_and_port, dns_resolver, executor),
+                LookupAddressAndConnect::new(host_and_port, dns_resolver),
                 Duration::from_secs(3),
                 &executor,
             );
@@ -87,17 +82,17 @@ impl Background {
             let h2_client = tower_h2::client::Connect::new(
                 connect,
                 h2::client::Builder::default(),
-                ::logging::context_executor(ctx, executor.clone()),
+                ::logging::context_executor(ctx, LazyExecutor),
             );
 
             let reconnect = Reconnect::new(h2_client);
             let log_errors = LogErrors::new(reconnect);
-            let backoff = Backoff::new(log_errors, Duration::from_secs(5), executor);
+            let backoff = Backoff::new(log_errors, Duration::from_secs(5));
             // TODO: Use AddOrigin in tower-http
             AddOrigin::new(scheme, authority, backoff)
         };
 
-        let mut disco = self.disco.process(executor);
+        let mut disco = self.disco.process();
 
         let fut = future::poll_fn(move || {
             disco.poll_rpc(&mut client);
@@ -115,16 +110,16 @@ impl Background {
 //TODO: move to tower-backoff
 struct Backoff<S> {
     inner: S,
-    timer: ReactorTimeout,
+    timer: Delay,
     waiting: bool,
     wait_dur: Duration,
 }
 
 impl<S> Backoff<S> {
-    fn new(inner: S, wait_dur: Duration, handle: &Handle) -> Self {
+    fn new(inner: S, wait_dur: Duration) -> Self {
         Backoff {
             inner,
-            timer: ReactorTimeout::new(wait_dur, handle).unwrap(),
+            timer: Delay::new(Instant::now() + wait_dur),
             waiting: false,
             wait_dur,
         }

--- a/proxy/src/dns.rs
+++ b/proxy/src/dns.rs
@@ -2,12 +2,13 @@ use futures::prelude::*;
 use std::fmt;
 use std::net::IpAddr;
 use std::time::{Instant, Duration};
+use tokio::timer::Delay;
 use transport;
 use trust_dns_resolver;
 use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
 use trust_dns_resolver::ResolverFuture;
-use trust_dns_resolver::lookup_ip::LookupIp,;
+use trust_dns_resolver::lookup_ip::LookupIp;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -18,7 +19,6 @@ pub struct Config {
 #[derive(Clone, Debug)]
 pub struct Resolver {
     config: Config,
-    executor: Handle,
 }
 
 pub enum IpAddrFuture {
@@ -77,10 +77,9 @@ impl Config {
 }
 
 impl Resolver {
-    pub fn new(config: Config, executor: &Handle) -> Self {
+    pub fn new(config: Config,) -> Self {
         Resolver {
             config,
-            executor: executor.clone(),
         }
     }
 
@@ -99,8 +98,7 @@ impl Resolver {
         let name_clone = name.clone();
         trace!("resolve_all_ips {}", &name);
         let resolver = self.clone();
-        let f = Timeout::new(delay, &resolver.executor)
-            .expect("Timeout::new() won't fail")
+        let f = Delay::new(Instant::now() + delay)
             .then(move |_| {
                 trace!("resolve_all_ips {} after delay", &name);
                 resolver.lookup_ip(&name)
@@ -124,14 +122,14 @@ impl Resolver {
     // `ResolverFuture` can only be used for one lookup, so we have to clone all
     // the state during each resolution.
     fn lookup_ip(self, &Name(ref name): &Name)
-        -> impl Future<Item = LookupIp, Error = ResolveError>
+        -> Box<Future<Item = LookupIp, Error = ResolveError>>
     {
         let name = name.clone(); // TODO: ref-count names.
         let resolver = ResolverFuture::new(
             self.config.config,
             self.config.opts
         );
-        resolver.and_then(move |r| r.lookup_ip(name.as_str()))
+        Box::new(resolver.and_then(move |r| r.lookup_ip(name.as_str())))
     }
 }
 

--- a/proxy/src/dns.rs
+++ b/proxy/src/dns.rs
@@ -1,14 +1,13 @@
 use futures::prelude::*;
 use std::fmt;
 use std::net::IpAddr;
-use std::time::Duration;
-use tokio_core::reactor::{Handle, Timeout};
+use std::time::{Instant, Duration};
 use transport;
 use trust_dns_resolver;
 use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
 use trust_dns_resolver::ResolverFuture;
-use trust_dns_resolver::lookup_ip::{LookupIp, LookupIpFuture};
+use trust_dns_resolver::lookup_ip::LookupIp,;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -23,7 +22,7 @@ pub struct Resolver {
 }
 
 pub enum IpAddrFuture {
-    DNS(LookupIpFuture),
+    DNS(Box<Future<Item = LookupIp, Error = ResolveError>>),
     Fixed(IpAddr),
 }
 
@@ -124,12 +123,15 @@ impl Resolver {
 
     // `ResolverFuture` can only be used for one lookup, so we have to clone all
     // the state during each resolution.
-    fn lookup_ip(self, &Name(ref name): &Name) -> LookupIpFuture {
+    fn lookup_ip(self, &Name(ref name): &Name)
+        -> impl Future<Item = LookupIp, Error = ResolveError>
+    {
+        let name = name.clone(); // TODO: ref-count names.
         let resolver = ResolverFuture::new(
             self.config.config,
-            self.config.opts,
-            &self.executor);
-        resolver.lookup_ip(name)
+            self.config.opts
+        );
+        resolver.and_then(move |r| r.lookup_ip(name.as_str()))
     }
 }
 

--- a/proxy/src/dns.rs
+++ b/proxy/src/dns.rs
@@ -77,7 +77,7 @@ impl Config {
 }
 
 impl Resolver {
-    pub fn new(config: Config,) -> Self {
+    pub fn new(config: Config) -> Self {
         Resolver {
             config,
         }

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -47,7 +47,7 @@ where
 impl<B> Recognize for Inbound<B>
 where
     B: tower_h2::Body + Send + 'static,
-    B::Data: Send,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Request = http::Request<B>;
     type Response = bind::HttpResponse;
@@ -103,7 +103,6 @@ mod tests {
     use std::sync::Arc;
 
     use http;
-    use tokio_core::reactor::Core;
     use conduit_proxy_router::Recognize;
 
     use super::Inbound;

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -29,9 +29,8 @@ extern crate prost_types;
 extern crate quickcheck;
 extern crate rand;
 extern crate regex;
+extern crate tokio;
 extern crate tokio_connect;
-extern crate tokio_core;
-extern crate tokio_io;
 extern crate tower_balance;
 extern crate tower_buffer;
 extern crate tower_discover;
@@ -54,7 +53,7 @@ use std::thread;
 use std::time::Duration;
 
 use indexmap::IndexSet;
-use tokio_core::reactor::{Core, Handle};
+use tokio::{executor, runtime::current_thread};
 use tower_service::NewService;
 use tower_fn::*;
 use conduit_proxy_router::{Recognize, Router, Error as RouteError};
@@ -71,6 +70,7 @@ mod inbound;
 mod logging;
 mod map_err;
 mod outbound;
+pub mod task;
 pub mod telemetry;
 mod transparency;
 mod transport;
@@ -82,6 +82,7 @@ use bind::Bind;
 use connection::BoundPort;
 use inbound::Inbound;
 use map_err::MapErr;
+use task::{MainRuntime, TaskError};
 use transparency::{HttpBody, Server};
 pub use transport::{GetOriginalDst, SoOriginalDst};
 use outbound::Outbound;
@@ -109,14 +110,21 @@ pub struct Main<G> {
 
     get_original_dst: G,
 
-    reactor: Core,
+    runtime: MainRuntime,
 }
 
 impl<G> Main<G>
 where
-    G: GetOriginalDst + Clone + 'static,
+    G: GetOriginalDst + Clone + Send + 'static,
 {
-    pub fn new(config: config::Config, get_original_dst: G) -> Self {
+    pub fn new<R>(
+        config: config::Config,
+        get_original_dst: G,
+        runtime: R
+    ) -> Self
+    where
+        R: Into<MainRuntime>,
+    {
 
         let control_listener = BoundPort::new(config.control_listener.addr)
             .expect("controller listener bind");
@@ -125,7 +133,7 @@ where
         let outbound_listener = BoundPort::new(config.private_listener.addr)
             .expect("private listener bind");
 
-        let reactor = Core::new().expect("reactor");
+        let runtime = runtime.into();
 
         let metrics_listener = BoundPort::new(config.metrics_listener.addr)
             .expect("metrics listener bind");
@@ -136,7 +144,7 @@ where
             outbound_listener,
             metrics_listener,
             get_original_dst,
-            reactor,
+            runtime,
         }
     }
 
@@ -151,10 +159,6 @@ where
 
     pub fn outbound_addr(&self) -> SocketAddr {
         self.outbound_listener.local_addr()
-    }
-
-    pub fn handle(&self) -> Handle {
-        self.reactor.handle()
     }
 
     pub fn metrics_addr(&self) -> SocketAddr {
@@ -174,7 +178,7 @@ where
             outbound_listener,
             metrics_listener,
             get_original_dst,
-            reactor: mut core,
+            runtime: mut rt,
         } = self;
 
         let control_host_and_port = config.control_host_and_port.clone();
@@ -213,10 +217,9 @@ where
 
         let (control, control_bg) = control::new(dns_config.clone(), config.pod_namespace.clone());
 
-        let executor = core.handle();
         let (drain_tx, drain_rx) = drain::channel();
 
-        let bind = Bind::new(executor.clone()).with_sensors(sensors.clone());
+        let bind = Bind::new().with_sensors(sensors.clone());
 
         // Setup the public listener. This will listen on a publicly accessible
         // address and listen for inbound connections that should be forwarded
@@ -242,7 +245,6 @@ where
                 sensors.clone(),
                 get_original_dst.clone(),
                 drain_rx.clone(),
-                &executor,
             );
             ::logging::context_future("inbound", fut)
         };
@@ -267,7 +269,6 @@ where
                 sensors,
                 get_original_dst,
                 drain_rx,
-                &executor,
             );
             ::logging::context_future("outbound", fut)
         };
@@ -281,20 +282,16 @@ where
                 .spawn(move || {
                     use conduit_proxy_controller_grpc::tap::server::TapServer;
 
-                    let mut core = Core::new().expect("initialize controller core");
-                    let executor = core.handle();
+                    let mut rt = current_thread::Runtiem::new()
+                        .expect("initialize controller-client thread runtime");
 
                     let (taps, observe) = control::Observe::new(100);
                     let new_service = TapServer::new(observe);
 
-                    let server = serve_control(
-                        control_listener,
-                        new_service,
-                        &executor,
-                    );
+                    let server = serve_control(control_listener, new_service);
 
                     let telemetry = telemetry
-                        .make_control(&taps, &executor)
+                        .make_control(&taps)
                         .expect("bad news in telemetry town");
 
                     let metrics_server = telemetry
@@ -303,7 +300,6 @@ where
                     let client = control_bg.bind(
                         control_host_and_port,
                         dns_config,
-                        &executor
                     );
 
                     let fut = client.join4(
@@ -311,12 +307,16 @@ where
                         telemetry,
                         metrics_server.map_err(|_| {}),
                     ).map(|_| {});
-                    executor.spawn(::logging::context_future("controller-client", fut));
+                    let fut = ::logging::context_future("controller-client", fut);
+
+                    rt.spawn(Box::new(fut));
 
                     let shutdown = controller_shutdown_signal.then(|_| Ok::<(), ()>(()));
-                    core.run(shutdown).expect("controller api");
+                    rt.block_on(shutdown).expect("controller api");
+                    trace!("controller client shutdown finished");
                 })
                 .expect("initialize controller api thread");
+            trace!("controller client thread spawned");
         }
 
         let fut = inbound
@@ -324,12 +324,14 @@ where
             .map(|_| ())
             .map_err(|err| error!("main error: {:?}", err));
 
-        core.handle().spawn(fut);
+        rt.spawn(Box::new(fut));
+        trace!("main task spawned");
+
         let shutdown_signal = shutdown_signal.and_then(move |()| {
             debug!("shutdown signaled");
             drain_tx.drain()
         });
-        core.run(shutdown_signal).expect("executor");
+        rt.run_until(shutdown_signal).expect("executor");
         debug!("shutdown complete");
     }
 }
@@ -342,21 +344,21 @@ fn serve<R, B, E, F, G>(
     proxy_ctx: Arc<ctx::Proxy>,
     sensors: telemetry::Sensors,
     get_orig_dst: G,
-    drain_rx: drain::Watch,
-    executor: &Handle,
-) -> Box<Future<Item = (), Error = io::Error> + 'static>
+    drain_rx: drain::Watch,=
+) -> impl Future<Item = (), Error = io::Error> + Send + 'static
 where
-    B: tower_h2::Body + Default + 'static,
-    E: Error + 'static,
-    F: Error + 'static,
+    B: tower_h2::Body + Default + Send + 'static,
+    B::Data: Send,
+    E: Error + Send + 'static,
+    F: Error + Send + 'static,
     R: Recognize<
         Request = http::Request<HttpBody>,
         Response = http::Response<telemetry::sensor::http::ResponseBody<B>>,
         Error = E,
         RouteError = F,
     >
-        + 'static,
-    G: GetOriginalDst + 'static,
+        + Send + 'static,
+    G: GetOriginalDst + Send + 'static,
 {
     let stack = Arc::new(NewServiceFn::new(move || {
         // Clone the router handle
@@ -455,24 +457,33 @@ where
 fn serve_control<N, B>(
     bound_port: BoundPort,
     new_service: N,
-    executor: &Handle,
-) -> Box<Future<Item = (), Error = io::Error> + 'static>
+) -> impl Future<Item = (), Error = io::Error> + Send + 'static
 where
-    B: tower_h2::Body + 'static,
-    N: NewService<Request = http::Request<tower_h2::RecvBody>, Response = http::Response<B>> + 'static,
+    B: tower_h2::Body + Send + 'static,
+    B::Data: Send,
+    N: NewService<
+        Request = http::Request<tower_h2::RecvBody>,
+        Response = http::Response<B>
+    >
+        + Send + 'static,
 {
     let h2_builder = h2::server::Builder::default();
-    let server = tower_h2::Server::new(new_service, h2_builder, executor.clone());
+    let server = tower_h2::Server::new(
+        new_service,
+        h2_builder,
+        LazyExecutor
+    );
     bound_port.listen_and_fold(
-        executor,
-        (server, executor.clone()),
-        move |(server, executor), (session, _)| {
+        server,
+        move |server, (session, _)| {
             let s = server.serve(session).map_err(|_| ());
+            let s = ::logging::context_future("serve_control", s);
 
-            executor.spawn(::logging::context_future("serve_control", s));
-
-
-            future::ok((server, executor))
+            let r = current_thread::TaskExecutor::current()
+                .spawn_local(Box::new(s))
+                .map(move |_| server)
+                .map_err(TaskError::into_io);
+            future::result(r)
         },
     )
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -82,7 +82,7 @@ use bind::Bind;
 use connection::BoundPort;
 use inbound::Inbound;
 use map_err::MapErr;
-use task::{MainRuntime, TaskError};
+use task::MainRuntime;
 use transparency::{HttpBody, Server};
 pub use transport::{GetOriginalDst, SoOriginalDst};
 use outbound::Outbound;
@@ -491,7 +491,7 @@ where
             let r = executor::current_thread::TaskExecutor::current()
                 .spawn_local(Box::new(s))
                 .map(move |_| server)
-                .map_err(TaskError::into_io);
+                .map_err(task::Error::into_io);
             future::result(r)
         },
     )

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -178,7 +178,7 @@ where
             outbound_listener,
             metrics_listener,
             get_original_dst,
-            runtime: mut rt,
+            mut runtime,
         } = self;
 
         let control_host_and_port = config.control_host_and_port.clone();
@@ -324,14 +324,14 @@ where
             .map(|_| ())
             .map_err(|err| error!("main error: {:?}", err));
 
-        rt.spawn(Box::new(fut));
+        runtime.spawn(Box::new(fut));
         trace!("main task spawned");
 
         let shutdown_signal = shutdown_signal.and_then(move |()| {
             debug!("shutdown signaled");
             drain_tx.drain()
         });
-        rt.run_until(shutdown_signal).expect("executor");
+        runtime.run_until(shutdown_signal).expect("executor");
         debug!("shutdown complete");
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -459,7 +459,7 @@ where
 fn serve_control<N, B>(
     bound_port: BoundPort,
     new_service: N,
-) -> Box<Future<Item = (), Error = io::Error> + Send + 'static>
+) -> Box<Future<Item = (), Error = io::Error> + 'static>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as bytes::IntoBuf>::Buf: Send,

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::env;
 use std::io::Write;
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use env_logger;
 use futures::{Future, Poll};
@@ -69,7 +69,7 @@ pub fn context_future<T, F>(context: T, future: F) -> ContextualFuture<T, F> {
 /// value, inserting it into all logs created by this future.
 pub fn context_executor<T, E>(context: T, executor: E) -> ContextualExecutor<T, E> {
     ContextualExecutor {
-        context: Rc::new(context),
+        context: Arc::new(context),
         executor,
     }
 }
@@ -97,14 +97,14 @@ where
 
 #[derive(Clone, Debug)]
 pub struct ContextualExecutor<T, E> {
-    context: Rc<T>,
+    context: Arc<T>,
     executor: E,
 }
 
 impl<T, E, F> Executor<F> for ContextualExecutor<T, E>
 where
     T: ::std::fmt::Debug + 'static,
-    E: Executor<ContextualFuture<Rc<T>, F>>,
+    E: Executor<ContextualFuture<Arc<T>, F>>,
     F: Future<Item = (), Error = ()>,
 {
     fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -3,6 +3,7 @@
 extern crate conduit_proxy;
 
 #[macro_use] extern crate log;
+extern crate tokio;
 
 use std::process;
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -18,7 +18,15 @@ fn main() {
             process::exit(64)
         }
     };
-    let main = conduit_proxy::Main::new(config, conduit_proxy::SoOriginalDst);
-    let shutdown_signal = signal::shutdown(&main.handle());
+    // NOTE: eventually, this is where we would choose to use the threadpool
+    //       runtime instead, if acting as an ingress proxy.
+    let runtime = tokio::runtime::current_thread::Runtime::new()
+        .expect("initialize main runtime");
+    let main = conduit_proxy::Main::new(
+        config,
+        conduit_proxy::SoOriginalDst,
+        runtime,
+    );
+    let shutdown_signal = signal::shutdown();
     main.run_until(shutdown_signal);
 }

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -17,6 +17,7 @@ use bind::{self, Bind, Protocol};
 use control;
 use control::destination::{Bind as BindTrait, Resolution};
 use ctx;
+use task::LazyExecutor;
 use timeout::Timeout;
 use transparency::h1;
 use transport::{DnsNameAndPort, Host, HostAndPort};
@@ -55,7 +56,8 @@ impl<B> Outbound<B> {
 
 impl<B> Clone for Outbound<B>
 where
-    B: tower_h2::Body + 'static,
+    B: tower_h2::Body + Send + 'static,
+    B::Data: Send,
 {
     fn clone(&self) -> Self {
         Self {
@@ -153,13 +155,13 @@ where
 
         let loaded = tower_balance::load::WithPendingRequests::new(resolve);
 
+
+        // We can't use `rand::thread_rng` here because the returned `Service`
+        // needs to be `Send`, so instead, we use `LazyRng`, which calls
+        // `rand::thread_rng()` when it is *used*.
         let balance = tower_balance::power_of_two_choices(loaded, LazyThreadRng);
 
-        // use the same executor as the underlying `Bind` for the `Buffer` and
-        // `Timeout`.
-        let handle = self.bind.executor();
-
-        let buffer = Buffer::new(balance, handle)
+        let buffer = Buffer::new(balance, &LazyExecutor)
             .map_err(|_| bind::BufferSpawnError::Outbound)?;
 
         let timeout = Timeout::new(buffer, self.bind_timeout, handle);
@@ -176,7 +178,8 @@ pub enum Discovery<B> {
 
 impl<B> Discover for Discovery<B>
 where
-    B: tower_h2::Body + 'static,
+    B: tower_h2::Body + Send + 'static,
+    B::Data: Send,
 {
     type Key = SocketAddr;
     type Request = http::Request<B>;

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -44,7 +44,7 @@ pub enum Destination {
 impl<B> Outbound<B> {
     pub fn new(bind: Bind<Arc<ctx::Proxy>, B>,
                discovery: control::Control,
-               bind_timeout: Duration,)
+               bind_timeout: Duration)
                -> Outbound<B> {
         Self {
             bind,

--- a/proxy/src/task.rs
+++ b/proxy/src/task.rs
@@ -1,0 +1,168 @@
+//! Task execution utilities.
+use futures::future::{
+    Future,
+    ExecuteError,
+    ExecuteErrorKind,
+    Executor,
+};
+use rand;
+use tokio::executor::{
+    DefaultExecutor,
+    Executor as TokioExecutor,
+    SpawnError,
+};
+
+use std::error::Error;
+use std::{fmt, io};
+
+
+/// An empty type which implements `Executor` by lazily  calling
+/// `tokio::executor::DefaultExecutor::current().execute(...)`.
+///
+/// This can be used when we would simply like to call `tokio::spawn` rather
+/// than explicitly using a particular executor, but need an `Executor` for
+/// a generic type or to pass to a function which expects one.
+///
+/// Note that this uses `DefaultExecutor` rather than `tokio::spawn`, as we
+/// would prefer for our `Executor` implementation to pass errors rather than
+/// panicking (as `tokio::spawn` does).
+#[derive(Copy, Clone, Debug, Default)]
+pub struct LazyExecutor;
+
+/// Like a `SpawnError` or `ExecuteError`, but with an implementation
+/// of `std::error::Error`.
+#[derive(Debug, Clone)]
+pub enum TaskError {
+    /// The executor has shut down and will no longer spawn new tasks.
+    Shutdown,
+    /// The executor had no capacity to run more futures.
+    NoCapacity,
+    /// An unknown error occurred.
+    ///
+    /// This indicates that `tokio` or `futures-rs` has
+    /// added additional error types that we are not aware of.
+    Unknown,
+}
+
+// ===== impl LazyExecutor =====;
+
+impl TokioExecutor for LazyExecutor {
+    fn spawn(
+        &mut self,
+        future: Box<Future<Item = (), Error = ()> + 'static + Send>
+    ) -> Result<(), SpawnError>
+    {
+        DefaultExecutor::current().spawn(future)
+    }
+
+    fn status(&self) -> Result<(), SpawnError> {
+        DefaultExecutor::current().status()
+    }
+}
+
+impl<F> Executor<F> for LazyExecutor
+where
+    F: Future<Item = (), Error = ()> + 'static + Send,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        let mut executor = DefaultExecutor::current();
+        // Check the status of the executor first, so that we can return the
+        // future in the `ExecuteError`. If we just called `spawn` and
+        // `map_err`ed the error into an `ExecuteError`, we'd have to move the
+        // future into the closure, but it was already moved into `spawn`.
+        if let Err(e) = executor.status() {
+            if e.is_at_capacity() {
+                return Err(ExecuteError::new(ExecuteErrorKind::NoCapacity, future));
+            } else if e.is_shutdown() {
+                return Err(ExecuteError::new(ExecuteErrorKind::Shutdown, future));
+            } else {
+                panic!("unexpected `SpawnError`: {:?}", e);
+            }
+        };
+        executor.spawn(Box::new(future))
+            .expect("spawn() errored but status() was Ok");
+        Ok(())
+    }
+}
+
+// ===== impl LazyRng =====
+
+impl rand::Rng for LazyRng {
+    fn next_u32(&mut self) -> u32 {
+        rand::thread_rng().next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        rand::thread_rng().next_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        rand::thread_rng().fill_bytes(bytes)
+    }
+}
+
+// ===== impl TaskError =====
+
+impl TaskError {
+
+    /// Wrap a `SpawnError` or `ExecuteError` in an `io::Error`.
+    ///
+    /// The returned `io::Error` will have `ErrorKind::Other`. Wrapping
+    /// the error in `TaskError` is necessary as the type passed to
+    /// `io::Error::new` must implement `std::error::Error`.
+    pub fn into_io<I: Into<TaskError>>(inner: I) -> io::Error {
+        io::Error::new(io::ErrorKind::Other, inner.into())
+    }
+}
+
+impl From<SpawnError> for TaskError {
+    fn from(spawn_error: SpawnError) -> Self {
+        if spawn_error.is_shutdown() {
+            TaskError::Shutdown
+        } else if spawn_error.is_at_capacity() {
+            TaskError::NoCapacity
+        } else {
+            warn!(
+                "TaskError::from: unknown SpawnError '{:?}'\n\
+                 This indicates a change in Tokio's API surface that should\n\
+                 be handled.",
+                 spawn_error,
+            );
+            TaskError::Unknown
+        }
+    }
+}
+
+impl<F> From<ExecuteError<F>> for TaskError {
+    fn from(exec_error: ExecuteError<F>) -> Self {
+        match exec_error.kind() {
+            ExecuteErrorKind::Shutdown => TaskError::Shutdown,
+            ExecuteErrorKind::NoCapacity => TaskError::NoCapacity,
+            _ => {
+                warn!(
+                    "TaskError::from: unknown ExecuteError '{:?}'\n\
+                    This indicates a change in the futures-rs API surface\n\
+                    that should be handled.",
+                    exec_error,
+                );
+                TaskError::Unknown
+            }
+        }
+    }
+}
+impl fmt::Display for  TaskError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.description().fmt(f)
+    }
+}
+
+impl Error for TaskError {
+    fn description(&self) -> &str {
+        match *self {
+            TaskError::Shutdown => "executor has shut down",
+            TaskError::NoCapacity => "executor has no more capacity",
+            TaskError::Unknown => "unknown error executing future",
+        }
+    }
+}

--- a/proxy/src/task.rs
+++ b/proxy/src/task.rs
@@ -5,7 +5,6 @@ use futures::future::{
     ExecuteErrorKind,
     Executor,
 };
-use rand;
 use tokio::{
     executor::{
         DefaultExecutor,

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -111,12 +111,12 @@ impl Control {
     }
 
     pub fn serve_metrics(&self, bound_port: connection::BoundPort)
-        -> impl Future<Item = (), Error = io::Error>
+        -> Box<Future<Item = (), Error = io::Error>>
     {
         use hyper;
         let service = self.metrics_service.clone();
         bound_port.listen_and_fold(
-            hyper::server::conn::Http::new()
+            hyper::server::conn::Http::new(),
             move |hyper, (conn, _)| {
                 let service = service.clone();
                 let serve = hyper.serve_connection(conn, service)

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -4,13 +4,14 @@ use std::time::Duration;
 
 use futures::{future, Async, Future, Poll, Stream};
 use futures_mpsc_lossy::Receiver;
-use tokio_core::reactor::Handle;
+use tokio::executor::current_thread::TaskExecutor;
 
 use super::event::Event;
 use super::metrics;
 use super::tap::Taps;
 use connection;
 use ctx;
+use task::TaskError;
 
 /// A `Control` which has been configured but not initialized.
 #[derive(Debug)]
@@ -48,7 +49,6 @@ pub struct Control {
     /// Holds the current state of tap observations, as configured by an external source.
     taps: Option<Arc<Mutex<Taps>>>,
 
-    handle: Handle,
 }
 
 // ===== impl MakeControl =====
@@ -71,16 +71,15 @@ impl MakeControl {
         }
     }
 
-    /// Bind a `Control` with a reactor core.
+    /// Bind a `Control` with the current task executor.
     ///
     /// # Arguments
-    /// - `handle`: a `Handle` on an event loop that will track the timeout.
     /// - `taps`: shares a `Taps` instance.
     ///
     /// # Returns
     /// - `Ok(())` if the timeout was successfully created.
     /// - `Err(io::Error)` if the timeout could not be created.
-    pub fn make_control(self, taps: &Arc<Mutex<Taps>>, handle: &Handle) -> io::Result<Control> {
+    pub fn make_control(self, taps: &Arc<Mutex<Taps>>) -> io::Result<Control> {
         let (metrics_record, metrics_service) =
             metrics::new(&self.process_ctx, self.metrics_retain_idle);
 
@@ -89,7 +88,6 @@ impl MakeControl {
             metrics_service,
             rx: Some(self.rx),
             taps: Some(taps.clone()),
-            handle: handle.clone(),
         })
     }
 }
@@ -113,25 +111,27 @@ impl Control {
     }
 
     pub fn serve_metrics(&self, bound_port: connection::BoundPort)
-        -> Box<Future<Item = (), Error = io::Error> + 'static>
+        -> impl Future<Item = (), Error = io::Error>
     {
         use hyper;
         let service = self.metrics_service.clone();
-        let hyper = hyper::server::Http::<hyper::Chunk>::new();
         bound_port.listen_and_fold(
-            &self.handle,
-            (hyper, self.handle.clone()),
-            move |(hyper, executor), (conn, _)| {
+            hyper::server::conn::Http::new()
+            move |hyper, (conn, _)| {
                 let service = service.clone();
                 let serve = hyper.serve_connection(conn, service)
                     .map(|_| {})
                     .map_err(|e| {
                         error!("error serving prometheus metrics: {:?}", e);
                     });
+                let serve = ::logging::context_future("serve_metrics", serve);
 
-                executor.spawn(::logging::context_future("serve_metrics", serve));
+                let r = TaskExecutor::current()
+                    .spawn_local(Box::new(serve))
+                    .map(move |()| hyper)
+                    .map_err(TaskError::into_io);
 
-                future::ok((hyper, executor))
+                future::result(r)
             })
     }
 

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -11,7 +11,7 @@ use super::metrics;
 use super::tap::Taps;
 use connection;
 use ctx;
-use task::TaskError;
+use task;
 
 /// A `Control` which has been configured but not initialized.
 #[derive(Debug)]
@@ -129,7 +129,7 @@ impl Control {
                 let r = TaskExecutor::current()
                     .spawn_local(Box::new(serve))
                     .map(move |()| hyper)
-                    .map_err(TaskError::into_io);
+                    .map_err(task::Error::into_io);
 
                 future::result(r)
             })

--- a/proxy/src/telemetry/metrics/serve.rs
+++ b/proxy/src/telemetry/metrics/serve.rs
@@ -1,10 +1,17 @@
 use deflate::CompressionOptions;
 use deflate::write::GzEncoder;
 use futures::future::{self, FutureResult};
-use hyper::{self, Body, StatusCode};
-use hyper::header::{AcceptEncoding, ContentEncoding, ContentType, Encoding, QualityItem};
-use hyper::server::{Request, Response, Service};
-use std::io::Write;
+use http::{self, header, StatusCode};
+use hyper::{
+    service::Service,
+    Body,
+    Request,
+    Response,
+};
+
+use std::error::Error;
+use std::fmt;
+use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -17,6 +24,12 @@ pub struct Serve {
     idle_retain: Duration,
 }
 
+#[derive(Debug)]
+enum ServeError {
+    Http(http::Error),
+    Io(io::Error),
+}
+
 // ===== impl Serve =====
 
 impl Serve {
@@ -27,29 +40,30 @@ impl Serve {
         }
     }
 
-    fn is_gzip(req: &Request) -> bool {
-        if let Some(accept_encodings) = req
-            .headers()
-            .get::<AcceptEncoding>()
-        {
-            return accept_encodings
-                .iter()
-                .any(|&QualityItem { ref item, .. }| item == &Encoding::Gzip)
-        }
-        false
+    fn is_gzip<B>(req: &Request<B>) -> bool {
+        req.headers()
+            .get_all(header::ACCEPT_ENCODING).iter()
+            .any(|value| {
+                value.to_str().ok()
+                    .map(|value| value.contains("gzip"))
+                    .unwrap_or(false)
+            })
     }
 }
 
 impl Service for Serve {
-    type Request = Request;
-    type Response = Response;
-    type Error = hyper::Error;
-    type Future = FutureResult<Self::Response, Self::Error>;
+    type ReqBody = Body;
+    type ResBody = Body;
+    type Error = io::Error;
+    type Future = FutureResult<Response<Body>, Self::Error>;
 
-    fn call(&self, req: Self::Request) -> Self::Future {
-        if req.path() != "/metrics" {
-            return future::ok(Response::new()
-                .with_status(StatusCode::NotFound));
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        if req.uri().path() != "/metrics" {
+            let rsp = Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty())
+                .expect("builder with known status code should not fail");
+            return future::ok(rsp);
         }
 
         let mut metrics = self.metrics.lock()
@@ -63,22 +77,73 @@ impl Service for Serve {
             let mut writer = GzEncoder::new(Vec::<u8>::new(), CompressionOptions::fast());
             write!(&mut writer, "{}", *metrics)
                 .and_then(|_| writer.finish())
-                .map(|body| {
-                    Response::new()
-                        .with_header(ContentEncoding(vec![Encoding::Gzip]))
-                        .with_header(ContentType::plaintext())
-                        .with_body(Body::from(body))
+                .map_err(ServeError::from)
+                .and_then(|body| {
+                    Response::builder()
+                        .header(header::CONTENT_ENCODING, "gzip")
+                        .header(header::CONTENT_TYPE, "text/plain")
+                        .body(Body::from(body))
+                        .map_err(ServeError::from)
                 })
+
         } else {
             let mut writer = Vec::<u8>::new();
             write!(&mut writer, "{}", *metrics)
-                .map(|_| {
-                    Response::new()
-                        .with_header(ContentType::plaintext())
-                        .with_body(Body::from(writer))
+                .map_err(ServeError::from)
+                .and_then(|_| {
+                    Response::builder()
+                        .header(header::CONTENT_TYPE, "text/plain")
+                        .body(Body::from(writer))
+                        .map_err(ServeError::from)
                 })
         };
 
-        future::result(resp.map_err(hyper::Error::Io))
+        let resp = resp.unwrap_or_else(|e| {
+            error!("{}", e);
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .expect("builder with known status code should not fail")
+        });
+        future::ok(resp)
+    }
+}
+
+// ===== impl ServeError =====
+
+impl From<http::Error> for ServeError {
+    fn from(err: http::Error) -> Self {
+        ServeError::Http(err)
+    }
+}
+
+impl From<io::Error> for ServeError {
+    fn from(err: io::Error) -> Self {
+        ServeError::Io(err)
+    }
+}
+
+impl fmt::Display for ServeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}",
+            self.description(),
+            self.cause().expect("ServeError must have cause")
+        )
+    }
+}
+
+impl Error for ServeError {
+    fn description(&self) -> &str {
+        match *self {
+            ServeError::Http(_) => "error constructing HTTP response",
+            ServeError::Io(_) => "error writing metrics"
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            ServeError::Http(ref cause) => Some(cause),
+            ServeError::Io(ref cause) => Some(cause),
+        }
     }
 }

--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -434,25 +434,23 @@ where
 
     fn poll_data(&mut self) -> Poll<Option<Self::Data>, h2::Error> {
         let frame = try_ready!(self.sense_err(|b| b.poll_data()));
-        let is_eos = self.is_end_stream();
         let frame = frame.map(|frame| {
             let frame = frame.into_buf();
-            self.inner = self.inner.take().and_then(|mut inner| {
+            if let Some(ref mut inner) = self.inner {
                 *inner.frames_sent() += 1;
                 *inner.bytes_sent() += frame.remaining() as u64;
-                if is_eos {
-                    // If the stream was ended from a DATA frame, we have to
-                    // send the end event.
-                    inner.end(None);
-                    None
-                } else {
-                    // If we're not at the end of the stream yet, put
-                    // `inner` back for the next frame.
-                    Some(inner)
-                }
-            });
+            }
             frame
         });
+
+        // If the frame ended the stream, send the end of stream event now,
+        // as we may not be polled again.
+        if self.is_end_stream() {
+            if let Some(inner) = self.inner.take() {
+                inner.end(None);
+            }
+        }
+
         Ok(Async::Ready(frame))
     }
 

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use futures_mpsc_lossy::Sender;
 use http::{Request, Response};
 use tokio_connect;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::NewService;
 use tower_h2::{client, Body};
 

--- a/proxy/src/telemetry/sensor/transport.rs
+++ b/proxy/src/telemetry/sensor/transport.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio_connect;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use connection::Peek;
 use ctx;

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -1,38 +1,39 @@
 // #![deny(missing_docs)]
-use futures::{Async, Future, Poll};
+use futures::{Future, Poll};
 
 use std::error::Error;
 use std::{fmt, io};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio_connect::Connect;
-use tokio_core::reactor::{Timeout as ReactorTimeout, Handle};
-use tokio_io;
+use tokio::timer::{self, Deadline, DeadlineError};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
 /// A timeout that wraps an underlying operation.
 #[derive(Debug, Clone)]
-pub struct Timeout<U> {
-    inner: U,
+pub struct Timeout<T> {
+    inner: T,
     duration: Duration,
-    handle: Handle,
 }
+
 
 /// An error representing that an operation timed out.
 #[derive(Debug)]
-pub enum TimeoutError<E> {
-    /// Indicates the underlying operation timed out.
-    Timeout(Duration),
-    /// Indicates that the underlying operation failed.
-    Error(E),
+pub struct TimeoutError<E> {
+    kind: TimeoutErrorKind<E>,
 }
 
-/// A `Future` wrapped with a `Timeout`.
-pub struct TimeoutFuture<F> {
-    inner: F,
-    duration: Duration,
-    timeout: ReactorTimeout,
+#[derive(Debug)]
+enum TimeoutErrorKind<E> {
+    /// Indicates the underlying operation timed out.
+    Timeout (Duration),
+    /// Indicates that the underlying operation failed.
+    Error(E),
+    // Indicates that the timer returned an error.
+    Timer(timer::Error),
 }
+
 
 /// A duration which pretty-prints as fractional seconds.
 ///
@@ -43,16 +44,14 @@ pub struct HumanDuration(pub Duration);
 
 //===== impl Timeout =====
 
-impl<U> Timeout<U> {
+impl<T> Timeout<T> {
     /// Construct a new `Timeout` wrapping `inner`.
-    pub fn new(inner: U, duration: Duration, handle: &Handle) -> Self {
+    pub fn new(inner: T, duration: Duration,) -> Self {
         Timeout {
             inner,
             duration,
-            handle: handle.clone(),
         }
     }
-
 }
 
 impl<S, T, E> Service for Timeout<S>
@@ -62,21 +61,19 @@ where
     type Request = S::Request;
     type Response = T;
     type Error = TimeoutError<E>;
-    type Future = TimeoutFuture<S::Future>;
+    type Future = Timeout<Deadline<S::Future>>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready().map_err(Self::Error::from)
+        self.inner.poll_ready().map_err(TimeoutError::error)
     }
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         let duration = self.duration;
-        let timeout = ReactorTimeout::new(duration, &self.handle)
-            .expect("reactor gone");
-        let inner = self.inner.call(req);
-        TimeoutFuture {
+        let deadline = Instant::now() + duration;
+        let inner = Deadline::new(self.inner.call(req), deadline);
+        Timeout {
             inner,
-            duration,
-            timeout,
+            duration: self.duration,
         }
     }
 }
@@ -88,20 +85,30 @@ where
 {
     type Connected = C::Connected;
     type Error = TimeoutError<C::Error>;
-    type Future = TimeoutFuture<C::Future>;
+    type Future = Timeout<Deadline<C::Future>>;
 
     fn connect(&self) -> Self::Future {
-        let duration = self.duration;
-        let timeout = ReactorTimeout::new(duration, &self.handle)
-            .expect("reactor gone");
-        let inner = self.inner.connect();
-        TimeoutFuture {
+        let deadline = Instant::now() + self.duration;
+        let inner = Deadline::new(self.inner.connect(), deadline);
+        Timeout {
             inner,
-            duration,
-            timeout,
+            duration: self.duration,
         }
     }
 }
+
+impl<F> Future for Timeout<Deadline<F>>
+where
+    F: Future,
+    // F::Error: Error,
+{
+    type Item = F::Item;
+    type Error = TimeoutError<F::Error>;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map_err(TimeoutError::deadline_error)
+    }
+}
+
 
 impl<C> io::Read for Timeout<C>
 where
@@ -125,18 +132,18 @@ where
     }
 }
 
-impl<C> tokio_io::AsyncRead for Timeout<C>
+impl<C> AsyncRead for Timeout<C>
 where
-    C: tokio_io::AsyncRead,
+    C: AsyncRead,
 {
     unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
         self.inner.prepare_uninitialized_buffer(buf)
     }
 }
 
-impl<C> tokio_io::AsyncWrite for Timeout<C>
+impl<C> AsyncWrite for Timeout<C>
 where
-    C: tokio_io::AsyncWrite,
+    C: AsyncWrite,
 {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
         self.inner.shutdown()
@@ -145,10 +152,24 @@ where
 
 //===== impl TimeoutError =====
 
-impl<E> From<E> for TimeoutError<E> {
-    #[inline]
-    fn from(error: E) -> Self {
-        TimeoutError::Error(error)
+impl<E> TimeoutError<E> {
+    fn error<E>(error: E) -> Self {
+        TimeoutError {
+            kind: TimeoutErrorKind::Error(error),
+        }
+    }
+
+    fn deadline_error<E>(error: DeadlineError<E>) -> Self {
+        let kind = match error {
+            _ if error.is_timer() =>
+                TimeoutErrorKind::Timer(error.into_timer()
+                    .expect("error.into_timer() must succeed if error.is_timer()")),
+            _ if error.is_elapsed() =>
+                TimeoutErrorKind::Timeout(self.duration),
+            _ => TimeoutErrorKind::Error(error.into_inner()
+                .expect("if error is not elapsed or timer, must be inner")),
+        };
+        TimeoutError { kind }
     }
 }
 
@@ -157,10 +178,11 @@ where
     E: fmt::Display
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            TimeoutError::Timeout(ref d) =>
+        match *self.kind {
+            TimeoutErrorKind::Timeout(ref d) =>
                 write!(f, "operation timed out after {}", HumanDuration(*d)),
-            TimeoutError::Error(ref err) => fmt::Display::fmt(err, f),
+            TimeoutErrorKind::Timer(ref err) => write!(f, "timer failed: {}", err),
+            TimeoutErrorKind::Error(ref err) => fmt::Display::fmt(err, f),
         }
     }
 }
@@ -170,51 +192,19 @@ where
     E: Error
 {
     fn cause(&self) -> Option<&Error> {
-        match *self {
-            TimeoutError::Error(ref err) => Some(err),
+        match self.kind {
+            TimeoutErrorKind::Error(ref err) => Some(err),
+            TimeoutErrorKind::Timer(ref err) => Some(err),
             _ => None,
         }
     }
 
     fn description(&self) -> &str {
-        match *self {
-            TimeoutError::Timeout(_) => "operation timed out",
-            TimeoutError::Error(ref err) => err.description(),
+        match self.kind {
+            TimeoutErrorKind::Timeout(_) => "operation timed out",
+            TimeoutErrorKind::Error(ref err) => err.description(),
+            TimeoutErrorKind::Timer(ref err) => err.description(),
         }
-    }
-}
-
-//===== impl TimeoutFuture =====
-
-impl<F> Future for TimeoutFuture<F>
-where
-    F: Future,
-    // F::Error: Error,
-{
-    type Item = F::Item;
-    type Error = TimeoutError<F::Error>;
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        if let Async::Ready(item) = self.inner.poll().map_err(TimeoutError::from)? {
-            Ok(Async::Ready(item))
-        } else if let Async::Ready(_) = self.timeout.poll().expect("timer failed") {
-            Err(TimeoutError::Timeout(self.duration))
-        } else {
-            Ok(Async::NotReady)
-        }
-    }
-}
-
-// We have to provide a custom implementation of Debug, because
-// tokio_core::reactor::Timeout is not Debug.
-impl<F> fmt::Debug for TimeoutFuture<F>
-where
-    F: fmt::Debug
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("TimeoutFuture")
-           .field("inner", &self.inner)
-           .field("duration", &self.duration)
-           .finish()
     }
 }
 

--- a/proxy/src/timeout.rs
+++ b/proxy/src/timeout.rs
@@ -46,7 +46,7 @@ pub struct HumanDuration(pub Duration);
 
 impl<T> Timeout<T> {
     /// Construct a new `Timeout` wrapping `inner`.
-    pub fn new(inner: T, duration: Duration,) -> Self {
+    pub fn new(inner: T, duration: Duration) -> Self {
         Timeout {
             inner,
             duration,

--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -1,13 +1,14 @@
+use bytes::IntoBuf;
 use futures::{Async, Future, Poll};
 use h2;
 use http;
 use hyper;
 use tokio_connect::Connect;
-use tokio_core::reactor::Handle;
 use tower_service::{Service, NewService};
-use tower_h2::{self, Body};
+use tower_h2;
 
 use bind;
+use task::LazyExecutor;
 use telemetry::sensor::http::RequestBody;
 use super::glue::{BodyStream, HttpBody, HyperConnect};
 use super::h1::UriIsAbsoluteForm;
@@ -28,7 +29,7 @@ where
     B: tower_h2::Body + 'static,
 {
     Http1(HyperClient<C, B>),
-    Http2(tower_h2::client::Connect<C, Handle, RequestBody<B>>),
+    Http2(tower_h2::client::Connect<C, LazyExecutor, RequestBody<B>>),
 }
 
 /// A `Future` returned from `Client::new_service()`.
@@ -46,7 +47,7 @@ where
     C: Connect + 'static,
 {
     Http1(Option<HyperClient<C, B>>),
-    Http2(tower_h2::client::ConnectFuture<C, Handle, RequestBody<B>>),
+    Http2(tower_h2::client::ConnectFuture<C, LazyExecutor, RequestBody<B>>),
 }
 
 /// The `Service` yielded by `Client::new_service()`.
@@ -66,36 +67,29 @@ where
     Http1(HyperClient<C, B>),
     Http2(tower_h2::client::Connection<
         <C as Connect>::Connected,
-        Handle,
+        LazyExecutor,
         RequestBody<B>,
     >),
 }
 
 impl<C, B> Client<C, B>
 where
-    C: Connect + Clone + 'static,
-    C::Future: 'static,
-    B: tower_h2::Body + 'static,
+    C: Connect + Clone + Send + 'static,
+    C::Future: Send + 'static,
+    C::Connected: Send,
+    B: tower_h2::Body + Send + 'static,
+   <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     /// Create a new `Client`, bound to a specific protocol (HTTP/1 or HTTP/2).
-    pub fn new(protocol: &bind::Protocol,
-               connect: C,
-               executor: Handle)
-               -> Self
-    {
+    pub fn new(protocol: &bind::Protocol, connect: C) -> Self {
         match *protocol {
-            bind::Protocol::Http1 { .. } => {
+            bind::Protocol::Http1 { was_absolute_form, .. } => {
                 let h1 = hyper::Client::configure()
-                    // TODO: when using the latest version of Hyper, we'll want
-                    // to configure the connector with whether or not the
-                    // request URI is in absolute form, since this will be
-                    // handled at the connection level soon.
-                    .connector(HyperConnect::new(connect))
-                    .body()
+                    .executor(LazyExecutor)
                     // hyper should never try to automatically set the Host
                     // header, instead always just passing whatever we received.
                     .set_host(false)
-                    .build(&executor);
+                    .build(HyperConnect::new(connect, was_absolute_form);
                 Client {
                     inner: ClientInner::Http1(h1),
                 }
@@ -105,7 +99,7 @@ where
                 // h2 currently doesn't handle PUSH_PROMISE that well, so we just
                 // disable it for now.
                 h2_builder.enable_push(false);
-                let h2 = tower_h2::client::Connect::new(connect, h2_builder, executor);
+                let h2 = tower_h2::client::Connect::new(connect, h2_builder, LazyExecutor);
 
                 Client {
                     inner: ClientInner::Http2(h2),
@@ -117,9 +111,11 @@ where
 
 impl<C, B> NewService for Client<C, B>
 where
-    C: Connect + Clone + 'static,
-    C::Future: 'static,
-    B: tower_h2::Body + 'static,
+    C: Connect + Clone + Send + 'static,
+    C::Future: Send + 'static,
+    C::Connected: Send,
+    B: tower_h2::Body + Send + 'static,
+   <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     type Request = bind::HttpRequest<B>;
     type Response = http::Response<HttpBody>;
@@ -134,7 +130,8 @@ where
                 ClientNewServiceFutureInner::Http1(Some(h1.clone()))
             },
             ClientInner::Http2(ref h2) => {
-                ClientNewServiceFutureInner::Http2(h2.new_service())                        },
+                ClientNewServiceFutureInner::Http2(h2.new_service())
+            },
         };
         ClientNewServiceFuture {
             inner,
@@ -144,8 +141,11 @@ where
 
 impl<C, B> Future for ClientNewServiceFuture<C, B>
 where
-    C: Connect + 'static,
-    B: tower_h2::Body + 'static,
+    C: Connect + Send + 'static,
+    C::Connected: Send,
+    C::Future: Send + 'static,
+    B: tower_h2::Body + Send + 'static,
+   <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     type Item = ClientService<C, B>;
     type Error = tower_h2::client::ConnectError<C::Error>;
@@ -168,9 +168,11 @@ where
 
 impl<C, B> Service for ClientService<C, B>
 where
-    C: Connect + 'static,
-    C::Future: 'static,
-    B: tower_h2::Body + 'static,
+    C: Connect + Send + 'static,
+    C::Connected: Send,
+    C::Future: Send + 'static,
+    B: tower_h2::Body + Send + 'static,
+   <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     type Request = bind::HttpRequest<B>;
     type Response = http::Response<HttpBody>;
@@ -189,42 +191,7 @@ where
 
         match self.inner {
             ClientServiceInner::Http1(ref h1) => {
-                // This sentinel may be set in h1::normalize_our_view_of_uri
-                // when the original request-target was in absolute-form. In
-                // that case, for hyper 0.11.x, we need to call `req.set_proxy`.
-                let was_absolute_form = req.extensions()
-                    .get::<UriIsAbsoluteForm>()
-                    .is_some();
-                // As of hyper 0.11.x, a set body implies a body must be sent.
-                // If there is no content-length header, hyper adds a
-                // transfer-encoding: chunked header, since it has no other way
-                // of knowing if the body is empty or not.
-                //
-                // However, if we received a `Content-Length: 0` body ourselves,
-                // the `body.is_end_stream()` would be true. While its true that
-                // semantically a client request with no body headers and a request
-                // with `Content-Length: 0` have the exact same body length, we
-                // want to preserve the exact intent of the original request, as
-                // we are trying to be a transparent proxy.
-                //
-                // So, if `Content-Length` is set at all, we need to send it. If
-                // we unset the body, hyper assumes the RFC7230 semantics that
-                // it can strip content body headers. Therefore, even if the
-                // body is empty, it should still be passed to hyper so that
-                // the `Content-Length: 0` header is not stripped.
-                //
-                // This does *NOT* check for `Transfer-Encoding` as future-proofing
-                // measure. When we add the ability to proxy HTTP2 to HTTP1, this
-                // body could have come from h2, where there is no `Transfer-Encoding`.
-                // Instead, it has been replaced by `DATA` frames. The
-                // `HttpBody::is_end_stream()` manages that distinction for us.
-                let should_take_body = req.body().is_end_stream()
-                    && !req.headers().contains_key(CONTENT_LENGTH);
                 let mut req = hyper::Request::from(req.map(BodyStream::new));
-                if should_take_body {
-                    req.body_mut().take();
-                }
-                req.set_proxy(was_absolute_form);
                 ClientServiceFuture::Http1(h1.request(req))
             },
             ClientServiceInner::Http2(ref mut h2) => {
@@ -235,7 +202,7 @@ where
 }
 
 pub enum ClientServiceFuture {
-    Http1(hyper::client::FutureResponse),
+    Http1(hyper::client::ResponseFuture),
     Http2(tower_h2::client::ResponseFuture),
 }
 

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -9,6 +9,7 @@ use futures::future::Either;
 use h2;
 use http;
 use hyper;
+use hyper::client::connect as hyper_connect;
 use tokio_connect::Connect;
 use tower_service::{Service, NewService};
 use tower_h2;
@@ -27,12 +28,7 @@ pub enum HttpBody {
 #[derive(Debug)]
 pub(super) struct BodyStream<B> {
     body: B,
-    poll_trailers: bool,
 }
-
-/// Glue for the `Data` part of a `tower_h2::Body` to be used as an `AsRef` in `BodyStream`.
-#[derive(Debug)]
-pub(super) struct BufAsRef<B>(B);
 
 /// Glue for a `tower::Service` to used as a `hyper::server::Service`.
 #[derive(Debug)]
@@ -67,11 +63,13 @@ pub(super) struct HttpBodyNewSvcFuture<F> {
 #[derive(Debug, Clone)]
 pub(super) struct HyperConnect<C> {
     connect: C,
+    absolute_form: bool,
 }
 
 /// Future returned by `HyperConnect`.
 pub(super) struct HyperConnectFuture<F> {
     inner: F,
+    absolute_form: bool,
 }
 
 // ===== impl HttpBody =====
@@ -111,6 +109,28 @@ impl tower_h2::Body for HttpBody {
     }
 }
 
+impl hyper::body::Payload for HttpBody {
+    type Data = <Bytes as IntoBuf>::Buf;
+    type Error = h2::Error;
+
+    fn is_end_stream(&self) -> bool {
+        tower_h2::Body::is_end_stream(self)
+    }
+
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, h2::Error> {
+        tower_h2::Body::poll_data(self).map(|async| {
+            async.map(|opt|
+                opt.map(Bytes::into_buf)
+            )
+        })
+    }
+
+    fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, h2::Error> {
+        tower_h2::Body::poll_trailers(self)
+    }
+}
+
+
 impl Default for HttpBody {
     fn default() -> HttpBody {
         HttpBody::Http2(Default::default())
@@ -124,57 +144,41 @@ impl<B> BodyStream<B> {
     pub fn new(body: B) -> Self {
         BodyStream {
             body,
-            poll_trailers: false,
         }
     }
 }
 
-impl<B> Stream for BodyStream<B>
+// NOTE: I think it's possible the `BodyStream` type can be removed in favour
+//       of the `Body::Wrap_stream` constructor that's available on the master
+//       version of `hyper`. However, this will box the wrapped stream, so I'm
+//       not sure if we want to use it.
+impl<B> hyper::body::Payload for BodyStream<B>
 where
-    B: tower_h2::Body,
+    B: tower_h2::Body + Send + 'static,
+    <B::Data as IntoBuf>::Buf: Send,
 {
-    type Item = BufAsRef<<B::Data as ::bytes::IntoBuf>::Buf>;
-    type Error = hyper::Error;
+    type Data = <B::Data as IntoBuf>::Buf;
+    type Error = h2::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            if self.poll_trailers {
-                return match self.body.poll_trailers() {
-                    // we don't care about actual trailers, just that the poll
-                    // was ready. now we can tell hyper the stream is done
-                    Ok(Async::Ready(_)) => Ok(Async::Ready(None)),
-                    Ok(Async::NotReady) => Ok(Async::NotReady),
-                    Err(e) => {
-                        trace!("h2 trailers error: {:?}", e);
-                        Err(hyper::Error::Io(io::ErrorKind::Other.into()))
-                    }
-                };
-            } else {
-                match self.body.poll_data() {
-                    Ok(Async::Ready(Some(buf))) => return Ok(Async::Ready(Some(BufAsRef(buf.into_buf())))),
-                    Ok(Async::Ready(None)) => {
-                        // when the data is empty, even though hyper can't use the trailers,
-                        // we need to poll for them, to allow the stream to mark itself as
-                        // completed successfully.
-                        self.poll_trailers = true;
-                    },
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Err(e) => {
-                        trace!("h2 body error: {:?}", e);
-                        return Err(hyper::Error::Io(io::ErrorKind::Other.into()))
-                    }
-                }
-            }
-        }
+    #[inline]
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
+        self.body.poll_data().map(|async| {
+            async.map(|opt|
+                opt.map(B::Data::into_buf)
+            )
+        })
     }
-}
 
-// ===== impl BufAsRef =====
-
-impl<B: ::bytes::Buf> AsRef<[u8]> for BufAsRef<B> {
-    fn as_ref(&self) -> &[u8] {
-        ::bytes::Buf::bytes(&self.0)
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.body.is_end_stream()
     }
+
+    #[inline]
+    fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, Self::Error> {
+        self.body.poll_trailers()
+    }
+
 }
 
 // ===== impl HyperServerSvc =====
@@ -188,33 +192,34 @@ impl<S> HyperServerSvc<S> {
     }
 }
 
-impl<S, B> hyper::server::Service for HyperServerSvc<S>
+impl<S, B> hyper::service::Service for HyperServerSvc<S>
 where
     S: Service<
         Request=http::Request<HttpBody>,
         Response=http::Response<B>,
     >,
     S::Error: fmt::Debug,
-    B: tower_h2::Body + 'static,
+    B: tower_h2::Body + Default + Send + 'static,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
-    type Request = hyper::server::Request;
-    type Response = hyper::server::Response<BodyStream<B>>;
-    type Error = hyper::Error;
+    type ReqBody = hyper::Body;
+    type ResBody = BodyStream<B>;
+    type Error = h2::Error;
     type Future = Either<
         HyperServerSvcFuture<S::Future>,
-        future::FutureResult<Self::Response, Self::Error>,
+        future::FutureResult<http::Response<Self::ResBody>, Self::Error>,
     >;
 
-    fn call(&self, req: Self::Request) -> Self::Future {
-        if let &hyper::Method::Connect = req.method() {
+    fn call(&mut self, req: http::Request<Self::ReqBody>) -> Self::Future {
+        if let &hyper::Method::CONNECT = req.method() {
             debug!("HTTP/1.1 CONNECT not supported");
-            let res = hyper::Response::new()
-                .with_status(hyper::StatusCode::BadGateway);
+            let res = hyper::Response::builder()
+                .status(hyper::StatusCode::BAD_GATEWAY)
+                .body(BodyStream::new(Default::default()))
+                .expect("building response with empty body should not error!");
             return Either::B(future::ok(res));
-
         }
-
-        let mut req: http::Request<hyper::Body> = req.into();
+        let mut req = req;
         req.extensions_mut().insert(self.srv_ctx.clone());
 
         h1::strip_connection_headers(req.headers_mut());
@@ -232,13 +237,13 @@ where
     F: Future<Item=http::Response<B>>,
     F::Error: fmt::Debug,
 {
-    type Item = hyper::server::Response<BodyStream<B>>;
-    type Error = hyper::Error;
+    type Item = hyper::Response<BodyStream<B>>;
+    type Error = h2::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let mut res = try_ready!(self.inner.poll().map_err(|e| {
             debug!("h2 error: {:?}", e);
-            hyper::Error::Io(io::ErrorKind::Other.into())
+            h2::Error::from(io::Error::from(io::ErrorKind::Other))
         }));
 
         h1::strip_connection_headers(res.headers_mut());
@@ -273,7 +278,7 @@ impl<N> HttpBodyNewSvc<N>
 where
     N: NewService<Request=http::Request<HttpBody>>,
 {
-    pub fn new(new_service: N) -> Self {
+    pub fn new(new_service: N,) -> Self {
         HttpBodyNewSvc {
             new_service,
         }
@@ -320,26 +325,28 @@ where
     C: Connect,
     C::Future: 'static,
 {
-    pub fn new(connect: C) -> Self {
+    pub fn new(connect: C, absolute_form: bool,) -> Self {
         HyperConnect {
             connect,
+            absolute_form,
         }
     }
 }
 
-impl<C> hyper::client::Service for HyperConnect<C>
+impl<C> hyper_connect::Connect for HyperConnect<C>
 where
-    C: Connect,
-    C::Future: 'static,
+    C: Connect + Send + Sync,
+    C::Future: Send + 'static,
+    C::Connected: Send + 'static,
 {
-    type Request = hyper::Uri;
-    type Response = C::Connected;
+    type Transport = C::Connected;
     type Error = io::Error;
     type Future = HyperConnectFuture<C::Future>;
 
-    fn call(&self, _uri: Self::Request) -> Self::Future {
+    fn connect(&self, _dst: hyper_connect::Destination) -> Self::Future {
         HyperConnectFuture {
             inner: self.connect.connect(),
+            absolute_form: self.absolute_form,
         }
     }
 }
@@ -348,11 +355,16 @@ impl<F> Future for HyperConnectFuture<F>
 where
     F: Future,
 {
-    type Item = F::Item;
+    type Item = (F::Item, hyper_connect::Connected);
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-            .map_err(|_| io::ErrorKind::Other.into())
+        let transport = try_ready!(
+            self.inner.poll()
+                .map_err(|_| io::Error::from(io::ErrorKind::Other))
+        );
+        let connected = hyper_connect::Connected::new()
+            .proxy(self.absolute_form);
+        Ok(Async::Ready((transport, connected)))
     }
 }

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -278,7 +278,7 @@ impl<N> HttpBodyNewSvc<N>
 where
     N: NewService<Request=http::Request<HttpBody>>,
 {
-    pub fn new(new_service: N,) -> Self {
+    pub fn new(new_service: N) -> Self {
         HttpBodyNewSvc {
             new_service,
         }
@@ -325,7 +325,7 @@ where
     C: Connect,
     C::Future: 'static,
 {
-    pub fn new(connect: C, absolute_form: bool,) -> Self {
+    pub fn new(connect: C, absolute_form: bool) -> Self {
         HyperConnect {
             connect,
             absolute_form,

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -148,10 +148,6 @@ impl<B> BodyStream<B> {
     }
 }
 
-// NOTE: I think it's possible the `BodyStream` type can be removed in favour
-//       of the `Body::Wrap_stream` constructor that's available on the master
-//       version of `hyper`. However, this will box the wrapped stream, so I'm
-//       not sure if we want to use it.
 impl<B> hyper::body::Payload for BodyStream<B>
 where
     B: tower_h2::Body + Send + 'static,

--- a/proxy/src/transparency/h1.rs
+++ b/proxy/src/transparency/h1.rs
@@ -8,24 +8,9 @@ use http::header::HOST;
 use http::uri::{Authority, Parts, Scheme, Uri};
 use ctx::transport::{Server as ServerCtx};
 
-/// Sentinel extension to signal that we should tell hyper to serialize
-/// the `Uri` in absolute-form.
-pub struct UriIsAbsoluteForm;
-
 /// Tries to make sure the `Uri` of the request is in a form needed by
 /// hyper's Client.
-///
-/// Also sets the `UriIsAbsoluteForm` extension if received `Uri` was
-/// already in absolute-form.
-pub fn normalize_our_view_of_uri<B>(
-    req: &mut http::Request<B>,
-    was_absolute_form: bool
-) {
-    if was_absolute_form {
-        req.extensions_mut().insert(UriIsAbsoluteForm);
-        return;
-    }
-
+pub fn normalize_our_view_of_uri<B>(req: &mut http::Request<B>) {
     // try to parse the Host header
     if let Some(auth) = authority_from_host(&req) {
         set_authority(req.uri_mut(), auth);

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -7,7 +7,7 @@ use futures::Future;
 use http;
 use hyper;
 use indexmap::IndexSet;
-use tokio_core::reactor::Handle;
+use tokio::executor::{Executor, DefaultExecutor};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::NewService;
 use tower_h2;
@@ -16,6 +16,7 @@ use connection::{Connection, Peek};
 use ctx::Proxy as ProxyCtx;
 use ctx::transport::{Server as ServerCtx};
 use drain;
+use task::LazyExecutor;
 use telemetry::Sensors;
 use transport::GetOriginalDst;
 use super::glue::{HttpBody, HttpBodyNewSvc, HyperServerSvc};
@@ -35,10 +36,9 @@ where
 {
     disable_protocol_detection_ports: IndexSet<u16>,
     drain_signal: drain::Watch,
-    executor: Handle,
     get_orig_dst: G,
-    h1: hyper::server::Http,
-    h2: tower_h2::Server<HttpBodyNewSvc<S>, Handle, B>,
+    h1: hyper::server::conn::Http,
+    h2: tower_h2::Server<HttpBodyNewSvc<S>, LazyExecutor, B>,
     listen_addr: SocketAddr,
     new_service: S,
     proxy_ctx: Arc<ProxyCtx>,
@@ -51,14 +51,23 @@ where
     S: NewService<
         Request = http::Request<HttpBody>,
         Response = http::Response<B>
-    > + Clone + 'static,
+    > + Clone + Send + 'static,
     S::Future: 'static,
+    <S as NewService>::Service: Send,
     S::Error: fmt::Debug,
+    <<S as NewService>::Service as ::tower_service::Service>::Future: Send,
     S::InitError: fmt::Debug,
+    S::Future: Send + 'static,
     B: tower_h2::Body + 'static,
+    S::Error: Send + fmt::Debug,
+    S::InitError: Send + fmt::Debug,
+    B: tower_h2::Body + Send + Default + 'static,
+    B::Data: Send,
+    <B::Data as ::bytes::IntoBuf>::Buf: Send,
     G: GetOriginalDst,
 {
-    /// Creates a new `Server`.
+
+   /// Creates a new `Server`.
     pub fn new(
         listen_addr: SocketAddr,
         proxy_ctx: Arc<ProxyCtx>,
@@ -68,17 +77,19 @@ where
         tcp_connect_timeout: Duration,
         disable_protocol_detection_ports: IndexSet<u16>,
         drain_signal: drain::Watch,
-        executor: Handle,
     ) -> Self {
         let recv_body_svc = HttpBodyNewSvc::new(stack.clone());
-        let tcp = tcp::Proxy::new(tcp_connect_timeout, sensors.clone(), &executor);
+        let tcp = tcp::Proxy::new(tcp_connect_timeout, sensors.clone());
         Server {
             disable_protocol_detection_ports,
             drain_signal,
-            executor: executor.clone(),
             get_orig_dst,
-            h1: hyper::server::Http::new(),
-            h2: tower_h2::Server::new(recv_body_svc, Default::default(), executor),
+            h1: hyper::server::conn::Http::new(),
+            h2: tower_h2::Server::new(
+                recv_body_svc,
+                Default::default(),
+                LazyExecutor,
+            ),
             listen_addr,
             new_service: stack,
             proxy_ctx,
@@ -126,7 +137,10 @@ where
                 srv_ctx,
                 self.drain_signal.clone(),
             );
-            self.executor.spawn(fut);
+
+            DefaultExecutor::current()
+                .spawn(fut)
+                .expect("spawn TCP server task");
             return;
         }
 
@@ -138,7 +152,7 @@ where
         let drain_signal = self.drain_signal.clone();
         let fut = io.peek()
             .map_err(|e| debug!("peek error: {}", e))
-            .and_then(move |io| -> Box<Future<Item=(), Error=()>> {
+            .and_then(move |io| -> Box<Future<Item=(), Error=()> + Send> {
                 if let Some(proto) = Protocol::detect(io.peeked()) {
                     match proto {
                         Protocol::Http1 => {
@@ -150,7 +164,7 @@ where
                                     let svc = HyperServerSvc::new(s, srv_ctx);
                                     drain_signal
                                         .watch(h1.serve_connection(io, svc), |conn| {
-                                            conn.disable_keep_alive();
+                                            conn.graceful_shutdown();
                                         })
                                         .map(|_| ())
                                         .map_err(|e| trace!("http1 server error: {:?}", e))
@@ -183,16 +197,18 @@ where
                 }
             });
 
-        self.executor.spawn(fut);
+        DefaultExecutor::current()
+            .spawn(Box::new(fut))
+            .expect("spawn transparent server task")
     }
 }
 
-fn tcp_serve<T: AsyncRead + AsyncWrite + 'static>(
+fn tcp_serve<T: AsyncRead + AsyncWrite + Send + 'static>(
     tcp: &tcp::Proxy,
     io: T,
     srv_ctx: Arc<ServerCtx>,
     drain_signal: drain::Watch,
-) -> Box<Future<Item=(), Error=()>> {
+) -> Box<Future<Item=(), Error=()> + Send + 'static> {
     let fut = tcp.serve(io, srv_ctx);
 
     // There's nothing to do when drain is signaled, we just have to hope

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -8,7 +8,7 @@ use http;
 use hyper;
 use indexmap::IndexSet;
 use tokio_core::reactor::Handle;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::NewService;
 use tower_h2;
 

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use bytes::{Buf, BufMut};
 use futures::{future, Async, Future, Poll};
 use tokio_connect::Connect;
-use tokio_core::reactor::Handle;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use ctx::transport::{Client as ClientCtx, Server as ServerCtx};
@@ -17,24 +16,23 @@ use transport;
 #[derive(Debug, Clone)]
 pub struct Proxy {
     connect_timeout: Duration,
-    executor: Handle,
     sensors: Sensors,
 }
 
 impl Proxy {
     /// Create a new TCP `Proxy`.
-    pub fn new(connect_timeout: Duration, sensors: Sensors, executor: &Handle) -> Self {
+    pub fn new(connect_timeout: Duration, sensors: Sensors) -> Self {
         Self {
             connect_timeout,
-            executor: executor.clone(),
             sensors,
         }
     }
 
     /// Serve a TCP connection, trying to forward it to its destination.
-    pub fn serve<T>(&self, tcp_in: T, srv_ctx: Arc<ServerCtx>) -> Box<Future<Item=(), Error=()>>
+    pub fn serve<T>(&self, tcp_in: T, srv_ctx: Arc<ServerCtx>)
+        -> Box<Future<Item=(), Error=()> + Send>
     where
-        T: AsyncRead + AsyncWrite + 'static,
+        T: AsyncRead + AsyncWrite + Send + 'static,
     {
         let orig_dst = srv_ctx.orig_dst_if_not_local();
 
@@ -62,9 +60,8 @@ impl Proxy {
             None,
         );
         let c = Timeout::new(
-            transport::Connect::new(orig_dst, &self.executor),
+            transport::Connect::new(orig_dst),
             self.connect_timeout,
-            &self.executor,
         );
         let connect = self.sensors.connect(c, &client_ctx);
 

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, BufMut};
 use futures::{future, Async, Future, Poll};
 use tokio_connect::Connect;
 use tokio_core::reactor::Handle;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use ctx::transport::{Client as ClientCtx, Server as ServerCtx};
 use telemetry::Sensors;
@@ -272,7 +272,7 @@ mod tests {
     use std::io::{Error, Read, Write, Result};
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use tokio_io::{AsyncRead, AsyncWrite};
+    use tokio::io::{AsyncRead, AsyncWrite};
     use futures::{Async, Poll};
     use super::*;
 

--- a/proxy/src/transport/so_original_dst.rs
+++ b/proxy/src/transport/so_original_dst.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-use tokio_core::net::TcpStream;
+use tokio::net::TcpStream;
 
 /// A generic way to get the original destination address of a socket.
 ///

--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -14,8 +14,8 @@ extern crate h2;
 pub extern crate http;
 extern crate hyper;
 extern crate prost;
+extern crate tokio;
 extern crate tokio_connect;
-extern crate tokio_core;
 pub extern crate tokio_io;
 extern crate tower_h2;
 extern crate tower_grpc;
@@ -29,12 +29,17 @@ pub use std::time::Duration;
 
 pub use self::bytes::Bytes;
 pub use self::conduit_proxy::*;
-pub use self::futures::*;
+pub use self::conduit_proxy::task::LazyExecutor;
+pub use self::futures::{future::Executor, *,};
 use self::futures::sync::oneshot;
 pub use self::http::{HeaderMap, Request, Response, StatusCode};
+use self::tokio::{
+    executor::current_thread,
+    net::{TcpListener, TcpStream},
+    runtime,
+    reactor,
+};
 use self::tokio_connect::Connect;
-use self::tokio_core::net::{TcpListener, TcpStream};
-use self::tokio_core::reactor::{Core, Handle};
 use self::tower_h2::{Body, RecvBody};
 use self::tower_grpc as grpc;
 use self::tower_service::{NewService, Service};

--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -32,7 +32,7 @@ pub use self::bytes::Bytes;
 pub use self::conduit_proxy::*;
 pub use self::conduit_proxy::task::LazyExecutor;
 pub use self::futures::{future::Executor, *,};
-use self::futures::sync::oneshot;
+pub use self::futures::sync::oneshot;
 pub use self::http::{HeaderMap, Request, Response, StatusCode};
 use self::tokio::{
     executor::current_thread,

--- a/proxy/tests/support/proxy.rs
+++ b/proxy/tests/support/proxy.rs
@@ -182,8 +182,14 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
             let _c = controller;
 
             let mock_orig_dst = MockOriginalDst(Arc::new(Mutex::new(mock_orig_dst)));
-
-            let main = conduit_proxy::Main::new(config, mock_orig_dst.clone());
+            // TODO: a mock timer could be injected here?
+            let runtime = tokio::runtime::current_thread::Runtime::new()
+                .expect("initialize main runtime");
+            let main = conduit_proxy::Main::new(
+                config,
+                mock_orig_dst.clone(),
+                runtime,
+            );
 
             let control_addr = main.control_addr();
             let inbound_addr = main.inbound_addr();

--- a/proxy/tests/support/server.rs
+++ b/proxy/tests/support/server.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
@@ -115,72 +116,81 @@ impl Server {
             version,
             thread_name(),
         );
-        ::std::thread::Builder::new().name(tname).spawn(move || {
-            let mut core = Core::new().unwrap();
-            let reactor = core.handle();
+        ::std::thread::Builder::new()
+            .name(tname)
+            .spawn(move || {
+                let mut runtime = runtime::current_thread::Runtime::new()
+                    .expect("initialize support server runtime");
 
-            let new_svc = NewSvc(Arc::new(self.routes));
+                let new_svc = NewSvc(Arc::new(self.routes));
 
-            let srv: Box<Fn(TcpStream) -> Box<Future<Item=(), Error=()>>> = match self.version {
-                Run::Http1 => {
-                    let h1 = hyper::server::Http::<hyper::Chunk>::new();
+                let srv: Box<Fn(TcpStream) -> Box<Future<Item=(), Error=()>>> = match self.version {
+                    Run::Http1 => {
+                        let h1 = hyper::server::conn::Http::new();
 
-                    Box::new(move |sock| {
-                        let h1_clone = h1.clone();
-                        let srv_conn_count = Arc::clone(&srv_conn_count);
-                        let conn = new_svc.new_service()
-                            .inspect(move |_| {
-                                srv_conn_count.fetch_add(1, Ordering::Release);
+                        Box::new(move |sock| {
+                            let h1_clone = h1.clone();
+                            let srv_conn_count = Arc::clone(&srv_conn_count);
+                            let conn = new_svc.new_service()
+                                .inspect(move |_| {
+                                    srv_conn_count.fetch_add(1, Ordering::Release);
+                                })
+                                .map_err(|e| println!("server new_service error: {}", e))
+                                .and_then(move |svc|
+                                    h1_clone.serve_connection(sock, svc)
+                                        .map_err(|e| println!("server h1 error: {}", e))
+                                )
+                                .map(|_| ());
+                            Box::new(conn)
+                        })
+                    },
+                    Run::Http2 => {
+                        let h2 = tower_h2::Server::new(
+                            new_svc,
+                            Default::default(),
+                            LazyExecutor,
+                        );
+                        Box::new(move |sock| {
+                            let srv_conn_count = Arc::clone(&srv_conn_count);
+                            let conn = h2.serve(sock)
+                                .map_err(|e| println!("server h2 error: {:?}", e))
+                                .inspect(move |_| {
+                                    srv_conn_count.fetch_add(1, Ordering::Release);
+                                });
+                            Box::new(conn)
+                        })
+                    },
+                };
+
+                let addr = ([127, 0, 0, 1], 0).into();
+                let bind = TcpListener::bind(&addr).expect("bind");
+
+                let local_addr = bind.local_addr().expect("local_addr");
+                let _ = addr_tx.send(local_addr);
+
+                let serve = bind.incoming()
+                    .fold(srv, move |srv, sock| {
+                        if let Err(e) = sock.set_nodelay(true) {
+                            return Err(e);
+                        }
+                        current_thread::TaskExecutor::current()
+                            .execute(srv(sock))
+                            .map_err(|e| {
+                                println!("server execute error: {:?}", e);
+                                io::Error::from(io::ErrorKind::Other)
                             })
-                            .from_err()
-                            .and_then(move |svc| h1_clone.serve_connection(sock, svc))
-                            .map(|_| ())
-                            .map_err(|e| println!("server h1 error: {}", e));
-                        Box::new(conn)
-                    })
-                },
-                Run::Http2 => {
-                    let h2 = tower_h2::Server::new(
-                        new_svc,
-                        Default::default(),
-                        reactor.clone(),
-                    );
-                    Box::new(move |sock| {
-                        let srv_conn_count = Arc::clone(&srv_conn_count);
-                        let conn = h2.serve(sock)
-                            .map_err(|e| println!("server h2 error: {:?}", e))
-                            .inspect(move |_| {
-                                srv_conn_count.fetch_add(1, Ordering::Release);
-                            });
-                        Box::new(conn)
-                    })
-                },
-            };
+                            .map(|_| srv)
+                    });
 
-            let addr = ([127, 0, 0, 1], 0).into();
-            let bind = TcpListener::bind(&addr, &reactor).expect("bind");
+                runtime.spawn(
+                    Box::new(serve
+                        .map(|_| ())
+                        .map_err(|e| println!("server error: {}", e))
+                    )
+                );
 
-            let local_addr = bind.local_addr().expect("local_addr");
-            let _ = addr_tx.send(local_addr);
-
-            let serve = bind.incoming()
-                .fold((srv, reactor), move |(srv, reactor), (sock, _)| {
-                    if let Err(e) = sock.set_nodelay(true) {
-                        return Err(e);
-                    }
-                    reactor.spawn(srv(sock));
-
-                    Ok((srv, reactor))
-                });
-
-            core.handle().spawn(
-                serve
-                    .map(|_| ())
-                    .map_err(|e| println!("server error: {}", e)),
-            );
-
-            core.run(rx).unwrap();
-        }).unwrap();
+                runtime.block_on(rx).expect("block on");
+            }).unwrap();
 
         let addr = addr_rx.wait().expect("addr");
 
@@ -284,29 +294,30 @@ impl Service for Svc {
     }
 }
 
-impl hyper::server::Service for Svc {
-    type Request = hyper::server::Request;
-    type Response = hyper::server::Response<hyper::Body>;
-    type Error = hyper::Error;
-    type Future = future::FutureResult<hyper::server::Response<hyper::Body>, hyper::Error>;
+impl hyper::service::Service for Svc {
+    type ReqBody = hyper::Body;
+    type ResBody = hyper::Body;
+    type Error = http::Error;
+    type Future = future::FutureResult<hyper::Response<hyper::Body>, Self::Error>;
 
-    fn call(&self, req: Self::Request) -> Self::Future {
+    fn call(&mut self, req: hyper::Request<hyper::Body>) -> Self::Future {
 
         let rsp = match self.0.get(req.uri().path()) {
             Some(route) => {
-                (route.0)(Request::from(req).map(|_| ()))
-                    .map(|s| hyper::Body::from(s))
-                    .into()
+                let rsp = (route.0)(Request::from(req).map(|_| ()))
+                    .map(|s| hyper::Body::from(s));
+                Ok(rsp)
             }
             None => {
                 println!("server 404: {:?}", req.uri().path());
-                let rsp = hyper::server::Response::new();
+                let mut rsp = hyper::Response::builder();
                 let body = hyper::Body::empty();
-                rsp.with_status(hyper::NotFound)
-                    .with_body(body)
+                rsp.status(StatusCode::NOT_FOUND)
+                    .body(body)
             }
         };
-        future::ok(rsp)
+
+        future::result(rsp)
     }
 }
 


### PR DESCRIPTION
Closes #888.  Closes #867.

This branch upgrades Conduit to use the new Tokio API. It was also necessary to upgrade some other dependencies (including `tower-h2`, `hyper`, and `trust-dns`) alongside this upgrade. 

This is a more final version of this change than the previous WIP PR #916, which is obsoleted by this PR.