### PR TITLE
Allow the dashboard to be served when a namespace path is accessed directly

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -83,7 +83,14 @@ export default class Sidebar extends React.Component {
         <div className="sidebar">
 
           <div className={`sidebar-menu-header ${this.state.collapsed ? "collapsed" : ""}`}>
-            <ConduitLink to="/servicemesh"><img src={this.state.collapsed ? logo : wordLogo} /></ConduitLink>
+            <ConduitLink to="/servicemesh">
+              <img
+                src={this.state.collapsed ? logo : wordLogo}
+                onError={e => {
+                  // awful hack to deal with the fact that we don't serve assets off absolute paths
+                  e.target.src = e.target.src.replace(/(.*)(\/[a-zA-Z]*)(\/dist)(.*)/, "$1$3$4");
+                }} />
+            </ConduitLink>
           </div>
 
           <Menu

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -42,6 +42,7 @@ type (
 		ControllerNamespace string
 		Error               bool
 		ErrorMessage        string
+		PathPrefix          string
 	}
 )
 

--- a/web/templates/app.tmpl.html
+++ b/web/templates/app.tmpl.html
@@ -11,11 +11,9 @@
 {{ end }}
 
 {{ define "script-tags" }}
-  {{with .Context}}
-    {{ if .WebpackDevServer}}
-      <script type="text/javascript" src="{{.WebpackDevServer}}/dist/index_bundle.js" async></script>
-    {{else}}
-      <script type="text/javascript" src="dist/index_bundle.js" async></script>
-    {{end}}
+  {{ if .Context.WebpackDevServer }}
+    <script type="text/javascript" src="{{.Context.WebpackDevServer}}/dist/index_bundle.js" async></script>
+  {{else}}
+    <script type="text/javascript" src="{{.Contents.PathPrefix}}dist/index_bundle.js" async></script>
   {{end}}
 {{end}}


### PR DESCRIPTION
*Problem*
If you navigate directly to (or do a hard refresh on) a path with more than one segment, e.g. `http://localhost:8084/namespaces/conduit`, the dashboard js is not served. Pages with two paths have to be accessed by loading the dashboard on a different path and then clicking through.

When accessing the dashboard via `conduit dashboard` we append a path prefix so that we can connect using the k8s proxy. This means that moving the dashboard to serve images off relative paths won't work, because we need to serve images whether the dashboard is loaded from `http://localhost:8084/namespaces/conduit` or from `http://localhost:8084/namespaces`

(But you can't move to serving images from `/` since that won't work when visiting 
`http://127.0.0.1:62043/api/v1/namespaces/conduit/services/web:http/proxy/namespaces/conduit`)

*Solution? (A little hacky; suggestions welcome)*
Check whether we're serving the dashboard with the proxy url, and if we are, adjust the url at which we serve the index bundle from.
I've also added a very manual override if the conduit logo can't be found at the usual url. 

*Possible other solutions*
We could instead serve the conduit logo via svg as a jsx file (like we do for the conduit spinner). Then it'd be served as part of the index bundle and we wouldn't need a call to get the img file.

Also, we could also replace our use of some fontawesome icons with unicode or html so that we don't have to load the extra fonts required for fontawesome.

Fixes #933

The dashboard will now load when navigating directly to a namespace's page, however, there are little boxes that appear instead of the font icons (we could replace these with html/unicode to avoid an image request).
[Weirdly enough the font awesome icons in the sidebar load; I need to keep investigating].
The conduit logo not loading has been fixed by a frontend override.
The 404s will still be there.

Current state when you navigate directly to a namespace page:

![screen shot 2018-05-16 at 11 24 07 am](https://user-images.githubusercontent.com/549258/40136105-d02d6996-58fb-11e8-8109-613b14b0f8c5.png)



