### PR TITLE
proxy: Remove dynamic label updating on bound services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,6 @@ dependencies = [
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.3.0",
- "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future.git)",
  "h2 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -346,15 +345,6 @@ dependencies = [
 name = "futures-mpsc-lossy"
 version = "0.3.0"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "futures-watch"
-version = "0.1.0"
-source = "git+https://github.com/carllerche/better-future.git#07baa13e91fefe7a51533dfde7b4e69e109ebe14"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1393,7 +1383,6 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum futures-watch 0.1.0 (git+https://github.com/carllerche/better-future.git)" = "<none>"
 "checksum gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9fcfe1c9ee125342355b2467bc29b9dfcb2124fcae27edb9cee6f4cc5ecd40"
 "checksum h2 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "01f3fc6ec9a3437d52fdb95000b8aeec314842b47529631e3b5570597c6ffad7"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "tower-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "tower-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "tower-discover"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "tower-in-flight-limit"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "tower-reconnect"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "tower-service"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1163,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "tower-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#6cdc8d0ab594f8c8c06e74f78e2ee37abd3fd8bb"
+source = "git+https://github.com/tower-rs/tower#9d49396eb807e6913c46cd877d6f8d039d3d5e1d"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -19,7 +19,6 @@ bytes = "0.4"
 deflate = {version = "0.7.18", features = ["gzip"] }
 env_logger = { version = "0.5", default-features = false }
 futures = "0.1"
-futures-watch = { git = "https://github.com/carllerche/better-future.git" }
 h2 = "0.1.7"
 http = "0.1"
 httparse = "1.2"

--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -183,7 +183,7 @@ where
                             // them onto the new watch first
                             match set.addrs {
                                 Exists::Yes(ref cache) => for (&addr, meta) in cache {
-                                    let update = Update::Insert(addr, meta.clone());
+                                    let update = Update::Bind(addr, meta.clone());
                                     resolve.responder.update_tx
                                         .unbounded_send(update)
                                         .expect("unbounded_send does not fail");
@@ -526,12 +526,12 @@ impl<T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
     ) {
         let (update_str, update, addr) = match change {
             CacheChange::Insertion { key, value } => {
-                ("insert", Update::Insert(key, value.clone()), key)
+                ("insert", Update::Bind(key, value.clone()), key)
             },
             CacheChange::Removal { key } => ("remove", Update::Remove(key), key),
             CacheChange::Modification { key, new_value } => (
                 "change metadata for",
-                Update::ChangeMetadata(key, new_value.clone()),
+                Update::Bind(key, new_value.clone()),
                 key,
             ),
         };

--- a/proxy/src/control/destination/endpoint.rs
+++ b/proxy/src/control/destination/endpoint.rs
@@ -1,26 +1,24 @@
-use futures_watch;
-use std::{cmp, hash, net::SocketAddr};
+use std::net::SocketAddr;
 
 use telemetry::metrics::DstLabels;
 
-pub type DstLabelsWatch = futures_watch::Watch<Option<DstLabels>>;
 
 /// An individual traffic target.
 ///
 /// Equality, Ordering, and hashability is determined soley by the Endpoint's address.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Endpoint {
     address: SocketAddr,
-    dst_labels: Option<DstLabelsWatch>,
+    dst_labels: Option<DstLabels>,
 }
 
 // ==== impl Endpoint =====
 
 impl Endpoint {
-    pub fn new(address: SocketAddr, dst_labels: DstLabelsWatch) -> Self {
+    pub fn new(address: SocketAddr, dst_labels: Option<DstLabels>) -> Self {
         Self {
             address,
-            dst_labels: Some(dst_labels),
+            dst_labels,
         }
     }
 
@@ -28,7 +26,7 @@ impl Endpoint {
         self.address
     }
 
-    pub fn dst_labels(&self) -> Option<&DstLabelsWatch> {
+    pub fn dst_labels(&self) -> Option<&DstLabels> {
         self.dst_labels.as_ref()
     }
 }
@@ -41,17 +39,3 @@ impl From<SocketAddr> for Endpoint {
         }
     }
 }
-
-impl hash::Hash for Endpoint {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.address.hash(state)
-    }
-}
-
-impl cmp::PartialEq for Endpoint {
-    fn eq(&self, other: &Self) -> bool {
-        self.address.eq(&other.address)
-    }
-}
-
-impl cmp::Eq for Endpoint {}

--- a/proxy/src/control/pb.rs
+++ b/proxy/src/control/pb.rs
@@ -46,8 +46,7 @@ impl event::StreamResponseEnd {
         };
 
         let destination_meta = ctx.dst_labels()
-            .and_then(|b| b.borrow().clone())
-            .map(|d| tap_event::EndpointMeta {
+            .map(|ref d| tap_event::EndpointMeta {
                 labels: d.as_map().clone(),
             });
 
@@ -78,8 +77,7 @@ impl event::StreamResponseFail {
         };
 
         let destination_meta = ctx.dst_labels()
-            .and_then(|b| b.borrow().clone())
-            .map(|d| tap_event::EndpointMeta {
+            .map(|ref d| tap_event::EndpointMeta {
                 labels: d.as_map().clone(),
             });
 
@@ -110,8 +108,7 @@ impl event::StreamRequestFail {
         };
 
         let destination_meta = ctx.dst_labels()
-            .and_then(|b| b.borrow().clone())
-            .map(|d| tap_event::EndpointMeta {
+            .map(|ref d| tap_event::EndpointMeta {
                 labels: d.as_map().clone(),
             });
 
@@ -150,8 +147,7 @@ impl<'a> TryFrom<&'a Event> for common::TapEvent {
                 };
 
                 let destination_meta = ctx.dst_labels()
-                    .and_then(|b| b.borrow().clone())
-                    .map(|d| tap_event::EndpointMeta {
+                    .map(|ref d| tap_event::EndpointMeta {
                         labels: d.as_map().clone(),
                     });
 
@@ -176,9 +172,8 @@ impl<'a> TryFrom<&'a Event> for common::TapEvent {
                     http_status: u32::from(ctx.status.as_u16()),
                 };
 
-                let destination_meta = ctx.request.dst_labels()
-                    .and_then(|b| b.borrow().clone())
-                    .map(|d| tap_event::EndpointMeta {
+                let destination_meta = ctx.dst_labels()
+                    .map(|ref d| tap_event::EndpointMeta {
                         labels: d.as_map().clone(),
                     });
 

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -1,9 +1,8 @@
 use http;
 use std::sync::Arc;
 
-use control::destination::DstLabelsWatch;
 use ctx;
-
+use telemetry::metrics::DstLabels;
 
 /// Describes a stream's request headers.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -54,7 +53,7 @@ impl Request {
         Arc::new(r)
     }
 
-    pub fn dst_labels(&self) -> Option<&DstLabelsWatch> {
+    pub fn dst_labels(&self) -> Option<&DstLabels> {
         self.client.dst_labels.as_ref()
     }
 }
@@ -67,5 +66,9 @@ impl Response {
         };
 
         Arc::new(r)
+    }
+
+    pub fn dst_labels(&self) -> Option<&DstLabels> {
+        self.request.dst_labels()
     }
 }

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -78,7 +78,6 @@ impl Proxy {
 #[cfg(test)]
 pub mod test_util {
     use http;
-    use futures_watch;
     use std::{
         fmt,
         net::SocketAddr,
@@ -109,8 +108,8 @@ pub mod test_util {
         L: IntoIterator<Item=(S, S)>,
         S: fmt::Display,
     {
-        let (labels_watch, _store) = futures_watch::Watch::new(DstLabels::new(labels));
-        ctx::transport::Client::new(&proxy, &addr(), Some(labels_watch))
+        let labels = DstLabels::new(labels);
+        ctx::transport::Client::new(&proxy, &addr(), labels)
     }
 
     pub fn request(

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -2,8 +2,8 @@ use std::{cmp, hash};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
-use control::destination::DstLabelsWatch;
 use ctx;
+use telemetry::metrics::DstLabels;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Ctx {
@@ -25,7 +25,7 @@ pub struct Server {
 pub struct Client {
     pub proxy: Arc<ctx::Proxy>,
     pub remote: SocketAddr,
-    pub dst_labels: Option<DstLabelsWatch>,
+    pub dst_labels: Option<DstLabels>,
 }
 
 impl Ctx {
@@ -82,7 +82,7 @@ impl Client {
     pub fn new(
         proxy: &Arc<ctx::Proxy>,
         remote: &SocketAddr,
-        dst_labels: Option<DstLabelsWatch>,
+        dst_labels: Option<DstLabels>,
     ) -> Arc<Client> {
         let c = Client {
             proxy: Arc::clone(proxy),

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -10,7 +10,6 @@ extern crate deflate;
 #[macro_use]
 extern crate futures;
 extern crate futures_mpsc_lossy;
-extern crate futures_watch;
 extern crate h2;
 extern crate http;
 extern crate httparse;

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -85,8 +85,7 @@ impl RequestLabels {
     pub fn new(req: &ctx::http::Request) -> Self {
         let direction = Direction::from_context(req.server.proxy.as_ref());
 
-        let outbound_labels = req.dst_labels()
-            .and_then(|b| b.borrow().clone());
+        let outbound_labels = req.dst_labels().cloned();
 
         let authority = req.uri
             .authority_part()

--- a/proxy/src/telemetry/tap/match_.rs
+++ b/proxy/src/telemetry/tap/match_.rs
@@ -109,12 +109,7 @@ impl Match {
                 Event::StreamRequestOpen(ref req) | Event::StreamRequestFail(ref req, _) => {
                     match req.dst_labels() {
                         None => false,
-                        Some(ref b) => {
-                            match b.borrow().as_ref() {
-                                None => false,
-                                Some(ref labels) => label.matches(labels.as_map()),
-                            }
-                        }
+                        Some(labels) => label.matches(labels.as_map()),
                     }
                 }
 
@@ -123,12 +118,7 @@ impl Match {
                 Event::StreamResponseEnd(ref rsp, _) => {
                     match rsp.request.dst_labels() {
                         None => false,
-                        Some(ref b) => {
-                            match b.borrow().as_ref() {
-                                None => false,
-                                Some(ref labels) => label.matches(labels.as_map()),
-                            }
-                        }
+                        Some(labels) => label.matches(labels.as_map()),
                     }
                 },
 


### PR DESCRIPTION
Depends on tower-rs/tower#75. Required for #386

In order for the proxy to use the TLS support metadata from the Destination 
service correctly, we determined that the code for dynamically changing the
labels on an already-bound service should be removed, and any change in
metadata should cause an endpoint to be rebound.

I've modified the proxy so that we no longer update the labels using 
`futures-watch` (as a sidenote, we no longer depend on that crate). Metadata
update events now cause the `tower-discover::Discover` implementation for 
`DestinationSet` to re-insert the changed endpoint into the load balancer.
Upstream PR tower-rs/tower#75 in tower-balance changes the load balancer 
to honor duplicate insertions by replacing the old endpoint rather than 
ignoring them; that change is necessary for the tests to pass on this branch.