### PR TITLE
Add propType validation

### DIFF
--- a/web/app/.eslintrc
+++ b/web/app/.eslintrc
@@ -43,7 +43,6 @@
     "react/no-did-update-set-state": 1,
     "react/no-multi-comp": [1, { "ignoreStateless": true }],
     "react/prefer-es6-class": 1,
-    "react/prop-types": 0, // TODO: enable prop type validation
     "react/self-closing-comp": 1,
     "react/sort-comp": 1,
     "react/sort-prop-types": 1,

--- a/web/app/js/components/CallToAction.jsx
+++ b/web/app/js/components/CallToAction.jsx
@@ -1,43 +1,49 @@
 import _ from 'lodash';
 import { incompleteMeshMessage } from './util/CopyUtils.jsx';
+import PropTypes from 'prop-types';
 import React from 'react';
 import './../../css/cta.css';
 
-export default class CallToAction extends React.Component {
-  render() {
-    let resource = this.props.resource || "resource";
+const CallToAction = ({resource, numResources}) => (
+  <div className="call-to-action">
+    <div className="action summary">The service mesh was successfully installed!</div>
 
-    return (
-      <div className="call-to-action">
-        <div className="action summary">The service mesh was successfully installed!</div>
-
-        <div className="action-steps">
-          <div className="step-container complete">
-            <div className="icon-container">
-              <i className="fa fa-check-circle" aria-hidden="true" />
-            </div>
-            <div className="message"><p>Controller successfully installed</p></div>
-          </div>
-
-          <div className="step-container complete">
-            <div className="icon-container">
-              <i className="fa fa-check-circle" aria-hidden="true" />
-            </div>
-            <div className="message">{_.isNil(this.props.numResources) ? "No" : this.props.numResources} {resource}s detected</div>
-          </div>
-
-          <div className="step-container incomplete">
-            <div className="icon-container">
-              <i className="fa fa-circle-o" aria-hidden="true" />
-            </div>
-            <div className="message">Connect your first {resource}</div>
-          </div>
+    <div className="action-steps">
+      <div className="step-container complete">
+        <div className="icon-container">
+          <i className="fa fa-check-circle" aria-hidden="true" />
         </div>
-
-        <div className="clearfix">
-          {incompleteMeshMessage()}
-        </div>
+        <div className="message"><p>Controller successfully installed</p></div>
       </div>
-    );
-  }
-}
+
+      <div className="step-container complete">
+        <div className="icon-container">
+          <i className="fa fa-check-circle" aria-hidden="true" />
+        </div>
+        <div className="message">{_.isNil(numResources) ? "No" : numResources} {resource}s detected</div>
+      </div>
+
+      <div className="step-container incomplete">
+        <div className="icon-container">
+          <i className="fa fa-circle-o" aria-hidden="true" />
+        </div>
+        <div className="message">Connect your first {resource}</div>
+      </div>
+    </div>
+
+    <div className="clearfix">
+      {incompleteMeshMessage()}
+    </div>
+  </div>
+);
+
+CallToAction.defaultProps = {
+  resource: 'resource',
+};
+
+CallToAction.propTypes = {
+  numResources: PropTypes.number,
+  resource: PropTypes.string,
+};
+
+export default CallToAction;

--- a/web/app/js/components/ErrorBanner.jsx
+++ b/web/app/js/components/ErrorBanner.jsx
@@ -1,10 +1,11 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Row } from 'antd';
 
 const defaultErrorMsg = "An error has occurred";
 
