### PR TITLE
Fix the web docker build by running yarn outside of NODE_ENV=production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
         - export PATH="$HOME/.yarn/bin:$PATH"
       install:
-        - ./bin/web build
+        - ./bin/web
       script:
         - ./bin/web test --reporters dots
 

--- a/bin/web
+++ b/bin/web
@@ -40,8 +40,6 @@ function dev {
 }
 
 function build {
-  setup
-
   cd $ROOT/web/app
   yarn webpack
 }


### PR DESCRIPTION
As part of trying to be fancy, I moved the `setup` step into build. This breaks the docker builds because we need to run yarn *without* NODE_ENV=production and then the build *with* NODE_ENV=production (to do things like minify/compress assets).

Split apart build as something without setup and provide a default target that does setup + build for travis.