### PR TITLE
Add a controller namespace label to the destination service endpoints

### DIFF
--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -99,9 +99,6 @@ func (l *endpointListener) toWeightedAddr(address common.TcpAddress) *pb.Weighte
 				podFound = true
 				metricLabelsForPod = pkgK8s.GetOwnerLabels(pod.ObjectMeta)
 				metricLabelsForPod["pod"] = pod.Name
-				if pod.Labels[pkgK8s.ControllerNSLabel] != "" {
-					metricLabelsForPod["conduit_io_control_plane_ns"] = pod.Labels[pkgK8s.ControllerNSLabel]
-				}
 				break
 			}
 		}

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -99,6 +99,9 @@ func (l *endpointListener) toWeightedAddr(address common.TcpAddress) *pb.Weighte
 				podFound = true
 				metricLabelsForPod = pkgK8s.GetOwnerLabels(pod.ObjectMeta)
 				metricLabelsForPod["pod"] = pod.Name
+				if pod.Labels[pkgK8s.ControllerNSLabel] != "" {
+					metricLabelsForPod["conduit_io_control_plane_ns"] = pod.Labels[pkgK8s.ControllerNSLabel]
+				}
 				break
 			}
 		}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -97,6 +97,9 @@ func GetOwnerLabels(objectMeta meta.ObjectMeta) map[string]string {
 // toOwnerLabel converts a proxy label to a prometheus label, following the
 // relabel conventions from the prometheus scrape config file
 func toOwnerLabel(proxyLabel string) string {
+	if proxyLabel == ControllerNSLabel {
+		return "conduit_io_control_plane_ns"
+	}
 	stripped := strings.TrimPrefix(proxyLabel, "conduit.io/proxy-")
 	if stripped == "job" {
 		return "k8s_job"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -65,6 +65,7 @@ const (
 )
 
 var proxyLabels = []string{
+	ControllerNSLabel,
 	ProxyDeploymentLabel,
 	ProxyReplicationControllerLabel,
 	ProxyReplicaSetLabel,

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -12,6 +12,7 @@ func TestGetOwnerLabels(t *testing.T) {
 	t.Run("Maps proxy labels to prometheus labels", func(t *testing.T) {
 		metadata := meta.ObjectMeta{
 			Labels: map[string]string{
+				ControllerNSLabel:                     "conduit-namespace",
 				ProxyDeploymentLabel:                  "test-deployment",
 				ProxyReplicationControllerLabel:       "test-replication-controller",
 				ProxyReplicaSetLabel:                  "test-replica-set",
@@ -23,13 +24,14 @@ func TestGetOwnerLabels(t *testing.T) {
 		}
 
 		expectedLabels := map[string]string{
-			"deployment":             "test-deployment",
-			"replication_controller": "test-replication-controller",
-			"replica_set":            "test-replica-set",
-			"k8s_job":                "test-job",
-			"daemon_set":             "test-daemon-set",
-			"stateful_set":           "test-stateful-set",
-			"pod_template_hash":      "test-pth",
+			"conduit_io_control_plane_ns": "conduit-namespace",
+			"deployment":                  "test-deployment",
+			"replication_controller":      "test-replication-controller",
+			"replica_set":                 "test-replica-set",
+			"k8s_job":                     "test-job",
+			"daemon_set":                  "test-daemon-set",
+			"stateful_set":                "test-stateful-set",
+			"pod_template_hash":           "test-pth",
 		}
 
 		ownerLabels := GetOwnerLabels(metadata)


### PR DESCRIPTION
Adds the label `conduit_io_control_plane_ns` to endpoints returned by the destination service.

Fixes #951