### PR TITLE
proxy: Record EOS when bodies are dropped

### DIFF
--- a/proxy/src/telemetry/sensor/http.rs
+++ b/proxy/src/telemetry/sensor/http.rs
@@ -507,6 +507,14 @@ where
 
 }
 
+impl<B, I: BodySensor> Drop for MeasuredBody<B, I> {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            inner.end(None);
+        }
+    }
+}
+
 // ===== impl BodySensor =====
 
 impl BodySensor for ResponseBodyInner {


### PR DESCRIPTION
It appears that hyper does not necessarily poll bodies to completion,
and instead simply drops a body as soon as `content-length` is reached
(hyperium/hyper#1521).

This change implements Drop for MeasuredBody such that the stream-end
event is triggered if it had not been triggered previously. This ensures
that response latencies and counts are recorded for HTTP/1 streams.

Fixes #994