### PR TITLE
proxy: Drop destination resolutions when unused

### DIFF
--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -107,7 +107,7 @@ where
         // in `poll_destinations` while the `rpc` service is ready should
         // be reconnected now, otherwise the task would just sleep...
         loop {
-            self.poll_new_watches(client);
+            self.poll_resolve_requests(client);
             self.retain_active_destinations();
             self.poll_destinations();
 
@@ -117,7 +117,7 @@ where
         }
     }
 
-    fn poll_new_watches(&mut self, client: &mut T) {
+    fn poll_resolve_requests(&mut self, client: &mut T) {
         loop {
             // if rpc service isn't ready, not much we can do...
             match client.poll_ready() {

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -26,12 +26,14 @@ pub struct Resolver {
     request_tx: mpsc::UnboundedSender<ResolveRequest>,
 }
 
+/// Requests that resolution updaes for `authority` be sent on `responder`.
 #[derive(Debug)]
 struct ResolveRequest {
     authority: DnsNameAndPort,
     responder: Responder,
 }
 
+/// A handle through which response updates may be sent.
 #[derive(Debug)]
 struct Responder {
     /// Sends updates from the controller to a `Resoliution`.

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -24,9 +24,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::{
-    Arc, Weak,
-};
+use std::sync::{Arc, Weak};
 
 use futures::sync::mpsc;
 use futures::{Async, Poll, Stream};
@@ -74,6 +72,9 @@ pub struct Resolution<B> {
     update_rx: mpsc::UnboundedReceiver<Update>,
 
     /// Allows `Responder` to detect when its `Resolution` has been lost.
+    ///
+    /// `Responder` holds the corresponding `Arc` and can determine when this weak
+    /// reference has been dropped.
     _active: Weak<()>,
 
     /// Map associating addresses with the `Store` for the watch on that
@@ -151,10 +152,7 @@ impl Resolver {
             let authority = authority.clone();
             ResolveRequest {
                 authority,
-                responder: Responder {
-                    update_tx,
-                    active: active,
-                },
+                responder: Responder { update_tx, active },
             }
         };
         self.request_tx

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -8,7 +8,9 @@
 //!
 //! The number of active resolutions is not currently bounded by this module. Instead, we
 //! trust that callers of `Resolver` enforce such a constraint (for example, via
-//! `conduit_proxy_router`'s LRU cache).
+//! `conduit_proxy_router`'s LRU cache). Additionally, users of this module must ensure
+//! they consume resolutions as they are sent so that the response channels don't grow
+//! without bounds.
 //!
 //! Furthermore, there are not currently any bounds on the number of endpoints that may be
 //! returned for a single resolution. It is expected that the Destination service enforce
@@ -58,7 +60,7 @@ struct ResolveRequest {
 /// A handle through which response updates may be sent.
 #[derive(Debug)]
 struct Responder {
-    /// Sends updates from the controller to a `Resoliution`.
+    /// Sends updates from the controller to a `Resolution`.
     update_tx: mpsc::UnboundedSender<Update>,
 
     /// Indicates whether the corresponding `Resolution` is still active.

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -1,3 +1,27 @@
+//! A client for the controller's Destination service.
+//!
+//! This client is split into two primary components: A `Resolver`, that routers use to
+//! initiate service discovery for a given name, and a `background::Process` that
+//! satisfies these resolution requests. These components are separated by a channel so
+//! that the thread responsible for proxying data need not also do this administrative
+//! work of communicating with the control plane.
+//!
+//! The number of active resolutions is not currently bounded by this module. Instead, we
+//! trust that callers of `Resolver` enforce such a constraint (for example, via
+//! `conduit_proxy_router`'s LRU cache).
+//!
+//! Furthermore, there are not currently any bounds on the number of endpoints that may be
+//! returned for a single resolution. It is expected that the Destination service enforce
+//! some reasonable upper bounds.
+//!
+//! ## TODO
+//!
+//! - Given that the underlying gRPC client has some max number of concurrent streams, we
+//!   actually do have an upper bound on concurrent resolutions. This needs to be made
+//!   more explicit.
+//! - We need some means to limit the number of endpoints that can be returned for a
+//!   single resolution so that `control::Cache` is not effectively unbounded.
+
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{


### PR DESCRIPTION
A proxy dispatches requests over a constrained number of routes. When
the router's upper bound is reached---and potentially in other future
scenarios---router capacity is created by removing unused routes, their
load balancers, and all related endpoint stacks.

However, in the current regime, the controller subsystem will continue
to monitor discovery observations. As the number of active observations
expands over time, the controller task ends up with more and more work
to do.

This change introduces a shared atomic boolean between the resolution
returned to the load balancer and the state maintained when
communicating with the service. Before the controller polls its active
resolutions, it first ensures that all unused resolutions are dropped.