### PR TITLE
Optimize frontend assets to improve load times (#378)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $PACKAGEDIR
 # node dependencies
 RUN $HOME/.yarn/bin/yarn install --pure-lockfile
 # frontend assets
-RUN $HOME/.yarn/bin/yarn webpack
+RUN $HOME/.yarn/bin/yarn webpack -p
 
 ## compile go server
 FROM gcr.io/runconduit/go-deps:e7d5fcae as golang

--- a/web/app/webpack.config.js
+++ b/web/app/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
         test: /\.css$/,
         use: [
           'style-loader',
-          { loader: 'css-loader', options: { importLoaders: 1 } },
+          { loader: 'css-loader', options: { importLoaders: 1, minimize: true } },
           'postcss-loader'
         ]
       },


### PR DESCRIPTION
The frontend assets was not optimized, resulting in suboptimal page load times.

Enabled webpack production mode in the Dockerfile, this still allows good development
and debugging experience when running the web interface locally during development.
Also added minification of the CSS handled by css-loader.

The web interface still works as expected.
The size of the JS file has been reduced from 3.6 MB to 1.2 MB.
And the CSS minification has resulted in sidebar.css from 5.71 kB to 4.33 kb,
and styles.css from 4.18 kB to 3.1 kB.

Fixes #378

Signed-off-by: Kim Christensen <kimworking@gmail.com>