-export default class ErrorMessage extends React.Component {
+class ErrorMessage extends React.Component {
   constructor(props) {
     super(props);
     this.hideMessage = this.hideMessage.bind(this);
@@ -40,3 +41,9 @@ export default class ErrorMessage extends React.Component {
     );
   }
 }
+
+ErrorMessage.propTypes = {
+  message: PropTypes.string.isRequired,
+};
+
+export default ErrorMessage;

--- a/web/app/js/components/GrafanaLink.jsx
+++ b/web/app/js/components/GrafanaLink.jsx
@@ -1,17 +1,26 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class GrafanaLink extends React.Component {
-  render() {
-    let resourceVariableName = this.props.resource.toLowerCase().replace(" ", "_");
-    let dashboardName = this.props.resource.toLowerCase().replace(" ", "-");
+const GrafanaLink = ({ConduitLink, displayName, name, namespace, resource}) => {
+  let resourceVariableName = resource.toLowerCase().replace(" ", "_");
+  let dashboardName = resource.toLowerCase().replace(" ", "-");
 
-    return (
-      <this.props.conduitLink
-        to={`/dashboard/db/conduit-${dashboardName}?var-namespace=${this.props.namespace}&var-${resourceVariableName}=${this.props.name}`}
-        deployment={"grafana"}
-        targetBlank={true}>
-        {this.props.displayName || this.props.name}&nbsp;&nbsp;<i className="fa fa-external-link" />
-      </this.props.conduitLink>
-    );
-  }
-}
+  return (
+    <ConduitLink
+      to={`/dashboard/db/conduit-${dashboardName}?var-namespace=${namespace}&var-${resourceVariableName}=${name}`}
+      deployment={"grafana"}
+      targetBlank={true}>
+      {displayName || name}&nbsp;&nbsp;<i className="fa fa-external-link" />
+    </ConduitLink>
+  );
+};
+
+GrafanaLink.propTypes = {
+  ConduitLink: PropTypes.func.isRequired,
+  displayName: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  namespace: PropTypes.string.isRequired,
+  resource: PropTypes.string.isRequired,
+};
+
+export default GrafanaLink;

--- a/web/app/js/components/Metric.jsx
+++ b/web/app/js/components/Metric.jsx
@@ -1,12 +1,17 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
-export default class Metric extends React.Component {
-  render() {
-    return (
-      <div className={`metric ${this.props.className || ""}`}>
-        <div className="metric-title">{this.props.title}</div>
-        <div className="metric-value">{this.props.value}</div>
-      </div>
-    );
-  }
-}
+const Metric = ({className, title, value}) => (
+  <div className={`metric ${className || ""}`}>
+    <div className="metric-title">{title}</div>
+    <div className="metric-value">{value}</div>
+  </div>
+);
+
+Metric.propTypes = {
+  className: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+export default Metric;

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -68,7 +68,7 @@ const columnDefinitions = (sortable = true, resource, namespaces, onFilterClick,
               name={row.name}
               namespace={row.namespace}
               resource={resource}
-              conduitLink={ConduitLink} />
+              ConduitLink={ConduitLink} />
           );
         }
       }

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -5,11 +5,12 @@ import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
 import { processMultiResourceRollup } from './util/MetricUtils.js';
+import PropTypes from 'prop-types';
 import React from 'react';
 import './../../css/list.css';
 import 'whatwg-fetch';
 
-export default class Namespaces extends React.Component {
+class Namespaces extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
@@ -111,6 +112,29 @@ export default class Namespaces extends React.Component {
             {this.renderResourceSection("Pod", this.state.metrics.pods)}
           </div>
         }
-      </div>);
+      </div>
+    );
   }
 }
+
+Namespaces.defaultProps = {
+  params: {
+    namespace: 'default',
+  },
+};
+
+Namespaces.propTypes = {
+  api: PropTypes.shape({
+    cancelCurrentRequests: PropTypes.func.isRequired,
+    fetchMetrics: PropTypes.func.isRequired,
+    getCurrentPromises: PropTypes.func.isRequired,
+    setCurrentRequests: PropTypes.func.isRequired,
+    urlsForResource: PropTypes.object.isRequired, // TODO: generate a shape for this.
+  }).isRequired,
+  controllerNamespace: PropTypes.string.isRequired,
+  params: PropTypes.shape({
+    namespace: PropTypes.string,
+  }),
+};
+
+export default Namespaces;

--- a/web/app/js/components/PageHeader.jsx
+++ b/web/app/js/components/PageHeader.jsx
@@ -1,8 +1,9 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Radio, Row } from 'antd';
 
