### PR TITLE
Introduce meshed label in simulate-proxy

### DIFF
--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -370,12 +370,19 @@ func newSimulatedProxy(
 		// "replica_set",
 	}
 
+	// make 50% of requests meshed
+	meshed := "false"
+	if rand.Int31n(2) > 0 {
+		meshed = "true"
+	}
+
 	constLabels := prom.Labels{
 		"authority":         "fakeauthority:123",
 		"namespace":         pod.GetNamespace(),
 		"deployment":        deploy.Name,
 		"pod_template_hash": pod.GetLabels()["pod-template-hash"],
 		"pod":               pod.GetName(),
+		"meshed":            meshed,
 
 		// TODO: support other k8s objects
 		// "daemon_set",

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -34,6 +34,9 @@ Each of these metrics has the following labels:
                header of the request.
 * `direction`: `inbound` if the request originated from outside of the pod,
                `outbound` if the request originated from inside of the pod.
+* `meshed`: `false` if the request's source and destination were not in the
+                    mesh,
+            `true` if the request's source and destination were in the mesh.
 
 ### Response Labels
 
@@ -150,17 +153,17 @@ A gauge of the number of transport connections currently open.
 
 ### `tcp_write_bytes_total`
 
-A counter of the total number of sent bytes. This is updated when the 
+A counter of the total number of sent bytes. This is updated when the
 connection closes.
 
 ### `tcp_read_bytes_total`
 
-A counter of the total number of recieved bytes. This is updated when the 
+A counter of the total number of recieved bytes. This is updated when the
 connection closes.
 
 ### `tcp_connection_duration_ms`
 
-A histogram of the duration of the lifetime of a connection, in milliseconds. 
+A histogram of the duration of the lifetime of a connection, in milliseconds.
 This is updated when the connection closes.
 
 ## Labels


### PR DESCRIPTION
The proxy does not yet support a `meshed` label.

In anticipation of a `meshed` label in the proxy, introduce this label
in `simulate-proxy`, for testing.

Relates to #306 and #386.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![screen shot 2018-05-23 at 2 59 29 pm](https://user-images.githubusercontent.com/236915/40453403-eaecf33e-5e99-11e8-8a9a-f79e8207521e.png)
