### PR TITLE
Enable optional parallel build of docker images

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -25,7 +25,7 @@ fi
 if which parallel >/dev/null; then
   cmd="parallel $bindir/docker-build-{}"
 else
-  printf "Install parallel to speed the build up (brew install parallel)\n"
+  printf "Install parallel to speed the build up (brew install parallel)\n" >&2
   cmd="xargs -I{} /bin/sh -c $bindir/docker-build-{}"
 fi
 

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -9,11 +9,24 @@ fi
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$bindir/docker-build-controller
-$bindir/docker-build-web
-$bindir/docker-build-proxy-init
+containers=$(cat <<-END
+controller
+web
+proxy-init
+grafana
+proxy
+END
+)
+
 if [ -z "${CONDUIT_SKIP_CLI_CONTAINER:-}" ]; then
-    $bindir/docker-build-cli-bin
+  containers=$(printf "$containers\ncli-bin")
 fi
-$bindir/docker-build-grafana
-$bindir/docker-build-proxy
+
+if which parallel >/dev/null; then
+  cmd="parallel $bindir/docker-build-{}"
+else
+  printf "Install parallel to speed the build up (brew install parallel)\n"
+  cmd="xargs -I{} /bin/sh -c $bindir/docker-build-{}"
+fi
+
+echo "$containers" | $cmd


### PR DESCRIPTION
By default, docker does image builds in a single thread. For our containers, this is a little slow on my system. Using `parallel` allows for *optional* improvements in speed there.

Before: 41s
After: 22s