### PR TITLE
Remove RC/Pods/Deploys from the sidebar, replace with namespaces

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -25,6 +25,14 @@
     }
   }
 
+  & .sidebar-submenu-item {
+    font-size: 14px;
+
+    & a {
+      color: var(--silver);
+    }
+  }
+
   & img {
     height: 36px;
   }

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -36,10 +36,10 @@ class Namespaces extends React.Component {
     this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
   }
 
-  componentWillReceiveProps() {
+  componentWillReceiveProps(newProps) {
     // React won't unmount this component when switching resource pages so we need to clear state
     this.api.cancelCurrentRequests();
-    this.setState(this.getInitialState(this.props.match.params));
+    this.setState(this.getInitialState(newProps.match.params));
   }
 
   componentWillUnmount() {

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -70,8 +70,7 @@ class Sidebar extends React.Component {
     this.serverPromise = Promise.all(this.api.getCurrentPromises())
       .then(([versionRsp, nsRsp]) => {
         let nsStats = _.get(nsRsp, ["ok", "statTables", 0, "podGroup", "rows"], []);
-        let namespaces = _(nsStats).map(r => r.resource.name)
-          .sortBy().take(this.state.maxNsItemsToShow).value();
+        let namespaces = _(nsStats).map(r => r.resource.name).sortBy().value();
 
         this.setState({
           latestVersion: versionRsp.version,
@@ -103,6 +102,7 @@ class Sidebar extends React.Component {
   render() {
     let normalizedPath = this.props.location.pathname.replace(this.props.pathPrefix, "");
     let ConduitLink = this.api.ConduitLink;
+    let numHiddenNamespaces = _.size(this.state.namespaces) - this.state.maxNsItemsToShow;
 
     return (
       <Layout.Sider
@@ -145,16 +145,27 @@ class Sidebar extends React.Component {
             </Menu.Item>
 
             {
-              _.map(this.state.namespaces, ns => {
+              _.map(_.take(this.state.namespaces, this.state.maxNsItemsToShow), ns => {
                 return (
                   <Menu.Item className="sidebar-submenu-item" key={ns}>
                     <ConduitLink to={`/namespaces/${ns}`}>
-                      <Icon>{_.take(ns, 2)}</Icon>
+                      <Icon>{this.state.collapsed ? _.take(ns, 2) : <span>&nbsp;&nbsp;</span> }</Icon>
                       <span>{ns} {this.state.collapsed ? "namespace" : ""}</span>
                     </ConduitLink>
                   </Menu.Item>
                 );
               })
+            }
+
+            { // if we're hiding some namespaces, show a count
+              numHiddenNamespaces > 0 ?
+                <Menu.Item className="sidebar-submenu-item" key="extra-items">
+                  <ConduitLink to="/namespaces">
+                    <Icon>{this.state.collapsed ? <span>...</span> : <span>&nbsp;&nbsp;</span> }</Icon>
+                    <span>{numHiddenNamespaces} more namespace{numHiddenNamespaces === 1 ? "" : "s"}</span>
+                  </ConduitLink>
+                </Menu.Item>
+                : null
             }
 
             <Menu.Item className="sidebar-menu-item" key="/docs">

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -147,7 +147,7 @@ class Sidebar extends React.Component {
             {
               _.map(_.take(this.state.namespaces, this.state.maxNsItemsToShow), ns => {
                 return (
-                  <Menu.Item className="sidebar-submenu-item" key={ns}>
+                  <Menu.Item className="sidebar-submenu-item" key={`/namespaces/${ns}`}>
                     <ConduitLink to={`/namespaces/${ns}`}>
                       <Icon>{this.state.collapsed ? _.take(ns, 2) : <span>&nbsp;&nbsp;</span> }</Icon>
                       <span>{ns} {this.state.collapsed ? "namespace" : ""}</span>


### PR DESCRIPTION
In an effort to highlight the namespace overview pages, remove the Deployments, Replication Controllers and Pods items from the sidebar and replace them with direct links to individual Namespace pages. If the user has more than 8 namespaces, only list the first 8 (the rest can be accessed by the namespace list page).

The Deployments/RCs/Pods endpoints are still available if you go directly to /deployments, /pods, etc. but they're not highlighted to the user.

One thing I've been sorting through is how to display an abbreviated version of the namespace name when the sidebar is collapsed. If our default view is doing to be with the sidebar collapsed, unless the user knows their namespaces, they'll need to hover over the sidebar items to see the full namespace name.

Also note that since conduit, default, kube-public and kube-system are near the beginning of the alphabet, we'll be likely showing these namespaces a bunch. We could consider filtering those out of the navbar (you could still find them in the Namespaces list page). 

Additionally, we're getting a list of namespaces from the stat api, but we don't need the stats. It'd be nice if the stat endpoint knew it didn't need to query prometheus for these requests. I've filed #1022 to track.

![screen shot 2018-05-25 at 10 54 34 am](https://user-images.githubusercontent.com/549258/40559420-9087d03a-600b-11e8-99df-2ba0b0735e88.png)
![screen shot 2018-05-25 at 10 54 43 am](https://user-images.githubusercontent.com/549258/40559421-90a1d5ca-600b-11e8-827a-f4f1557ad7ed.png)
