### PR TITLE
Consolidate calls to /metrics to use the new resource type all

### DIFF
--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -53,7 +53,7 @@ export default class Namespaces extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    this.api.setCurrentRequests([this.api.fetchMetrics(this.api.urlsForResource["all"].url(this.state.ns).rollup)]);
+    this.api.setCurrentRequests([this.api.fetchMetrics(this.api.urlsForResource("all", this.state.ns))]);
 
     Promise.all(this.api.getCurrentPromises())
       .then(([allRollup]) => {

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -4,7 +4,7 @@ import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
-import { processRollupMetrics } from './util/MetricUtils.js';
+import { processMultiResourceRollup } from './util/MetricUtils.js';
 import React from 'react';
 import './../../css/list.css';
 import 'whatwg-fetch';
@@ -53,24 +53,15 @@ export default class Namespaces extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    this.api.setCurrentRequests(
-      _.map(["deployment", "replication_controller", "pod"], resource =>
-        this.api.fetchMetrics(this.api.urlsForResource[resource].url(this.state.ns).rollup))
-    );
+    this.api.setCurrentRequests([this.api.fetchMetrics(this.api.urlsForResource["all"].url(this.state.ns).rollup)]);
 
     Promise.all(this.api.getCurrentPromises())
-      .then(([deployRollup, rcRollup, podRollup]) => {
+      .then(([allRollup]) => {
         let includeConduitStats = this.state.ns === this.props.controllerNamespace; // allow us to get stats on the conduit ns
-        let deploys = processRollupMetrics(deployRollup, this.props.controllerNamespace, includeConduitStats);
-        let rcs = processRollupMetrics(rcRollup, this.props.controllerNamespace, includeConduitStats);
-        let pods = processRollupMetrics(podRollup, this.props.controllerNamespace, includeConduitStats);
+        let metrics = processMultiResourceRollup(allRollup, this.props.controllerNamespace, includeConduitStats);
 
         this.setState({
-          metrics: {
-            deploy: deploys,
-            rc: rcs,
-            pod: pods
-          },
+          metrics: metrics,
           loaded: true,
           pendingRequests: false,
           error: ''
@@ -106,7 +97,7 @@ export default class Namespaces extends React.Component {
   }
 
   render() {
-    let noMetrics = _.isEmpty(this.state.metrics.pod);
+    let noMetrics = _.isEmpty(this.state.metrics.pods);
 
     return (
       <div className="page-content">
@@ -115,9 +106,9 @@ export default class Namespaces extends React.Component {
           <div>
             <PageHeader header={"Namespace: " + this.state.ns} api={this.api} />
             { noMetrics ? <CallToAction /> : null}
-            {this.renderResourceSection("Deployment", this.state.metrics.deploy)}
-            {this.renderResourceSection("Replication Controller", this.state.metrics.rc)}
-            {this.renderResourceSection("Pod", this.state.metrics.pod)}
+            {this.renderResourceSection("Deployment", this.state.metrics.deployments)}
+            {this.renderResourceSection("Replication Controller", this.state.metrics.replicationcontrollers)}
+            {this.renderResourceSection("Pod", this.state.metrics.pods)}
           </div>
         }
       </div>);

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -4,7 +4,7 @@ import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
-import { processRollupMetrics } from './util/MetricUtils.js';
+import { processSingleResourceRollup } from './util/MetricUtils.js';
 import React from 'react';
 import './../../css/list.css';
 import 'whatwg-fetch';
@@ -66,7 +66,8 @@ export default class ResourceList extends React.Component {
 
     Promise.all(this.api.getCurrentPromises())
       .then(([rollup]) => {
-        let processedMetrics = processRollupMetrics(rollup, this.props.controllerNamespace);
+        let processedMetrics = processSingleResourceRollup(rollup, this.props.controllerNamespace);
+
         this.setState({
           metrics: processedMetrics,
           loaded: true,

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -61,7 +61,7 @@ export default class ResourceList extends React.Component {
     this.setState({ pendingRequests: true });
 
     this.api.setCurrentRequests([
-      this.api.fetchMetrics(this.api.urlsForResource[resource].url().rollup)
+      this.api.fetchMetrics(this.api.urlsForResource(resource))
     ]);
 
     Promise.all(this.api.getCurrentPromises())

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -173,8 +173,8 @@ export default class ServiceMesh extends React.Component {
     this.setState({ pendingRequests: true });
 
     this.api.setCurrentRequests([
-      this.api.fetchMetrics(this.api.urlsForResource["pod"].url(this.props.controllerNamespace).rollup),
-      this.api.fetchMetrics(this.api.urlsForResource["namespace"].url().rollup)
+      this.api.fetchMetrics(this.api.urlsForResource("pod", this.props.controllerNamespace)),
+      this.api.fetchMetrics(this.api.urlsForResource("namespace"))
     ]);
 
     this.serverPromise = Promise.all(this.api.getCurrentPromises())

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -89,6 +89,9 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   };
 
   const urlsForResource = {
+    "all": {
+      url: genResourceUrl("all")
+    },
     "namespace": {
       url: genResourceUrl("namespace")
     },

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -79,31 +79,13 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     metricsWindow = window;
   };
 
-  const genResourceUrl = type => {
-    return namespace => {
-      let baseUrl = '/api/stat?resource_type=' + type;
-      return {
-        rollup: !namespace ? baseUrl : baseUrl + '&namespace=' + namespace
-      };
-    };
-  };
-
-  const urlsForResource = {
-    "all": {
-      url: genResourceUrl("all")
-    },
-    "namespace": {
-      url: genResourceUrl("namespace")
-    },
-    "replication_controller": {
-      url: genResourceUrl("replicationcontroller")
-    },
-    "deployment": {
-      url: genResourceUrl("deployment")
-    },
-    "pod": {
-      url: genResourceUrl("pod")
+  const urlsForResource = (type, namespace) => {
+    if (type === "replication_controller") {
+      type = "replicationcontroller";
     }
+
+    let baseUrl = '/api/stat?resource_type=' + type;
+    return !namespace ? baseUrl : baseUrl + '&namespace=' + namespace;
   };
 
   // maintain a list of a component's requests,
@@ -156,7 +138,7 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     setMetricsWindow,
     getValidMetricsWindows: () => _.keys(validMetricsWindows),
     getMetricsWindowDisplayText,
-    urlsForResource: urlsForResource,
+    urlsForResource,
     ConduitLink,
     setCurrentRequests,
     getCurrentPromises,

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -141,7 +141,9 @@ export const processMultiResourceRollup = (rawMetrics, controllerNamespace, incl
       return;
     }
 
+    // assumes all rows in a podGroup have the same resource type
     let resource = _.get(table, ["podGroup", "rows", 0, "resource", "type"]);
+
     metricsByResource[resource] = processStatTable(table, controllerNamespace, includeConduit);
   });
   return metricsByResource;

--- a/web/app/test/ApiHelpersTest.jsx
+++ b/web/app/test/ApiHelpersTest.jsx
@@ -284,14 +284,20 @@ describe('ApiHelpers', () => {
   describe('urlsForResource', () => {
     it('returns the correct rollup url for deployment overviews', () => {
       api = ApiHelpers('/go/my/own/way');
-      let deploymentUrls = api.urlsForResource["deployment"].url();
-      expect(deploymentUrls.rollup).to.equal('/api/stat?resource_type=deployment');
+      let deploymentUrl = api.urlsForResource("deployment");
+      expect(deploymentUrl).to.equal('/api/stat?resource_type=deployment');
     });
 
     it('returns the correct rollup url for pod overviews', () => {
       api = ApiHelpers('/go/my/own/way');
-      let deploymentUrls = api.urlsForResource["pod"].url();
-      expect(deploymentUrls.rollup).to.equal('/api/stat?resource_type=pod');
+      let deploymentUrls = api.urlsForResource("pod");
+      expect(deploymentUrls).to.equal('/api/stat?resource_type=pod');
+    });
+
+    it('scopes the query to the provided namespace', () => {
+      api = ApiHelpers('/go/my/own/way');
+      let deploymentUrls = api.urlsForResource("pod", "my-ns");
+      expect(deploymentUrls).to.equal('/api/stat?resource_type=pod&namespace=my-ns');
     });
   });
 });

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -1,12 +1,17 @@
+import _ from 'lodash';
 import deployRollupFixtures from './fixtures/deployRollup.json';
 import { expect } from 'chai';
 import multiDeployRollupFixtures from './fixtures/multiDeployRollup.json';
-import { processRollupMetrics } from '../js/components/util/MetricUtils.js';
+import multiResourceRollupFixtures from './fixtures/allRollup.json';
+import {
+  processMultiResourceRollup,
+  processSingleResourceRollup
+} from '../js/components/util/MetricUtils.js';
 
 describe('MetricUtils', () => {
-  describe('processRollupMetrics', () => {
+  describe('processSingleResourceRollup', () => {
     it('Extracts deploy metrics from a single response', () => {
-      let result = processRollupMetrics(deployRollupFixtures);
+      let result = processSingleResourceRollup(deployRollupFixtures);
       let expectedResult = [
         {
           name: 'voting',
@@ -25,7 +30,7 @@ describe('MetricUtils', () => {
     });
 
     it('Extracts and sorts multiple deploys from a single response', () => {
-      let result = processRollupMetrics(multiDeployRollupFixtures);
+      let result = processSingleResourceRollup(multiDeployRollupFixtures);
       expect(result).to.have.length(4);
       expect(result[0].name).to.equal("emoji");
       expect(result[0].namespace).to.equal("emojivoto");
@@ -35,6 +40,26 @@ describe('MetricUtils', () => {
       expect(result[2].namespace).to.equal("emojivoto");
       expect(result[3].name).to.equal("web");
       expect(result[3].namespace).to.equal("emojivoto");
+    });
+  });
+
+  describe('processMultiResourceRollup', () => {
+    it('Extracts metrics and groups them by resource type', () => {
+      let result = processMultiResourceRollup(multiResourceRollupFixtures);
+      expect(_.size(result)).to.equal(2);
+
+      expect(result["deployments"]).to.have.length(1);
+      expect(result["pods"]).to.have.length(3);
+      expect(result["replicationcontrollers"]).to.be.undefined;
+    });
+
+    it('Respects the includeConduit flag', () => {
+      let result = processMultiResourceRollup(multiResourceRollupFixtures, "conduit-other", true);
+      expect(_.size(result)).to.equal(2);
+
+      expect(result["deployments"]).to.have.length(1);
+      expect(result["pods"]).to.have.length(4);
+      expect(result["replicationcontrollers"]).to.be.undefined;
     });
   });
 });

--- a/web/app/test/fixtures/allRollup.json
+++ b/web/app/test/fixtures/allRollup.json
@@ -1,0 +1,97 @@
+{
+  "ok": {
+    "statTables": [
+      {
+        "podGroup": {
+          "rows": [
+            {
+              "meshedPodCount": "1",
+              "resource": {
+                "name": "voting",
+                "namespace": "emojivoto",
+                "type": "deployments"
+              },
+              "stats": {
+                "failureCount": "15",
+                "latencyMsP50": "1",
+                "latencyMsP95": "2",
+                "latencyMsP99": "7",
+                "successCount": "135"
+              },
+              "timeWindow": "1m",
+              "runningPodCount": "1",
+              "failedPodCount": null
+            }
+          ]
+        }
+      },
+      {
+        "podGroup": {
+          "rows": []
+        }
+      },
+      {
+        "podGroup": {
+          "rows": [
+            {
+              "resource": {
+                "namespace": "conduit",
+                "type": "pods",
+                "name": "web-5f97578cf6-597sr"
+              },
+              "timeWindow": "1m",
+              "meshedPodCount": "4",
+              "runningPodCount": "4",
+              "stats": {
+                "successCount": "6",
+                "failureCount": "0",
+                "latencyMsP50": "5",
+                "latencyMsP95": "9",
+                "latencyMsP99": "10"
+              }
+            },
+            {
+              "resource": {
+                "namespace": "conduit-other",
+                "type": "pods",
+                "name": "controller-795dd8df6-tjdt6"
+              },
+              "timeWindow": "1m",
+              "meshedPodCount": "4",
+              "runningPodCount": "4",
+              "stats": {
+                "successCount": "24",
+                "failureCount": "0",
+                "latencyMsP50": "7",
+                "latencyMsP95": "18",
+                "latencyMsP99": "20"
+              }
+            },
+            {
+              "resource": {
+                "namespace": "not-conduit",
+                "type": "pods",
+                "name": "prometheus-595785446-r7rlq"
+              },
+              "timeWindow": "1m",
+              "meshedPodCount": "4",
+              "runningPodCount": "4",
+              "stats": null
+            },
+            {
+              "resource": {
+                "namespace": "conduit-other",
+                "type": "pods",
+                "name": "grafana-78cdb656bf-v8lsj"
+              },
+              "timeWindow": "1m",
+              "meshedPodCount": "4",
+              "runningPodCount": "4",
+              "stats": null
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Now that #928 has merged, we can use `resource_type=all` to request metrics for all resource types available. This PR modifies the `Namespace` page in the web UI to replace the 3 existing api calls with a single call.

There are no user visible changes.

Fixes #941 
