### PR TITLE
proxy: Improve GZIP detection

### DIFF
--- a/proxy/src/telemetry/metrics/serve.rs
+++ b/proxy/src/telemetry/metrics/serve.rs
@@ -45,7 +45,15 @@ impl Serve {
             .get_all(header::ACCEPT_ENCODING).iter()
             .any(|value| {
                 value.to_str().ok()
-                    .map(|value| value.contains("gzip"))
+                    .map(|value| value.split(",").any(|item| {
+                            match item.trim()  {
+                                // q=0 means that the encoding is *disallowed*.
+                                "gzip;q=0" | "*;q=0" => false,
+                                "gzip" | "*" => true,
+                                item => item.starts_with("gzip;q=") || item.starts_with("*")
+                            }
+                        })
+                    )
                     .unwrap_or(false)
             })
     }


### PR DESCRIPTION
This PR fixes an issue in how the proxy detects gzippable Accept-Encodings in #944; strings such as `bugzipped` will no longer be interpreted as `gzip`. Furthermore, it also fixes an issue that also exists on master, where `Accept-Encoding: gzip;q=0, ...`, a request that GZIP _not_ be used, will lead to GZIP being used.

I've also added to the test for metrics compression, to include `Accept-Encoding` values that we expect should _not_ be compressed with GZIP.