### PR TITLE
Fix non-default proxy-api port

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -30,6 +30,7 @@ type installConfig struct {
 	ControllerLogLevel       string
 	ControllerComponentLabel string
 	CreatedByAnnotation      string
+	ProxyAPIPort             uint
 }
 
 type installOptions struct {
@@ -97,6 +98,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		ControllerLogLevel:       options.controllerLogLevel,
 		ControllerComponentLabel: k8s.ControllerComponentLabel,
 		CreatedByAnnotation:      k8s.CreatedByAnnotation,
+		ProxyAPIPort:             options.proxyAPIPort,
 	}, nil
 }
 

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -35,6 +35,7 @@ func TestRender(t *testing.T) {
 		ControllerLogLevel:       "ControllerLogLevel",
 		ControllerComponentLabel: "ControllerComponentLabel",
 		CreatedByAnnotation:      "CreatedByAnnotation",
+		ProxyAPIPort:             123,
 	}
 
 	testCases := []struct {

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -170,6 +170,7 @@ spec:
         resources: {}
       - args:
         - proxy-api
+        - -addr=:8086
         - -log-level=info
         - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -111,8 +111,8 @@ spec:
     ControllerComponentLabel: controller
   ports:
   - name: grpc
-    port: 8086
-    targetPort: 8086
+    port: 123
+    targetPort: 123
 
 ---
 apiVersion: extensions/v1beta1
@@ -171,13 +171,14 @@ spec:
         resources: {}
       - args:
         - proxy-api
+        - -addr=:123
         - -log-level=ControllerLogLevel
         - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         name: proxy-api
         ports:
-        - containerPort: 8086
+        - containerPort: 123
           name: grpc
         - containerPort: 9996
           name: admin-http

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -114,8 +114,8 @@ spec:
     {{.ControllerComponentLabel}}: controller
   ports:
   - name: grpc
-    port: 8086
-    targetPort: 8086
+    port: {{.ProxyAPIPort}}
+    targetPort: {{.ProxyAPIPort}}
 
 ---
 kind: Deployment
@@ -167,13 +167,14 @@ spec:
       - name: proxy-api
         ports:
         - name: grpc
-          containerPort: 8086
+          containerPort: {{.ProxyAPIPort}}
         - name: admin-http
           containerPort: 9996
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - "proxy-api"
+        - "-addr=:{{.ProxyAPIPort}}"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
       - name: tap


### PR DESCRIPTION
Running `conduit install --api-port xxx` where xxx != 8086 would yield a
broken install.

Fix the install command to correctly propagate the `api-port` flag,
setting it as the serve address in the proxy-api container.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>