-export default class PageHeader extends React.Component {
+class PageHeader extends React.Component {
   constructor(props) {
     super(props);
     this.onTimeWindowClick = this.onTimeWindowClick.bind(this);
@@ -20,38 +21,59 @@ export default class PageHeader extends React.Component {
   // don't use time window changing until the results of Telemetry Scalability are in
   // https://github.com/runconduit/conduit/milestone/4
   renderMetricWindowButtons() {
-    if (this.props.hideButtons) {
-      return null;
-    } else {
-      return (<Col span={6}>
+    if (this.props.hideButtons) return null;
+
+    const buttons = _.map(this.props.api.getValidMetricsWindows(), (w, i) => {
+      return <Radio.Button key={`metrics-window-btn-${i}`} value={w}>{w}</Radio.Button>;
+    });
+
+    return (
+      <Col span={6}>
         <Radio.Group
           className="time-window-btns"
           value={this.state.selectedWindow}
           onChange={this.onTimeWindowClick} >
-          {
-            _.map(this.props.api.getValidMetricsWindows(), (w, i) => {
-              return <Radio.Button key={`metrics-window-btn-${i}`} value={w}>{w}</Radio.Button>;
-            })
-          }
+          {buttons}
         </Radio.Group>
-      </Col>);
-    }
+      </Col>
+    );
   }
 
   render() {
+    const {header, subHeader, subHeaderTitle, subMessage} = this.props;
+
     return (
       <div className="page-header">
         <Row>
           <Col span={18}>
-            {!this.props.header ? null : <h1>{this.props.header}</h1>}
-            {!this.props.subHeaderTitle ? null : <div className="subsection-header">{this.props.subHeaderTitle}</div>}
-            {!this.props.subHeader ? null : <h1>{this.props.subHeader}</h1>}
+            {!header ? null : <h1>{header}</h1>}
+            {!subHeaderTitle ? null : <div className="subsection-header">{subHeaderTitle}</div>}
+            {!subHeader ? null : <h1>{subHeader}</h1>}
           </Col>
           {/* {this.renderMetricWindowButtons()} */}
         </Row>
 
-        {!this.props.subMessage ? null : <div>{this.props.subMessage}</div>}
+        {!subMessage ? null : <div>{subMessage}</div>}
       </div>
     );
   }
 }
+
+PageHeader.defaultProps = {
+  hideButtons: false,
+};
+
+PageHeader.propTypes = {
+  api: PropTypes.shape({
+    getMetricsWindow: PropTypes.func.isRequired,
+    getValidMetricsWindows: PropTypes.func.isRequired,
+    setMetricsWindow: PropTypes.func.isRequired,
+  }).isRequired,
+  header: PropTypes.string.isRequired,
+  hideButtons: PropTypes.bool,
+  subHeader: PropTypes.string,
+  subHeaderTitle: PropTypes.string,
+  subMessage: PropTypes.string,
+};
+
+export default PageHeader;

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -5,11 +5,12 @@ import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
 import { processSingleResourceRollup } from './util/MetricUtils.js';
+import PropTypes from 'prop-types';
 import React from 'react';
 import './../../css/list.css';
 import 'whatwg-fetch';
 
-export default class ResourceList extends React.Component {
+class ResourceList extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
@@ -117,3 +118,17 @@ export default class ResourceList extends React.Component {
       </div>);
   }
 }
+
+ResourceList.propTypes = {
+  api: PropTypes.shape({
+    cancelCurrentRequests: PropTypes.func.isRequired,
+    fetchMetrics: PropTypes.func.isRequired,
+    getCurrentPromises: PropTypes.func.isRequired,
+    setCurrentRequests: PropTypes.func.isRequired,
+    urlsForResource: PropTypes.func.isRequired,
+  }).isRequired,
+  controllerNamespace: PropTypes.string.isRequired,
+  resource: PropTypes.string.isRequired,
+};
+
+export default ResourceList;

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -7,6 +7,7 @@ import Metric from './Metric.jsx';
 import { numericSort } from './util/Utils.js';
 import PageHeader from './PageHeader.jsx';
 import Percentage from './util/Percentage.js';
+import PropTypes from 'prop-types';
 import React from 'react';
 import StatusTable from './StatusTable.jsx';
 import { Col, Row, Table, Tooltip } from 'antd';
@@ -98,7 +99,7 @@ const componentDeploys = {
   "web":          "web"
 };
 
-export default class ServiceMesh extends React.Component {
+class ServiceMesh extends React.Component {
   constructor(props) {
     super(props);
     this.loadFromServer = this.loadFromServer.bind(this);
@@ -335,3 +336,18 @@ export default class ServiceMesh extends React.Component {
     );
   }
 }
+
+ServiceMesh.propTypes = {
+  api: PropTypes.shape({
+    cancelCurrentRequests: PropTypes.func.isRequired,
+    ConduitLink: PropTypes.func.isRequired,
+    fetchMetrics: PropTypes.func.isRequired,
+    getCurrentPromises: PropTypes.func.isRequired,
+    setCurrentRequests: PropTypes.func.isRequired,
+    urlsForResource: PropTypes.func.isRequired,
+  }).isRequired,
+  controllerNamespace: PropTypes.string.isRequired,
+  releaseVersion: PropTypes.string.isRequired,
+};
+
+export default ServiceMesh;

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -2,14 +2,16 @@ import { ApiHelpers } from './util/ApiHelpers.jsx';
 import { Layout } from 'antd';
 import { Link } from 'react-router-dom';
 import logo from './../../img/logo_only.png';
+import PropTypes from 'prop-types';
 import React from 'react';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import SocialLinks from './SocialLinks.jsx';
 import Version from './Version.jsx';
 import wordLogo from './../../img/reversed_logo.png';
 import { Icon, Menu } from 'antd';
 import './../../css/sidebar.css';
 
-export default class Sidebar extends React.Component {
+class Sidebar extends React.Component {
   constructor(props) {
     super(props);
     this.api= this.props.api;
@@ -21,7 +23,7 @@ export default class Sidebar extends React.Component {
       initialCollapse: true,
       collapsed: true,
       error: null,
-      latest: null,
+      latestVersion: '',
       isLatest: true,
       pendingRequests: false
     };
@@ -156,7 +158,7 @@ export default class Sidebar extends React.Component {
               <SocialLinks />
               <Version
                 isLatest={this.state.isLatest}
-                latest={this.state.latestVersion}
+                latestVersion={this.state.latestVersion}
                 releaseVersion={this.props.releaseVersion}
                 error={this.state.error}
                 uuid={this.props.uuid} />
@@ -167,3 +169,15 @@ export default class Sidebar extends React.Component {
     );
   }
 }
+
+Sidebar.propTypes = {
+  api: PropTypes.shape({
+    ConduitLink: PropTypes.func.isRequired,
+  }).isRequired,
+  location: ReactRouterPropTypes.location.isRequired,
+  pathPrefix: PropTypes.string.isRequired,
+  releaseVersion: PropTypes.string.isRequired,
+  uuid: PropTypes.string.isRequired,
+};
+
+export default Sidebar;

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Table, Tooltip } from 'antd';
 
@@ -38,6 +39,15 @@ const StatusDot = ({status, multilineDots, columnName}) => (
   </Tooltip>
 );
 
+StatusDot.propTypes = {
+  columnName: PropTypes.string.isRequired,
+  multilineDots: PropTypes.bool.isRequired,
+  status: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
 const columns = {
   resourceName: {
     title: "Deployment",
@@ -68,7 +78,7 @@ const columns = {
   }
 };
 
-export default class StatusTable extends React.Component {
+class StatusTable extends React.Component {
   getTableData() {
     let tableData = _.map(this.props.data, datum => {
       return {
@@ -98,3 +108,14 @@ export default class StatusTable extends React.Component {
       size="middle" />);
   }
 }
+
+StatusTable.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    pods: PropTypes.arrayOf(PropTypes.object).isRequired, // TODO: What's the real shape here.
+    added: PropTypes.bool,
+  })).isRequired,
+  statusColumnTitle: PropTypes.string.isRequired,
+};
+
+export default StatusTable;

--- a/web/app/js/components/Version.jsx
+++ b/web/app/js/components/Version.jsx
@@ -1,22 +1,32 @@
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import React from 'react';
 import './../../css/version.css';
 
-export default class Version extends React.Component {
-  renderVersionCheck() {
-    if (!this.props.latest) {
+class Version extends React.Component {
+  renderVersionCheck = () => {
+    const {latestVersion, error, isLatest} = this.props;
+
+    if (!latestVersion) {
       return (<div>
         Version check failed
-        {this.props.error ? ": "+this.props.error : null}
-      </div>);
-    } else if (this.props.isLatest) {
-      return "Conduit is up to date";
-    } else {
-      return (<div>
-        A new version ({this.props.latest}) is available<br />
-        <Link to="https://versioncheck.conduit.io/update" className="button primary" target="_blank">Update Now</Link>
+        {error ? `: ${this.props.error}` : ''}
       </div>);
     }
+
+    if (isLatest) return "Conduit is up to date";
+
+    return (
+      <div>
+        A new version ({latestVersion}) is available<br />
+        <Link
+          to="https://versioncheck.conduit.io/update"
+          className="button primary"
+          target="_blank">
+          Update Now
+        </Link>
+      </div>
+    );
   }
 
   render() {
@@ -29,3 +39,16 @@ export default class Version extends React.Component {
   }
 
 }
+
+Version.defaultProps = {
+  latestVersion: '',
+};
+
+Version.propTypes = {
+  error: PropTypes.instanceOf(Error),
+  isLatest: PropTypes.bool.isRequired,
+  latestVersion: PropTypes.string,
+  releaseVersion: PropTypes.string.isRequired,
+};
+
+export default Version;

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -107,7 +107,7 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   class ConduitLink extends React.Component {
     render() {
       let prefix = pathPrefix;
-      if (this.props.deployment) {
+      if (!_.isEmpty(this.props.deployment)) {
         prefix = prefix.replace("/web:", "/"+this.props.deployment+":");
       }
       let url = `${prefix}${this.props.to}`;
@@ -121,13 +121,17 @@ export const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
       );
     }
   }
+
   ConduitLink.propTypes = {
+    children: PropTypes.node.isRequired,
     deployment: PropTypes.string,
     targetBlank: PropTypes.bool,
-    to: PropTypes.string,
+    to: PropTypes.string.isRequired,
   };
+
   ConduitLink.defaultProps = {
-    targetBlank: false
+    deployment: '',
+    targetBlank: false,
   };
 
   return {

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -22,6 +22,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
+    "react-router-prop-types": "^1.0.3",
     "react-test-renderer": "15.6.1",
     "sinon": "^4.1.2",
     "sinon-chai": "^2.14.0",

--- a/web/app/test/GrafanaLinkTest.jsx
+++ b/web/app/test/GrafanaLinkTest.jsx
@@ -18,7 +18,7 @@ describe('GrafanaLink', () => {
       resource: "Replication Controller",
       name: "aldksf-3409823049823",
       namespace: "myns",
-      conduitLink: api.ConduitLink
+      ConduitLink: api.ConduitLink
     };
     let component = mount(routerWrap(GrafanaLink, linkProps));
 

--- a/web/app/test/VersionTest.jsx
+++ b/web/app/test/VersionTest.jsx
@@ -12,6 +12,13 @@ import sinonStubPromise from 'sinon-stub-promise';
 Enzyme.configure({ adapter: new Adapter() });
 sinonStubPromise(sinon);
 
+const loc = {
+  pathname: '',
+  hash: '',
+  pathPrefix: '',
+  search: '',
+};
+
 describe('Version', () => {
   let curVer = "v1.2.3";
   let newVer = "v2.3.4";
@@ -46,9 +53,10 @@ describe('Version', () => {
     component = mount(
       <BrowserRouter>
         <Sidebar
-          location={{ pathname: ""}}
+          location={loc}
           api={apiHelpers}
           releaseVersion={curVer}
+          pathPrefix=""
           uuid="fakeuuid" />
       </BrowserRouter>
     );
@@ -69,9 +77,10 @@ describe('Version', () => {
     component = mount(
       <BrowserRouter>
         <Sidebar
-          location={{ pathname: ""}}
+          location={loc}
           api={apiHelpers}
           releaseVersion={curVer}
+          pathPrefix=""
           uuid="fakeuuid" />
       </BrowserRouter>
     );
@@ -92,9 +101,10 @@ describe('Version', () => {
     component = mount(
       <BrowserRouter>
         <Sidebar
-          location={{ pathname: ""}}
+          location={loc}
           api={apiHelpers}
           releaseVersion={curVer}
+          pathPrefix=""
           uuid="fakeuuid" />
       </BrowserRouter>
     );
@@ -119,8 +129,11 @@ describe('Version', () => {
     component = mount(
       <BrowserRouter>
         <Sidebar
-          location={{ pathname: ""}}
-          api={apiHelpers} />
+          location={loc}
+          api={apiHelpers}
+          releaseVersion={curVer}
+          pathPrefix=""
+          uuid="fakeuuid" />
       </BrowserRouter>
     );
 

--- a/web/app/test/testHelpers.jsx
+++ b/web/app/test/testHelpers.jsx
@@ -4,7 +4,11 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Route, Router } from 'react-router';
 
-const componentDefaultProps = { api: ApiHelpers("") };
+const componentDefaultProps = {
+  api: ApiHelpers(""),
+  controllerNamespace: 'conduit',
+  releaseVersion: '',
+};
 
 export function routerWrap(Component, extraProps={}, route="/", currentLoc="/") {
   const createElement = (ComponentToWrap, props) => <ComponentToWrap {...(_.merge({}, componentDefaultProps, props, extraProps))} />;

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -78,6 +78,10 @@
   version "8.0.58"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.58.tgz#5b3881c0be3a646874803fee3197ea7f1ed6df90"
 
+"@types/prop-types@^15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -5662,7 +5666,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -6173,6 +6177,13 @@ react-router-dom@^4.2.2:
     prop-types "^15.5.4"
     react-router "^4.2.0"
     warning "^3.0.0"
+
+react-router-prop-types@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-router-prop-types/-/react-router-prop-types-1.0.3.tgz#82fde339ba97d75fd7d1e9f14efdb72b506a82e2"
+  dependencies:
+    "@types/prop-types" "^15.5.2"
+    prop-types "^15.6.1"
 
 react-router@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
When refactoring components, it is hard to know what is required and isn't.

Adds propTypes to the existing components and enables eslint errors for anything moving forward. This should keep us documenting the API for components.