### PR TITLE
Fix nil pointer dereference in StatSummary

### DIFF
--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -57,6 +57,12 @@ type podCount struct {
 }
 
 func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest) (*pb.StatSummaryResponse, error) {
+
+	// check for well-formed request
+	if req.GetSelector().GetResource() == nil {
+		return statSummaryError(req, "StatSummary request missing Selector Resource"), nil
+	}
+
 	// special case to check for services as outbound only
 	if isInvalidServiceRequest(req) {
 		return statSummaryError(req, "service only supported as a target on 'from' queries, or as a destination on 'to' queries"), nil
@@ -117,7 +123,7 @@ func statSummaryError(req *pb.StatSummaryRequest, message string) *pb.StatSummar
 	return &pb.StatSummaryResponse{
 		Response: &pb.StatSummaryResponse_Error{
 			Error: &pb.ResourceError{
-				Resource: req.Selector.Resource,
+				Resource: req.GetSelector().GetResource(),
 				Error:    message,
 			},
 		},

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -551,6 +551,9 @@ status:
 
 		invalidRequests := []statSumExpected{
 			statSumExpected{
+				req: pb.StatSummaryRequest{},
+			},
+			statSumExpected{
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{


### PR DESCRIPTION
The StatSummary endpoint was dereferencing
StatSummaryRequest.Selector.Resource, causing a panic when it received
an empty request.

Fix StatSummary to use the nil-friendly
StatSummaryRequest.GetSelector().GetResource() methods, and add a test
to validate.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>