### PR TITLE
proxy: Alter telemetry to use discrete instants

### DIFF
--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -18,7 +18,7 @@ use std::{
     fmt,
     net::SocketAddr,
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use test::Bencher;
 
@@ -81,10 +81,13 @@ fn record_response_end(b: &mut Bencher) {
 
     let (_, rsp) = request("http://buoyant.io", &server, &client, 1);
 
+    let request_open_at = Instant::now();
+    let response_open_at = request_open_at + Duration::from_millis(300);
     let end = event::StreamResponseEnd {
         grpc_status: None,
-        since_request_open: Duration::from_millis(300),
-        since_response_open: Duration::from_millis(0),
+        request_open_at,
+        response_open_at,
+        response_end_at: response_open_at,
         bytes_sent: 0,
         frames_sent: 0,
     };
@@ -110,22 +113,30 @@ fn record_one_conn_request(b: &mut Bencher) {
     let server_transport = Arc::new(ctx::transport::Ctx::Server(server));
     let client_transport = Arc::new(ctx::transport::Ctx::Client(client));
 
+    let request_open_at = Instant::now();
+    let request_end_at = request_open_at + Duration::from_millis(10);
+    let response_open_at = request_open_at + Duration::from_millis(300);
+    let response_end_at = response_open_at;
+
     use Event::*;
     let events = vec![
         TransportOpen(server_transport.clone()),
         TransportOpen(client_transport.clone()),
         StreamRequestOpen(req.clone()),
         StreamRequestEnd(req.clone(), event::StreamRequestEnd {
-            since_request_open: Duration::from_millis(10),
+            request_open_at,
+            request_end_at,
         }),
 
         StreamResponseOpen(rsp.clone(), event::StreamResponseOpen {
-            since_request_open: Duration::from_millis(300),
+            request_open_at,
+            response_open_at,
         }),
         StreamResponseEnd(rsp.clone(), event::StreamResponseEnd {
             grpc_status: None,
-            since_request_open: Duration::from_millis(300),
-            since_response_open: Duration::from_millis(0),
+            request_open_at,
+            response_open_at,
+            response_end_at,
             bytes_sent: 0,
             frames_sent: 0,
         }),
@@ -159,6 +170,11 @@ fn record_many_dsts(b: &mut Bencher) {
     let mut events = Vec::new();
     events.push(TransportOpen(server_transport.clone()));
 
+    let request_open_at = Instant::now();
+    let request_end_at = request_open_at + Duration::from_millis(10);
+    let response_open_at = request_open_at + Duration::from_millis(300);
+    let response_end_at = response_open_at;
+
     for n in 0..REQUESTS {
         let client = client(&proxy, vec![
             ("service".into(), format!("svc{}", n)),
@@ -173,16 +189,19 @@ fn record_many_dsts(b: &mut Bencher) {
 
         events.push(StreamRequestOpen(req.clone()));
         events.push(StreamRequestEnd(req.clone(), event::StreamRequestEnd {
-            since_request_open: Duration::from_millis(10),
+            request_open_at,
+            request_end_at,
         }));
 
         events.push(StreamResponseOpen(rsp.clone(), event::StreamResponseOpen {
-            since_request_open: Duration::from_millis(300),
+            request_open_at,
+            response_open_at,
         }));
         events.push(StreamResponseEnd(rsp.clone(), event::StreamResponseEnd {
             grpc_status: None,
-            since_request_open: Duration::from_millis(300),
-            since_response_open: Duration::from_millis(0),
+            request_open_at,
+            response_open_at,
+            response_end_at,
             bytes_sent: 0,
             frames_sent: 0,
         }));

--- a/proxy/controller-grpc/src/lib.rs
+++ b/proxy/controller-grpc/src/lib.rs
@@ -34,8 +34,12 @@ mod gen {
     }
 }
 
+pub fn pb_elapsed(t0: ::std::time::Instant, t1: ::std::time::Instant) -> ::prost_types::Duration {
+    pb_duration(t1 - t0)
+}
+
 /// Converts a Rust Duration to a Protobuf Duration.
-pub fn pb_duration(d: &::std::time::Duration) -> ::prost_types::Duration {
+pub fn pb_duration(d: ::std::time::Duration) -> ::prost_types::Duration {
     let seconds = if d.as_secs() > ::std::i64::MAX as u64 {
         ::std::i64::MAX
     } else {

--- a/proxy/src/control/pb.rs
+++ b/proxy/src/control/pb.rs
@@ -34,13 +34,15 @@ impl event::StreamResponseEnd {
             .map(Eos::from_grpc_status)
             ;
 
+        let since_request_open = self.response_end_at - self.request_open_at;
+        let since_response_open = self.response_end_at - self.response_open_at;
         let end = tap_event::http::ResponseEnd {
             id: Some(tap_event::http::StreamId {
                 base: 0, // TODO FIXME
                 stream: ctx.id as u64,
             }),
-            since_request_init: Some(pb_duration(&self.since_request_open)),
-            since_response_init: Some(pb_duration(&self.since_response_open)),
+            since_request_init: Some(pb_duration(&since_request_open)),
+            since_response_init: Some(pb_duration(&since_response_open)),
             response_bytes: self.bytes_sent,
             eos,
         };
@@ -66,13 +68,15 @@ impl event::StreamResponseFail {
     fn to_tap_event(&self, ctx: &Arc<ctx::http::Request>) -> common::TapEvent {
         use self::common::tap_event;
 
+        let since_request_open = self.response_fail_at - self.request_open_at;
+        let since_response_open = self.response_fail_at - self.response_open_at;
         let end = tap_event::http::ResponseEnd {
             id: Some(tap_event::http::StreamId {
                 base: 0, // TODO FIXME
                 stream: ctx.id as u64,
             }),
-            since_request_init: Some(pb_duration(&self.since_request_open)),
-            since_response_init: Some(pb_duration(&self.since_response_open)),
+            since_request_init: Some(pb_duration(&since_request_open)),
+            since_response_init: Some(pb_duration(&since_response_open)),
             response_bytes: self.bytes_sent,
             eos: Some(self.error.into()),
         };
@@ -98,12 +102,13 @@ impl event::StreamRequestFail {
     fn to_tap_event(&self, ctx: &Arc<ctx::http::Request>) -> common::TapEvent {
         use self::common::tap_event;
 
+        let since_request_open = self.request_fail_at - self.request_open_at;
         let end = tap_event::http::ResponseEnd {
             id: Some(tap_event::http::StreamId {
                 base: 0, // TODO FIXME
                 stream: ctx.id as u64,
             }),
-            since_request_init: Some(pb_duration(&self.since_request_open)),
+            since_request_init: Some(pb_duration(&since_request_open)),
             since_response_init: None,
             response_bytes: 0,
             eos: Some(self.error.into()),
@@ -166,13 +171,14 @@ impl<'a> TryFrom<&'a Event> for common::TapEvent {
             }
 
             Event::StreamResponseOpen(ref ctx, ref rsp) => {
+                let since_request_open = rsp.response_open_at - rsp.request_open_at;
                 let init = tap_event::http::ResponseInit {
                     id: Some(tap_event::http::StreamId {
                         base: 0,
                         // TODO FIXME
                         stream: ctx.request.id as u64,
                     }),
-                    since_request_init: Some(pb_duration(&rsp.since_request_open)),
+                    since_request_init: Some(pb_duration(&since_request_open)),
                     http_status: u32::from(ctx.status.as_u16()),
                 };
 

--- a/proxy/src/telemetry/event.rs
+++ b/proxy/src/telemetry/event.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use h2;
 
@@ -33,24 +33,28 @@ pub struct TransportClose {
 
 #[derive(Clone, Debug)]
 pub struct StreamRequestFail {
-    pub since_request_open: Duration,
+    pub request_open_at: Instant,
+    pub request_fail_at: Instant,
     pub error: h2::Reason,
 }
 
 #[derive(Clone, Debug)]
 pub struct StreamRequestEnd {
-    pub since_request_open: Duration,
+    pub request_open_at: Instant,
+    pub request_end_at: Instant,
 }
 
 #[derive(Clone, Debug)]
 pub struct StreamResponseOpen {
-    pub since_request_open: Duration,
+    pub request_open_at: Instant,
+    pub response_open_at: Instant,
 }
 
 #[derive(Clone, Debug)]
 pub struct StreamResponseFail {
-    pub since_request_open: Duration,
-    pub since_response_open: Duration,
+    pub request_open_at: Instant,
+    pub response_open_at: Instant,
+    pub response_fail_at: Instant,
     pub error: h2::Reason,
     pub bytes_sent: u64,
     pub frames_sent: u32,
@@ -58,9 +62,10 @@ pub struct StreamResponseFail {
 
 #[derive(Clone, Debug)]
 pub struct StreamResponseEnd {
+    pub request_open_at: Instant,
+    pub response_open_at: Instant,
+    pub response_end_at: Instant,
     pub grpc_status: Option<u32>,
-    pub since_request_open: Duration,
-    pub since_response_open: Duration,
     pub bytes_sent: u64,
     pub frames_sent: u32,
 }


### PR DESCRIPTION
Proxy tasks emit events to the telemetry system. These events are used
aggregate counts and latencies, as well as to inform Tap requests.
Initially, these events included durations, describing the relevant time
that elapsed between this event and another.

This approach is somewhat inflexible -- it unnecessarily constrains the
set of measurements that can computed in the telemetry system.

To remedy this, the `Event` types can be changed to report discrete
`Instant`s (rather than `Duration`s). Then, when latencies are computed
in the telemetry system, these discrete instants can be compared to
produce durations.

There are no functional changes in this PR.