### PR TITLE
Update web dockerfile to use dev deps when building prod assets

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -259,8 +259,7 @@ address of the public API server that's running in your docker environment:
 
 ```bash
 docker-compose stop web
-cd web
-../bin/go-run . --api-addr=$DOCKER_IP:8085
+bin/web run --api-addr=$DOCKER_IP:8085
 ```
 
 #### 3. Connect to `public-api` in Kubernetes
@@ -283,8 +282,7 @@ bin/web port-forward
 Then connect the local web process to the forwarded port:
 
 ```bash
-cd web
-../bin/go-run . --api-addr=localhost:8085
+bin/web run --api-addr=localhost:8085
 ```
 
 ### Webpack dev server

--- a/bin/web
+++ b/bin/web
@@ -24,7 +24,7 @@ USAGE
 }; function --help { -h ;}
 
 function dev {
-  setup
+  build
 
   while getopts "p:" opt; do
     case "$opt" in
@@ -36,7 +36,7 @@ function dev {
 
   cd $ROOT/web/app && yarn webpack-dev-server --port $DEV_PORT &
   cd $ROOT/web && \
-    ../bin/go-run . --webpack-dev-server=http://localhost:$DEV_PORT
+    ../bin/go-run . --webpack-dev-server=http://localhost:$DEV_PORT $*
 }
 
 function build {
@@ -58,7 +58,7 @@ function run {
   port-forward &
 
   cd $ROOT/web
-  ../bin/go-run .
+  ../bin/go-run . $*
 }
 
 function setup {
@@ -67,8 +67,6 @@ function setup {
 }
 
 function test {
-  setup
-
   cd $ROOT/web/app
   yarn karma start --single-run $*
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ RUN $ROOT/bin/web setup --pure-lockfile
 # set the env to production *after* yarn has done an install, to make sure all
 # libraries required for building are included.
 ENV NODE_ENV production
-RUN yarn webpack
+RUN $ROOT/bin/web build
 
 ## compile go server
 FROM gcr.io/runconduit/go-deps:69ba71ed as golang

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ RUN $ROOT/bin/web setup --pure-lockfile
 # set the env to production *after* yarn has done an install, to make sure all
 # libraries required for building are included.
 ENV NODE_ENV production
-RUN $ROOT/bin/web build
+RUN yarn webpack
 
 ## compile go server
 FROM gcr.io/runconduit/go-deps:69ba71ed as golang


### PR DESCRIPTION
This branch fixes a master branch CI failure that was introduced in #976. Specifically, the `bin/docker-build-web` script is failing due to docker not being able to find dev dependencies, such as "babel-loader", when running `NODE_ENV=production yarn webpack`.

The issue arises from these stages in the Dockerfile:

```
# node dependencies
RUN $ROOT/bin/web setup --pure-lockfile

# frontend assets
# set the env to production *after* yarn has done an install, to make sure all
# libraries required for building are included.
ENV NODE_ENV production
RUN $ROOT/bin/web build
```

Calling `web setup` the first time effectively runs `NODE_ENV=development yarn`, which installs the development dependencies that we need. Unfortunately, calling `web build` also calls `web setup`, and that causes us to re-run the setup with `NODE_ENV=production yarn`, which removes the development dependencies that were previously installed.

A different fix for this would be to modify `web build` to stop calling setup, and require that folks run the setup command explicitly, as needed. Since setup only really needs to be called when package.json changes, that would also speed up steady-state development. @grampelberg thoughts?