### PR TITLE
Add an app-wide context for global props.

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -3,6 +3,7 @@ import BaseTable from './BaseTable.jsx';
 import GrafanaLink from './GrafanaLink.jsx';
 import React from 'react';
 import { Tooltip } from 'antd';
+import { withContext } from './util/AppContext.jsx';
 import { metricToFormatter, numericSort } from './util/Utils.js';
 
 /*
@@ -122,7 +123,7 @@ const columnDefinitions = (sortable = true, resource, namespaces, onFilterClick,
   }
 };
 
-export default class MetricsTable extends BaseTable {
+class MetricsTable extends BaseTable {
   constructor(props) {
     super(props);
     this.api = this.props.api;
@@ -183,3 +184,5 @@ export default class MetricsTable extends BaseTable {
       size="middle" />);
   }
 }
+
+export default withContext(MetricsTable);

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -6,16 +6,17 @@ import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
 import { processMultiResourceRollup } from './util/MetricUtils.js';
 import React from 'react';
+import { withContext } from './util/AppContext.jsx';
 import './../../css/list.css';
 import 'whatwg-fetch';
 
-export default class Namespaces extends React.Component {
+class Namespaces extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
-    this.state = this.getInitialState(this.props.params);
+    this.state = this.getInitialState(this.props.match.params);
   }
 
   getInitialState(params) {
@@ -39,7 +40,7 @@ export default class Namespaces extends React.Component {
   componentWillReceiveProps() {
     // React won't unmount this component when switching resource pages so we need to clear state
     this.api.cancelCurrentRequests();
-    this.setState(this.getInitialState(this.props.params));
+    this.setState(this.getInitialState(this.props.match.params));
   }
 
   componentWillUnmount() {
@@ -90,8 +91,7 @@ export default class Namespaces extends React.Component {
         <h1>{friendlyTitle}s</h1>
         <MetricsTable
           resource={friendlyTitle}
-          metrics={metrics}
-          api={this.api} />
+          metrics={metrics} />
       </div>
     );
   }
@@ -104,7 +104,7 @@ export default class Namespaces extends React.Component {
         { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
-            <PageHeader header={"Namespace: " + this.state.ns} api={this.api} />
+            <PageHeader header={`Namespace: ${this.state.ns}`} />
             { noMetrics ? <CallToAction /> : null}
             {this.renderResourceSection("Deployment", this.state.metrics.deployments)}
             {this.renderResourceSection("Replication Controller", this.state.metrics.replicationcontrollers)}
@@ -114,3 +114,5 @@ export default class Namespaces extends React.Component {
       </div>);
   }
 }
+
+export default withContext(Namespaces);

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -1,8 +1,9 @@
 import _ from 'lodash';
 import React from 'react';
+import { withContext } from './util/AppContext.jsx';
 import { Col, Radio, Row } from 'antd';
 
-export default class PageHeader extends React.Component {
+class PageHeader extends React.Component {
   constructor(props) {
     super(props);
     this.onTimeWindowClick = this.onTimeWindowClick.bind(this);
@@ -55,3 +56,5 @@ export default class PageHeader extends React.Component {
     );
   }
 }
+
+export default withContext(PageHeader);

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -6,10 +6,11 @@ import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
 import { processSingleResourceRollup } from './util/MetricUtils.js';
 import React from 'react';
+import { withContext } from './util/AppContext.jsx';
 import './../../css/list.css';
 import 'whatwg-fetch';
 
-export default class ResourceList extends React.Component {
+class ResourceList extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
@@ -104,16 +105,17 @@ export default class ResourceList extends React.Component {
         { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
-            <PageHeader header={friendlyTitle + "s"} api={this.api} />
+            <PageHeader header={friendlyTitle + "s"} />
             { _.isEmpty(this.state.metrics) ?
               this.renderEmptyMessage(friendlyTitle) :
               <MetricsTable
                 resource={friendlyTitle}
-                metrics={this.state.metrics}
-                api={this.api} />
+                metrics={this.state.metrics} />
             }
           </div>
         }
       </div>);
   }
 }
+
+export default withContext(ResourceList);

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -9,6 +9,7 @@ import PageHeader from './PageHeader.jsx';
 import Percentage from './util/Percentage.js';
 import React from 'react';
 import StatusTable from './StatusTable.jsx';
+import { withContext } from './util/AppContext.jsx';
 import { Col, Row, Table, Tooltip } from 'antd';
 import './../../css/service-mesh.css';
 
@@ -98,7 +99,7 @@ const componentDeploys = {
   "web":          "web"
 };
 
-export default class ServiceMesh extends React.Component {
+class ServiceMesh extends React.Component {
   constructor(props) {
     super(props);
     this.loadFromServer = this.loadFromServer.bind(this);
@@ -315,8 +316,7 @@ export default class ServiceMesh extends React.Component {
           <div>
             <PageHeader
               header="Service mesh overview"
-              hideButtons={this.proxyCount() === 0}
-              api={this.api} />
+              hideButtons={this.proxyCount() === 0} />
 
             {this.proxyCount() === 0 ?
               <CallToAction
@@ -335,3 +335,5 @@ export default class ServiceMesh extends React.Component {
     );
   }
 }
+
+export default withContext(ServiceMesh);

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -5,11 +5,12 @@ import logo from './../../img/logo_only.png';
 import React from 'react';
 import SocialLinks from './SocialLinks.jsx';
 import Version from './Version.jsx';
+import { withContext } from './util/AppContext.jsx';
 import wordLogo from './../../img/reversed_logo.png';
 import { Icon, Menu } from 'antd';
 import './../../css/sidebar.css';
 
-export default class Sidebar extends React.Component {
+class Sidebar extends React.Component {
   constructor(props) {
     super(props);
     this.api= this.props.api;
@@ -167,3 +168,5 @@ export default class Sidebar extends React.Component {
     );
   }
 }
+
+export default withContext(Sidebar);

--- a/web/app/js/components/util/AppContext.jsx
+++ b/web/app/js/components/util/AppContext.jsx
@@ -1,0 +1,14 @@
+import { ApiHelpers } from './ApiHelpers.jsx';
+import React from 'react';
+
+const Context = React.createContext({
+  api: ApiHelpers(""),
+});
+
+export const withContext = Component => props => (
+  <Context.Consumer>
+    {ctx => <Component {...props} {...ctx} />}
+  </Context.Consumer>
+);
+
+export default Context;

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -1,4 +1,5 @@
 import { ApiHelpers } from './components/util/ApiHelpers.jsx';
+import AppContext from './components/util/AppContext.jsx';
 import { Layout } from 'antd';
 import Namespace from './components/Namespace.jsx';
 import NoMatch from './components/NoMatch.jsx';
@@ -21,37 +22,45 @@ if (proxyPathMatch) {
 
 let controllerNs = appData.controllerNamespace || "conduit";
 
-let api = ApiHelpers(pathPrefix);
+const context = {
+  api: ApiHelpers(pathPrefix),
+  controllerNamespace: controllerNs,
+  pathPrefix: pathPrefix,
+  ...appData,
+};
 
 let applicationHtml = (
-  <BrowserRouter>
-    <Layout>
-      <Route
-        render={routeProps => (<Sidebar
-          {...routeProps}
-          goVersion={appData.goVersion}
-          releaseVersion={appData.releaseVersion}
-          api={api}
-          pathPrefix={pathPrefix}
-          uuid={appData.uuid} />)} />
+  <AppContext.Provider value={context}>
+    <BrowserRouter>
       <Layout>
-        <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
-          <div className="main-content">
-            <Switch>
-              <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
-              <Route path={`${pathPrefix}/servicemesh`} render={() => <ServiceMesh api={api} releaseVersion={appData.releaseVersion} controllerNamespace={controllerNs} />} />
-              <Route path={`${pathPrefix}/namespaces/:namespace`} render={props => <Namespace resource="namespace" api={api} controllerNamespace={controllerNs} params={props.match.params} />} />
-              <Route path={`${pathPrefix}/namespaces`} render={() => <ResourceList resource="namespace" api={api} controllerNamespace={controllerNs} />} />
-              <Route path={`${pathPrefix}/deployments`} render={() => <ResourceList resource="deployment" api={api} controllerNamespace={controllerNs} />} />
-              <Route path={`${pathPrefix}/replicationcontrollers`} render={() => <ResourceList resource="replication_controller" api={api} controllerNamespace={controllerNs} />} />
-              <Route path={`${pathPrefix}/pods`} render={() => <ResourceList resource="pod" api={api} controllerNamespace={controllerNs} />} />
-              <Route component={NoMatch} />
-            </Switch>
-          </div>
-        </Layout.Content>
+        <Route component={Sidebar} />
+        <Layout>
+          <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
+            <div className="main-content">
+              <Switch>
+                <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
+                <Route path={`${pathPrefix}/servicemesh`} component={ServiceMesh} />
+                <Route path={`${pathPrefix}/namespaces/:namespace`} component={Namespace} />
+                <Route
+                  path={`${pathPrefix}/namespaces`}
+                  render={() => <ResourceList resource="namespace" />} />
+                <Route
+                  path={`${pathPrefix}/deployments`}
+                  render={() => <ResourceList resource="deployment" />} />
+                <Route
+                  path={`${pathPrefix}/replicationcontrollers`}
+                  render={() => <ResourceList resource="replication_controller" />} />
+                <Route
+                  path={`${pathPrefix}/pods`}
+                  render={() => <ResourceList resource="pod" />} />
+                <Route component={NoMatch} />
+              </Switch>
+            </div>
+          </Layout.Content>
+        </Layout>
       </Layout>
-    </Layout>
-  </BrowserRouter>
+    </BrowserRouter>
+  </AppContext.Provider>
 );
 
 ReactDOM.render(applicationHtml, appMain);

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { ApiHelpers } from './components/util/ApiHelpers.jsx';
 import AppContext from './components/util/AppContext.jsx';
 import { Layout } from 'antd';
@@ -20,13 +21,12 @@ if (proxyPathMatch) {
   pathPrefix = proxyPathMatch[0];
 }
 
-let controllerNs = appData.controllerNamespace || "conduit";
+if (_.isEmpty(appData.controllerNamespace)) appData.controllerNamespace = 'conduit';
 
 const context = {
-  api: ApiHelpers(pathPrefix),
-  controllerNamespace: controllerNs,
-  pathPrefix: pathPrefix,
   ...appData,
+  api: ApiHelpers(pathPrefix),
+  pathPrefix: pathPrefix,
 };
 
 let applicationHtml = (

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -21,7 +21,9 @@ if (proxyPathMatch) {
   pathPrefix = proxyPathMatch[0];
 }
 
-if (_.isEmpty(appData.controllerNamespace)) appData.controllerNamespace = 'conduit';
+if (_.isEmpty(appData.controllerNamespace)) {
+  appData.controllerNamespace = 'conduit';
+}
 
 const context = {
   ...appData,

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -38,6 +38,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react-app": "^3.1.1",
     "css-loader": "^0.28.7",
+    "enzyme-context-patch": "^0.0.7",
     "eslint": "^4.12.1",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-promise": "^3.6.0",

--- a/web/app/test/testHelpers.jsx
+++ b/web/app/test/testHelpers.jsx
@@ -1,13 +1,10 @@
 import _ from 'lodash';
-import { ApiHelpers } from '../js/components/util/ApiHelpers.jsx';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Route, Router } from 'react-router';
 
-const componentDefaultProps = { api: ApiHelpers("") };
-
 export function routerWrap(Component, extraProps={}, route="/", currentLoc="/") {
-  const createElement = (ComponentToWrap, props) => <ComponentToWrap {...(_.merge({}, componentDefaultProps, props, extraProps))} />;
+  const createElement = (ComponentToWrap, props) => <ComponentToWrap {...(_.merge({}, props, extraProps))} />;
   return (
     <Router history={createMemoryHistory(currentLoc)} createElement={createElement}>
       <Route path={route} render={props => createElement(Component, props)} />

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -2583,6 +2583,10 @@ enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
+enzyme-context-patch@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/enzyme-context-patch/-/enzyme-context-patch-0.0.7.tgz#24559e8ed25e83ced33bfc72fe7e1678a5d90a28"
+
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
@@ -6133,8 +6137,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
We've been passing the `api` object down from the top of the react tree. With
16.x, there's now the ability to have context that can inject anywhere in the
tree. This creates a top level context provider that contains most of the global
variables we've been using (api, appData, ...). It subsequently cleans up some
of the routes and nested components.

- Bumps `react-dom` to 16.3.2 (to match `react`).
- Adds `enzyme-context-patch` for now. This is fixed in enzyme master, but there
  has not been a release yet. Needs to be removed when that is fixed.