### PR TITLE
Show kube-* stats in the web UI, tweaks to no resources appearance

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -22,20 +22,14 @@ const withTooltip = (d, metricName) => {
 };
 
 const formatTitle = (title, tooltipText) => {
-  let words = title.split(" ");
-  let content = title;
-  if (words.length === 2) {
-    content = (<div className="table-long-title">{words[0]}<br />{words[1]}</div>);
-  }
-
   if (!tooltipText) {
-    return content;
+    return title;
   } else {
     return (
       <Tooltip
         title={tooltipText}
         overlayStyle={{ fontSize: "12px" }}>
-        {content}
+        {title}
       </Tooltip>
     );
   }
@@ -186,12 +180,17 @@ class MetricsTable extends BaseTable {
       this.api.ConduitLink
     ));
 
+    let locale = {
+      emptyText: `No ${this.props.resource}s detected.`
+    };
+
     return (<BaseTable
       dataSource={tableData.rows}
       columns={columns}
       pagination={false}
       className="conduit-table"
-      rowKey={r => r.name}
+      rowKey={r => `${r.namespace}/${r.name}`}
+      locale={locale}
       size="middle" />);
   }
 }

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import CallToAction from './CallToAction.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
@@ -104,7 +103,7 @@ class Namespaces extends React.Component {
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
             <PageHeader header={`Namespace: ${this.state.ns}`} />
-            { noMetrics ? <CallToAction /> : null}
+            { noMetrics ? <div>No resources detected.</div> : null}
             {this.renderResourceSection("Deployment", this.state.metrics.deployments)}
             {this.renderResourceSection("Replication Controller", this.state.metrics.replicationcontrollers)}
             {this.renderResourceSection("Pod", this.state.metrics.pods)}

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -58,8 +58,7 @@ class Namespaces extends React.Component {
 
     Promise.all(this.api.getCurrentPromises())
       .then(([allRollup]) => {
-        let includeConduitStats = this.state.ns === this.props.controllerNamespace; // allow us to get stats on the conduit ns
-        let metrics = processMultiResourceRollup(allRollup, this.props.controllerNamespace, includeConduitStats);
+        let metrics = processMultiResourceRollup(allRollup);
 
         this.setState({
           metrics: metrics,

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -67,7 +67,7 @@ class ResourceList extends React.Component {
 
     Promise.all(this.api.getCurrentPromises())
       .then(([rollup]) => {
-        let processedMetrics = processSingleResourceRollup(rollup, this.props.controllerNamespace);
+        let processedMetrics = processSingleResourceRollup(rollup);
 
         this.setState({
           metrics: processedMetrics,

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import CallToAction from './CallToAction.jsx';
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
@@ -90,28 +89,18 @@ class ResourceList extends React.Component {
     });
   }
 
-  renderEmptyMessage() {
-    let shortResource = this.props.resource === "replication_controller" ?
-      "RC" : this.props.resource;
-    return (<CallToAction
-      resource={shortResource}
-      numResources={_.size(this.state.metrics)} />);
-  }
-
   render() {
     let friendlyTitle = _.startCase(this.props.resource);
+
     return (
       <div className="page-content">
         { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
             <PageHeader header={friendlyTitle + "s"} />
-            { _.isEmpty(this.state.metrics) ?
-              this.renderEmptyMessage(friendlyTitle) :
-              <MetricsTable
-                resource={friendlyTitle}
-                metrics={this.state.metrics} />
-            }
+            <MetricsTable
+              resource={friendlyTitle}
+              metrics={this.state.metrics} />
           </div>
         }
       </div>);

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -130,9 +130,6 @@ class ServiceMesh extends React.Component {
   extractNsStatuses(nsData) {
     let podsByNs = _.get(nsData, ["ok", "statTables", 0, "podGroup", "rows"], []);
     let dataPlaneNamepaces = _.map(podsByNs, ns => {
-      if (ns.resource.name.indexOf("kube-") === 0) {
-        return;
-      }
       let meshedPods = parseInt(ns.meshedPodCount, 10);
       let totalPods = parseInt(ns.runningPodCount, 10);
       let failedPods = parseInt(ns.failedPodCount, 10);

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -54,15 +54,6 @@ describe('MetricUtils', () => {
       expect(_.size(result)).to.equal(2);
 
       expect(result["deployments"]).to.have.length(1);
-      expect(result["pods"]).to.have.length(3);
-      expect(result["replicationcontrollers"]).to.be.undefined;
-    });
-
-    it('Respects the includeConduit flag', () => {
-      let result = processMultiResourceRollup(multiResourceRollupFixtures, "conduit-other", true);
-      expect(_.size(result)).to.equal(2);
-
-      expect(result["deployments"]).to.have.length(1);
       expect(result["pods"]).to.have.length(4);
       expect(result["replicationcontrollers"]).to.be.undefined;
     });

--- a/web/app/test/ServiceMeshTest.jsx
+++ b/web/app/test/ServiceMeshTest.jsx
@@ -160,14 +160,22 @@ describe('ServiceMesh', () => {
       component = mount(routerWrap(ServiceMesh));
 
       return withPromise(() => {
-        expect(component.html()).to.include("2 namespaces have no meshed resources.");
+        expect(component.html()).to.include("4 namespaces have no meshed resources.");
       });
     });
 
     it("displays a message if 1 resource has not added to servicemesh", () => {
+      let nsOneResourceNotAdded = _.cloneDeep(nsFixtures);
+      _.each(nsOneResourceNotAdded.ok.statTables[0].podGroup.rows, row => {
+        // set all namespaces to have fully meshed pod counts, except one
+        if (row.resource.name !== "default") {
+          row.meshedPodCount = "10";
+          row.runningPodCount = "10";
+        }
+      });
       fetchStub.resolves({
         ok: true,
-        json: () => Promise.resolve(nsFixtures)
+        json: () => Promise.resolve(nsOneResourceNotAdded)
       });
       component = mount(routerWrap(ServiceMesh));
 
@@ -176,13 +184,11 @@ describe('ServiceMesh', () => {
       });
     });
 
-    it("displays a message if all resource have been added to servicemesh", () => {
+    it("displays a message if all resources have been added to servicemesh", () => {
       let nsAllResourcesAdded = _.cloneDeep(nsFixtures);
       _.each(nsAllResourcesAdded.ok.statTables[0].podGroup.rows, row => {
-        if (row.resource.name === "default") {
-          row.meshedPodCount = "10";
-          row.runningPodCount = "10";
-        }
+        row.meshedPodCount = "10";
+        row.runningPodCount = "10";
       });
       fetchStub.resolves({
         ok: true,


### PR DESCRIPTION
Previously, we would filter out stats coming from Conduit itself and from the `kube-*` namespaces on some views in the Web UI. Remove this filtering, so that we display all the resource information we get 
back from the Stat API. (Fixes #997)

On the Resource pages, the call to action would show up when there were no metrics present, but that's actually not actionable by the user. Instead, I'm going to show a blank table with a "no <resource>s detected" message.

No resources message:
![screen shot 2018-05-24 at 3 45 27 pm](https://user-images.githubusercontent.com/549258/40517869-7283b968-5f6c-11e8-9f46-1ac684c1abb4.png)

Metrics for all namespaces now being shown:
![screen shot 2018-05-24 at 2 14 34 pm](https://user-images.githubusercontent.com/549258/40517865-6ea3883c-5f6c-11e8-93f9-ba015c4b10df.png)
