### PR TITLE
Add a secured label to the CLI tap responses

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -242,7 +242,16 @@ func writeTapEventsToBuffer(tapClient pb.Api_TapByResourceClient, w *tabwriter.W
 
 func renderTapEvent(event *common.TapEvent) string {
 	dst := util.AddressToString(event.GetDestination())
-	dstPod := event.GetDestinationMeta().GetLabels()["pod"]
+	dstLabels := event.GetDestinationMeta().GetLabels()
+	dstPod := dstLabels["pod"]
+	isSecured := "no"
+	controllerNs := dstLabels["conduit_io_control_plane_ns"]
+	controllerDstNs := dstLabels["dst_conduit_io_control_plane_ns"]
+
+	if controllerNs != "" && controllerNs == controllerDstNs {
+		isSecured = "yes"
+	}
+
 	if dstPod != "" {
 		dst = dstPod
 	}
@@ -256,43 +265,47 @@ func renderTapEvent(event *common.TapEvent) string {
 	httpEvent := http.Event
 	switch ev := httpEvent.(type) {
 	case *common.TapEvent_Http_RequestInit_:
-		return fmt.Sprintf("req id=%d:%d %s :method=%s :authority=%s :path=%s",
+		return fmt.Sprintf("req id=%d:%d %s :method=%s :authority=%s :path=%s secured=%s",
 			ev.RequestInit.Id.Base,
 			ev.RequestInit.Id.Stream,
 			flow,
 			ev.RequestInit.Method.GetRegistered().String(),
 			ev.RequestInit.Authority,
 			ev.RequestInit.Path,
+			isSecured,
 		)
 	case *common.TapEvent_Http_ResponseInit_:
-		return fmt.Sprintf("rsp id=%d:%d %s :status=%d latency=%dµs",
+		return fmt.Sprintf("rsp id=%d:%d %s :status=%d latency=%dµs secured=%s",
 			ev.ResponseInit.Id.Base,
 			ev.ResponseInit.Id.Stream,
 			flow,
 			ev.ResponseInit.GetHttpStatus(),
 			ev.ResponseInit.GetSinceRequestInit().Nanos/1000,
+			isSecured,
 		)
 	case *common.TapEvent_Http_ResponseEnd_:
 
 		if ev.ResponseEnd.Eos != nil {
 			switch eos := ev.ResponseEnd.Eos.End.(type) {
 			case *common.Eos_GrpcStatusCode:
-				return fmt.Sprintf("end id=%d:%d %s grpc-status=%s duration=%dµs response-length=%dB",
+				return fmt.Sprintf("end id=%d:%d %s grpc-status=%s duration=%dµs response-length=%dB secured=%s",
 					ev.ResponseEnd.Id.Base,
 					ev.ResponseEnd.Id.Stream,
 					flow,
 					codes.Code(eos.GrpcStatusCode),
 					ev.ResponseEnd.GetSinceResponseInit().Nanos/1000,
 					ev.ResponseEnd.GetResponseBytes(),
+					isSecured,
 				)
 			case *common.Eos_ResetErrorCode:
-				return fmt.Sprintf("end id=%d:%d %s reset-error=%+v duration=%dµs response-length=%dB",
+				return fmt.Sprintf("end id=%d:%d %s reset-error=%+v duration=%dµs response-length=%dB secured=%s",
 					ev.ResponseEnd.Id.Base,
 					ev.ResponseEnd.Id.Stream,
 					flow,
 					eos.ResetErrorCode,
 					ev.ResponseEnd.GetSinceResponseInit().Nanos/1000,
 					ev.ResponseEnd.GetResponseBytes(),
+					isSecured,
 				)
 			}
 		}
@@ -300,12 +313,13 @@ func renderTapEvent(event *common.TapEvent) string {
 		// this catchall handles 2 cases:
 		// 1) ev.ResponseEnd.Eos == nil
 		// 2) ev.ResponseEnd.Eos.End == nil
-		return fmt.Sprintf("end id=%d:%d %s duration=%dµs response-length=%dB",
+		return fmt.Sprintf("end id=%d:%d %s duration=%dµs response-length=%dB secured=%s",
 			ev.ResponseEnd.Id.Base,
 			ev.ResponseEnd.Id.Stream,
 			flow,
 			ev.ResponseEnd.GetSinceResponseInit().Nanos/1000,
 			ev.ResponseEnd.GetResponseBytes(),
+			isSecured,
 		)
 
 	default:

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -245,10 +245,9 @@ func renderTapEvent(event *common.TapEvent) string {
 	dstLabels := event.GetDestinationMeta().GetLabels()
 	dstPod := dstLabels["pod"]
 	isSecured := "no"
-	controllerNs := dstLabels["conduit_io_control_plane_ns"]
-	controllerDstNs := dstLabels["dst_conduit_io_control_plane_ns"]
 
-	if controllerNs != "" && controllerNs == controllerDstNs {
+	if dstLabels["meshed"] == "true" {
+		// assumption: meshed traffic is secured by default
 		isSecured = "yes"
 	}
 

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -46,7 +46,11 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 					},
 				},
 			},
-			map[string]string{"pod": "my-pod"},
+			map[string]string{
+				"pod": "my-pod",
+				"conduit_io_control_plane_ns":     "my-con",
+				"dst_conduit_io_control_plane_ns": "my-con",
+			},
 		)
 		event2 := createEvent(
 			&common.TapEvent_Http{
@@ -213,7 +217,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "req id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello"
+		expectedOutput := "req id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello secured=no"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
@@ -230,7 +234,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "rsp id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 :status=200 latency=999µs"
+		expectedOutput := "rsp id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 :status=200 latency=999µs secured=no"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
@@ -251,7 +255,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 grpc-status=OK duration=888µs response-length=111B"
+		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 grpc-status=OK duration=888µs response-length=111B secured=no"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
@@ -272,7 +276,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 reset-error=123 duration=888µs response-length=111B"
+		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 reset-error=123 duration=888µs response-length=111B secured=no"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
@@ -291,7 +295,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 duration=888µs response-length=111B"
+		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 duration=888µs response-length=111B secured=no"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
@@ -309,7 +313,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 duration=888µs response-length=111B"
+		expectedOutput := "end id=7:8 src=1.2.3.4:5555 dst=2.3.4.5:6666 duration=888µs response-length=111B secured=no"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -47,9 +47,8 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 				},
 			},
 			map[string]string{
-				"pod": "my-pod",
-				"conduit_io_control_plane_ns":     "my-con",
-				"dst_conduit_io_control_plane_ns": "my-con",
+				"pod":    "my-pod",
+				"meshed": "true",
 			},
 		)
 		event2 := createEvent(

--- a/cli/cmd/testdata/tap_busy_output.golden
+++ b/cli/cmd/testdata/tap_busy_output.golden
@@ -1,2 +1,2 @@
-req id=1:0 src=0.0.0.1:0 dst=my-pod :method=GET :authority=localhost :path=/some/path
-end id=1:0 src=0.0.0.1:0 dst=0.0.0.9:0 grpc-status=Code(666) duration=0µs response-length=1337B
+req id=1:0 src=0.0.0.1:0 dst=my-pod :method=GET :authority=localhost :path=/some/path secured=yes
+end id=1:0 src=0.0.0.1:0 dst=0.0.0.9:0 grpc-status=Code(666) duration=0µs response-length=1337B secured=no


### PR DESCRIPTION
Adds `secured=yes/no` to the `conduit tap` responses. This uses the `conduit_io_control_plane_ns` labels added in #960, but could be changed to use a `meshed` label being returned by the proxy.


```
$ go run cli/main.go tap deploy/web -n emojivoto --kubeconfig ~/.kube/config
req id=0:2150 src=10.1.0.31:36828 dst=10.1.0.29:80 :method=GET :authority=web-svc.emojivoto:80 :path=/api/list secured=no
req id=0:2151 src=10.1.0.29:51590 dst=emoji-7649584cd-cllzj :method=POST :authority=emoji-svc.emojivoto:8080 :path=/emojivoto.v1.EmojiService/ListAll secured=no
rsp id=0:2151 src=10.1.0.29:51590 dst=emoji-7649584cd-cllzj :status=200 latency=1457µs secured=no
end id=0:2151 src=10.1.0.29:51590 dst=emoji-7649584cd-cllzj grpc-status=OK duration=171µs response-length=2161B secured=no
rsp id=0:2150 src=10.1.0.31:36828 dst=10.1.0.29:80 :status=200 latency=5006µs secured=no
req id=0:2222 src=10.1.0.31:37596 dst=10.1.0.30:80 :method=GET :authority=web-svc.emojivoto:80 :path=/api/vote secured=no
req id=0:2223 src=10.1.0.30:45812 dst=emoji-7649584cd-cllzj :method=POST :authority=emoji-svc.emojivoto:8080 :path=/emojivoto.v1.EmojiService/FindByShortcode secured=no
rsp id=0:2223 src=10.1.0.30:45812 dst=emoji-7649584cd-cllzj :status=200 latency=2154µs secured=no
end id=0:2223 src=10.1.0.30:45812 dst=emoji-7649584cd-cllzj grpc-status=OK duration=266µs response-length=21B secured=no
req id=0:2224 src=10.1.0.30:50536 dst=voting-747789c9f6-qtwq5 :method=POST :authority=voting-svc.emojivoto:8080 :path=/emojivoto.v1.VotingService/VotePoop secured=no
rsp id=0:2224 src=10.1.0.30:50536 dst=voting-747789c9f6-qtwq5 :status=200 latency=1936µs secured=no
```