### PR TITLE
proxy: Require that HTTP bodies implement Debug

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -50,6 +50,7 @@ pub struct BoundService<B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
+    B: ::std::fmt::Debug,
 {
     bind: Bind<Arc<ctx::Proxy>, B>,
     binding: Binding<B>,
@@ -72,6 +73,7 @@ pub enum Binding<B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
+    B: ::std::fmt::Debug,
 {
     Bound(Stack<B>),
     BindsPerRequest {
@@ -202,6 +204,7 @@ impl<B> Bind<Arc<ctx::Proxy>, B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
+    B: ::std::fmt::Debug,
 {
     fn bind_stack(&self, ep: &Endpoint, protocol: &Protocol) -> Stack<B> {
         debug!("bind_stack endpoint={:?}, protocol={:?}", ep, protocol);
@@ -274,6 +277,7 @@ impl<B> control::destination::Bind for BindProtocol<Arc<ctx::Proxy>, B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
+    B: ::std::fmt::Debug,
 {
     type Endpoint = Endpoint;
     type Request = http::Request<B>;
@@ -309,6 +313,7 @@ where
     >,
     NormalizeUri<S::Service>: tower::Service,
     B: tower_h2::Body,
+    B: ::std::fmt::Debug,
 {
     type Request = <Self::Service as tower::Service>::Request;
     type Response = <Self::Service as tower::Service>::Response;
@@ -339,6 +344,7 @@ where
         Response=HttpResponse,
     >,
     B: tower_h2::Body,
+    B: ::std::fmt::Debug,
 {
     type Request = S::Request;
     type Response = HttpResponse;
@@ -365,6 +371,7 @@ where
 impl<B> tower::Service for BoundService<B>
 where
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Request = <Stack<B> as tower::Service>::Request;

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -47,6 +47,7 @@ where
 impl<B> Recognize for Inbound<B>
 where
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Request = http::Request<B>;

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -345,6 +345,7 @@ fn serve<R, B, E, F, G>(
 where
     B: tower_h2::Body + Default + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
+    B: ::std::fmt::Debug,
     E: Error + Send + 'static,
     F: Error + Send + 'static,
     R: Recognize<

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -57,6 +57,7 @@ impl<B> Clone for Outbound<B>
 where
     B: tower_h2::Body + Send + 'static,
     B::Data: Send,
+    B: ::std::fmt::Debug,
 {
     fn clone(&self) -> Self {
         Self {
@@ -70,6 +71,7 @@ where
 impl<B> Recognize for Outbound<B>
 where
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Request = http::Request<B>;
@@ -174,6 +176,7 @@ pub enum Discovery<B> {
 impl<B> Discover for Discovery<B>
 where
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Key = SocketAddr;

--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -78,7 +78,11 @@ pub type ResponseBody<B> = MeasuredBody<B, ResponseBodyInner>;
 pub type RequestBody<B> = MeasuredBody<B, RequestBodyInner>;
 
 #[derive(Debug)]
-pub struct MeasuredBody<B, I: BodySensor> {
+pub struct MeasuredBody<B, I: BodySensor>
+where
+    B: ::std::fmt::Debug,
+    I: ::std::fmt::Debug,
+{
     body: B,
     inner: Option<I>,
     _p: PhantomData<(B)>,
@@ -118,7 +122,9 @@ pub struct RequestBodyInner {
 impl<N, A, B> NewHttp<N, A, B>
 where
     A: Body + 'static,
+    A: ::std::fmt::Debug,
     B: Body + 'static,
+    B: ::std::fmt::Debug,
     N: NewService<
         Request = http::Request<RequestBody<A>>,
         Response = http::Response<B>,
@@ -145,7 +151,9 @@ where
 impl<N, A, B> NewService for NewHttp<N, A, B>
 where
     A: Body + 'static,
+    A: ::std::fmt::Debug,
     B: Body + 'static,
+    B: ::std::fmt::Debug,
     N: NewService<
         Request = http::Request<RequestBody<A>>,
         Response = http::Response<B>,
@@ -176,7 +184,9 @@ where
 impl<F, A, B> Future for Init<F, A, B>
 where
     A: Body + 'static,
+    A: ::std::fmt::Debug,
     B: Body + 'static,
+    B: ::std::fmt::Debug,
     F: Future,
     F::Item: Service<
         Request = http::Request<RequestBody<A>>,
@@ -204,7 +214,9 @@ where
 impl<S, A, B> Service for Http<S, A, B>
 where
     A: Body + 'static,
+    A: ::std::fmt::Debug,
     B: Body + 'static,
+    B: ::std::fmt::Debug,
     S: Service<
         Request = http::Request<RequestBody<A>>,
         Response = http::Response<B>,
@@ -292,6 +304,7 @@ impl<F, B> Future for Respond<F, B>
 where
     F: Future<Item = http::Response<B>, Error=client::Error>,
     B: Body + 'static,
+    B: ::std::fmt::Debug,
 {
     type Item = http::Response<ResponseBody<B>>;
     type Error = F::Error;
@@ -395,7 +408,11 @@ where
 
 // === MeasuredBody ===
 
-impl<B, I: BodySensor> MeasuredBody<B, I> {
+impl<B, I: BodySensor> MeasuredBody<B, I>
+where
+    B: ::std::fmt::Debug,
+    I: ::std::fmt::Debug,
+{
     pub fn new(body: B, inner: Option<I>) -> Self {
         Self {
             body,
@@ -430,7 +447,9 @@ impl<B, I: BodySensor> MeasuredBody<B, I> {
 impl<B, I> Body for MeasuredBody<B, I>
 where
     B: Body + 'static,
+    B: ::std::fmt::Debug,
     I: BodySensor,
+    I: ::std::fmt::Debug,
 {
     /// The body chunk type
     type Data = <B::Data as IntoBuf>::Buf;
@@ -482,7 +501,9 @@ where
 impl<B, I> Default for MeasuredBody<B, I>
 where
     B: Default,
+    B: ::std::fmt::Debug,
     I: BodySensor,
+    I: ::std::fmt::Debug,
 {
     fn default() -> Self {
         Self {
@@ -496,7 +517,9 @@ where
 impl<B, I> Stream for MeasuredBody<B, I>
 where
     B: Stream,
+    B: ::std::fmt::Debug,
     I: BodySensor,
+    I: ::std::fmt::Debug,
 {
     type Item = B::Item;
     type Error = B::Error;
@@ -557,7 +580,7 @@ impl BodySensor for ResponseBodyInner {
             bytes_sent,
             frames_sent,
         } = self;
-        let response_end_at =  Instant::now();
+        let response_end_at = Instant::now();
 
         handle.send(||
             event::Event::StreamResponseEnd(

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -83,7 +83,9 @@ impl Sensors {
     ) -> NewHttp<N, A, B>
     where
         A: Body + 'static,
+        A: ::std::fmt::Debug,
         B: Body + 'static,
+        B: ::std::fmt::Debug,
         N: NewService<
             Request = Request<http::RequestBody<A>>,
             Response = Response<B>,

--- a/proxy/src/transparency/client.rs
+++ b/proxy/src/transparency/client.rs
@@ -19,6 +19,7 @@ type HyperClient<C, B> =
 pub struct Client<C, B>
 where
     B: tower_h2::Body + 'static,
+    B: ::std::fmt::Debug,
 {
     inner: ClientInner<C, B>,
 }
@@ -26,6 +27,7 @@ where
 enum ClientInner<C, B>
 where
     B: tower_h2::Body + 'static,
+    B: ::std::fmt::Debug,
 {
     Http1(HyperClient<C, B>),
     Http2(tower_h2::client::Connect<C, LazyExecutor, RequestBody<B>>),
@@ -35,6 +37,7 @@ where
 pub struct ClientNewServiceFuture<C, B>
 where
     B: tower_h2::Body + 'static,
+    B: ::std::fmt::Debug,
     C: Connect + 'static,
 {
     inner: ClientNewServiceFutureInner<C, B>,
@@ -43,6 +46,7 @@ where
 enum ClientNewServiceFutureInner<C, B>
 where
     B: tower_h2::Body + 'static,
+    B: ::std::fmt::Debug,
     C: Connect + 'static,
 {
     Http1(Option<HyperClient<C, B>>),
@@ -53,6 +57,7 @@ where
 pub struct ClientService<C, B>
 where
     B: tower_h2::Body + 'static,
+    B: ::std::fmt::Debug,
     C: Connect,
 {
     inner: ClientServiceInner<C, B>,
@@ -61,6 +66,7 @@ where
 enum ClientServiceInner<C, B>
 where
     B: tower_h2::Body + 'static,
+    B: ::std::fmt::Debug,
     C: Connect
 {
     Http1(HyperClient<C, B>),
@@ -78,6 +84,7 @@ where
     C::Connected: Send,
     B: tower_h2::Body + Send + 'static,
    <B::Data as IntoBuf>::Buf: Send + 'static,
+    B: ::std::fmt::Debug,
 {
     /// Create a new `Client`, bound to a specific protocol (HTTP/1 or HTTP/2).
     pub fn new(protocol: &bind::Protocol, connect: C) -> Self {
@@ -114,6 +121,7 @@ where
     C::Future: Send + 'static,
     C::Connected: Send,
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
    <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     type Request = bind::HttpRequest<B>;
@@ -144,6 +152,7 @@ where
     C::Connected: Send,
     C::Future: Send + 'static,
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
    <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     type Item = ClientService<C, B>;
@@ -171,6 +180,7 @@ where
     C::Connected: Send,
     C::Future: Send + 'static,
     B: tower_h2::Body + Send + 'static,
+    B: ::std::fmt::Debug,
    <B::Data as IntoBuf>::Buf: Send + 'static,
 {
     type Request = bind::HttpRequest<B>;


### PR DESCRIPTION
When debugging proxy issues, it's helpful to be able to log details
about a stream body. However, because we are generally generic over the
body type, and the `Body` trait does not require that implementors also
implement `Debug`, then we must make this requirement explicit for all
uses.

This change adds `Debug` bounds to all body types. There is no
functional change.