### PR TITLE
proxy: Fix h1 body implementation

### DIFF
--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -8,7 +8,7 @@ use futures::{future, Async, Future, Poll, Stream};
 use futures::future::Either;
 use h2;
 use http;
-use hyper;
+use hyper::{self, body::Payload};
 use hyper::client::connect as hyper_connect;
 use tokio_connect::Connect;
 use tower_service::{Service, NewService};
@@ -79,7 +79,7 @@ impl tower_h2::Body for HttpBody {
 
     fn is_end_stream(&self) -> bool {
         match *self {
-            HttpBody::Http1(ref b) => b.is_empty(),
+            HttpBody::Http1(ref b) => b.is_end_stream(),
             HttpBody::Http2(ref b) => b.is_end_stream(),
         }
     }


### PR DESCRIPTION
In the h1-h2 glue code, we incorrectly called `is_empty()` to determine
if an H1 stream had ended. `is_empty` only returns true if there was no
body at all (rather than if the body has been fully consumed). This
causes H1 streams with bodies to be recorded incorrectly for telemetry.

By changing this to call `hyper::body::Payload::is_end_stream`, h1
bodies now behave the same as h2 bodies.

Fixes #994