### PR TITLE
Add meshed label support to Grafana

### DIFF
--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -419,7 +419,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deploy/{{deployment}}",
@@ -504,11 +504,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (deployment)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\", meshed=\"true\"}[30s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "deploy/{{deployment}}",
+          "legendFormat": "🔒deploy/{{deployment}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\", meshed=\"false\"}[30s])) by (deployment)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️deploy/{{deployment}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -589,14 +596,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 deploy/{{deployment}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -604,7 +611,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 deploy/{{deployment}}",
@@ -929,7 +936,7 @@
             "h": 2,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 20.8
           },
           "id": 39,
           "links": [],
@@ -949,7 +956,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 45
+            "y": 22.8
           },
           "id": 36,
           "legend": {
@@ -975,7 +982,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{classification=\"success\", deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (deployment, pod) / sum(irate(response_total{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (deployment, pod)",
+              "expr": "sum(irate(response_total{classification=\"success\", deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (deployment, pod) / sum(irate(response_total{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (deployment, pod)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1018,7 +1025,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -1031,7 +1042,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 45
+            "y": 22.8
           },
           "id": 22,
           "legend": {
@@ -1057,11 +1068,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (deployment, pod)",
+              "expr": "sum(irate(request_total{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\", meshed=\"true\"}[30s])) by (deployment, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "po/{{pod}}",
+              "legendFormat": "🔒po/{{pod}}",
               "refId": "A"
+            },
+            {
+              "expr": "sum(irate(request_total{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\", meshed=\"false\"}[30s])) by (deployment, pod)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "⚠️po/{{pod}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -1099,7 +1117,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -1112,7 +1134,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 45
+            "y": 22.8
           },
           "id": 29,
           "legend": {
@@ -1138,21 +1160,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, deployment))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P50 deploy/{{deployment}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, deployment))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 deploy/{{deployment}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, deployment))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (le, deployment))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 deploy/{{deployment}}",
@@ -1193,7 +1215,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "repeat": "inbound",
@@ -1266,7 +1292,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (dst_deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (dst_deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (dst_deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (dst_deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deploy/{{dst_deployment}}",
@@ -1351,11 +1377,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (dst_deployment)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "deploy/{{dst_deployment}}",
+          "legendFormat": "🔒deploy/{{dst_deployment}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_deployment)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️deploy/{{dst_deployment}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -1435,7 +1468,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\"}[30s])) by (le, dst_deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P95 deploy/{{dst_deployment}}",
@@ -1814,7 +1847,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_deployment)",
+              "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_deployment) / sum(irate(response_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "deploy/{{dst_deployment}}",
@@ -1899,11 +1932,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_deployment)",
+              "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "deploy/{{dst_deployment}}",
+              "legendFormat": "🔒deploy/{{dst_deployment}}",
               "refId": "A"
+            },
+            {
+              "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_deployment)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "⚠️deploy/{{dst_deployment}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -1983,21 +2023,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P50 deploy/{{dst_deployment}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 deploy/{{dst_deployment}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_deployment))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_deployment))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 deploy/{{dst_deployment}}",

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -85,7 +85,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (deployment, pod) / sum(irate(response_total{deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (deployment, pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod) / sum(irate(response_total{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "po/{{pod}}",
@@ -169,7 +169,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (deployment, pod)",
+          "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "po/{{pod}}",
@@ -253,21 +253,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le, deployment, pod))",
+          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 po/{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le, deployment, pod))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p95 po/{{pod}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[20s])) by (le, deployment, pod))",
+          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 po/{{pod}}",
@@ -1014,21 +1014,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(http_request_duration_seconds_bucket{job=\"conduit-controller\"}[20s])) by (le, component, code))",
+          "expr": "histogram_quantile(0.5, sum(rate(http_request_duration_seconds_bucket{job=\"conduit-controller\"}[30s])) by (le, component, code))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P50 {{component}}/{{code}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"conduit-controller\"}[20s])) by (le, component, code))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"conduit-controller\"}[30s])) by (le, component, code))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P95 {{component}}/{{code}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"conduit-controller\"}[20s])) by (le, component, code))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"conduit-controller\"}[30s])) by (le, component, code))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P99 {{component}}/{{code}}",
@@ -1148,7 +1148,7 @@
           "refId": "A"
         },
         {
-          "expr": "irate(go_memstats_alloc_bytes_total{job=\"conduit-controller\", component=\"$component\"}[20s])",
+          "expr": "irate(go_memstats_alloc_bytes_total{job=\"conduit-controller\", component=\"$component\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "alloc rate/{{component}}",
@@ -1344,14 +1344,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(grpc_server_msg_sent_total{job=\"conduit-controller\", component=\"$component\"}[20s])",
+          "expr": "irate(grpc_server_msg_sent_total{job=\"conduit-controller\", component=\"$component\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "sent/{{component}}/{{grpc_method}}",
           "refId": "A"
         },
         {
-          "expr": "irate(grpc_server_msg_received_total{job=\"conduit-controller\", component=\"$component\"}[20s])",
+          "expr": "irate(grpc_server_msg_received_total{job=\"conduit-controller\", component=\"$component\"}[30s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "received/{{component}}/{{grpc_method}}",

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -420,7 +420,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) by (pod) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) by (pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s])) by (pod) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "po/{{pod}}",
@@ -505,11 +505,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) by (pod)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\", meshed=\"true\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "po/{{pod}}",
+          "legendFormat": "🔒po/{{pod}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\", meshed=\"false\"}[30s])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️po/{{pod}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -590,14 +597,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 po/{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -605,7 +612,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 po/{{pod}}",
@@ -705,7 +712,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[20s])) by (pod) / sum(irate(response_total{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[20s])) by (pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[30s])) by (pod) / sum(irate(response_total{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[30s])) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -791,11 +798,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[20s])) by (pod)",
+          "expr": "sum(irate(request_total{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\", meshed=\"true\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "po/{{pod}}",
+          "legendFormat": "🔒po/{{pod}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\", meshed=\"false\"}[30s])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️po/{{pod}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -876,14 +890,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 po/{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -891,7 +905,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 po/{{pod}}",
@@ -991,7 +1005,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (pod) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (pod) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1077,11 +1091,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (pod)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\", meshed=\"true\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "po/{{pod}}",
+          "legendFormat": "🔒po/{{pod}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\", meshed=\"false\"}[30s])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️po/{{pod}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -1162,14 +1183,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 po/{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1177,7 +1198,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, pod))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 po/{{pod}}",
@@ -1277,7 +1298,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (dst_pod) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (dst_pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (dst_pod) / sum(irate(response_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (dst_pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1363,11 +1384,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (dst_pod)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "po/{{dst_pod}}",
+          "legendFormat": "🔒po/{{dst_pod}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️po/{{dst_pod}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -1448,14 +1476,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, dst_pod))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, dst_pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 po/{{dst_pod}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, dst_pod))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, dst_pod))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1463,7 +1491,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[20s])) by (le, dst_pod))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\"}[30s])) by (le, dst_pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 po/{{dst_pod}}",

--- a/grafana/dashboards/replication-controller.json
+++ b/grafana/dashboards/replication-controller.json
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -419,7 +419,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) by (replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) by (replication_controller)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (replication_controller)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "rc/{{replication_controller}}",
@@ -504,11 +504,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) by (replication_controller)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\", meshed=\"true\"}[30s])) by (replication_controller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "rc/{{replication_controller}}",
+          "legendFormat": "🔒rc/{{replication_controller}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\", meshed=\"false\"}[30s])) by (replication_controller)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️rc/{{replication_controller}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -589,14 +596,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) by (le, replication_controller))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (le, replication_controller))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 rc/{{replication_controller}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) by (le, replication_controller))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (le, replication_controller))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -604,7 +611,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[20s])) by (le, replication_controller))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (le, replication_controller))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 rc/{{replication_controller}}",
@@ -729,7 +736,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{classification=\"success\", replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (replication_controller, pod) / sum(irate(response_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (replication_controller, pod)",
+              "expr": "sum(irate(response_total{classification=\"success\", replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (replication_controller, pod) / sum(irate(response_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (replication_controller, pod)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -815,11 +822,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (replication_controller, pod)",
+              "expr": "sum(irate(request_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\", meshed=\"true\"}[30s])) by (replication_controller, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "po/{{pod}}",
+              "legendFormat": "🔒po/{{pod}}",
               "refId": "A"
+            },
+            {
+              "expr": "sum(irate(request_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\", meshed=\"false\"}[30s])) by (replication_controller, pod)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "⚠️po/{{pod}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -900,21 +914,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (le, replication_controller))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, replication_controller))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P50 rc/{{replication_controller}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (le, replication_controller))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, replication_controller))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 rc/{{replication_controller}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (le, replication_controller))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, replication_controller))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 rc/{{replication_controller}}",
@@ -1032,7 +1046,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (dst_replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (dst_replication_controller)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (dst_replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (dst_replication_controller)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "rc/{{dst_replication_controller}}",
@@ -1117,11 +1131,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (dst_replication_controller)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_replication_controller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "rc/{{dst_replication_controller}}",
+          "legendFormat": "🔒rc/{{dst_replication_controller}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_replication_controller)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️rc/{{dst_replication_controller}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -1201,7 +1222,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[20s])) by (le, dst_replication_controller))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P95 rc/{{dst_replication_controller}}",
@@ -1325,7 +1346,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_replication_controller)",
+              "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replication_controller)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "rc/{{dst_replication_controller}}",
@@ -1410,11 +1431,18 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[20s])) by (dst_replication_controller)",
+              "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_replication_controller)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "rc/{{dst_replication_controller}}",
+              "legendFormat": "🔒rc/{{dst_replication_controller}}",
               "refId": "A"
+            },
+            {
+              "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_replication_controller)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "⚠️rc/{{dst_replication_controller}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -1494,21 +1522,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_replication_controller))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P50 rc/{{dst_replication_controller}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_replication_controller))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 rc/{{dst_replication_controller}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[20s])) by (le, dst_replication_controller))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 rc/{{dst_replication_controller}}",

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -264,7 +264,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (le, dst_service))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (le, dst_service))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -338,7 +338,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (dst_service) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (dst_service)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "svc/{{dst_service}}",
@@ -423,11 +423,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_service)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "svc/{{dst_service}}",
+          "legendFormat": "🔒svc/{{dst_service}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_service)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️svc/{{dst_service}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -508,14 +515,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (le, dst_service))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (le, dst_service))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 svc/{{dst_service}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (le, dst_service))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (le, dst_service))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -523,7 +530,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (le, dst_service))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (le, dst_service))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 svc/{{dst_service}}",
@@ -623,7 +630,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service, deployment) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service, deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (dst_service, deployment) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (dst_service, deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deploy/{{deployment}}",
@@ -708,11 +715,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service, deployment)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_service, deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "deploy/{{deployment}}",
+          "legendFormat": "🔒deploy/{{deployment}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_service, deployment)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️deploy/{{deployment}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -792,7 +806,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (le, dst_service, deployment))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (le, dst_service, deployment))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P95 deploy/{{deployment}}",
@@ -891,7 +905,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service, pod) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service, pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (dst_service, pod) / sum(irate(response_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (dst_service, pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "po/{{pod}}",
@@ -976,11 +990,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (dst_service, pod)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", meshed=\"true\"}[30s])) by (dst_service, pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "po/{{pod}}",
+          "legendFormat": "🔒po/{{pod}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", meshed=\"false\"}[30s])) by (dst_service, pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️po/{{pod}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -1060,7 +1081,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[20s])) by (le, dst_service, pod))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\"}[30s])) by (le, dst_service, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "P95 po/{{pod}}",

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -97,7 +97,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", deployment=~\"$deployment\"}[20s])) / sum(irate(response_total{deployment=~\"$deployment\"}[20s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", deployment=~\"$deployment\"}[30s])) / sum(irate(response_total{deployment=~\"$deployment\"}[30s]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -179,7 +179,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[20s]))",
+          "expr": "sum(irate(request_total{deployment=~\"$deployment\"}[30s]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -416,7 +416,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (namespace) / sum(irate(response_total{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (namespace)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=~\"$namespace\", direction=\"inbound\"}[30s])) by (namespace) / sum(irate(response_total{namespace=~\"$namespace\", direction=\"inbound\"}[30s])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "ns/{{namespace}}",
@@ -500,11 +500,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (namespace)",
+          "expr": "sum(irate(request_total{namespace=~\"$namespace\", direction=\"inbound\", meshed=\"true\"}[30s])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "ns/{{namespace}}",
+          "legendFormat": "🔒ns/{{namespace}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=~\"$namespace\", direction=\"inbound\", meshed=\"false\"}[30s])) by (namespace)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️ns/{{namespace}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -513,7 +520,7 @@
       "title": "REQUEST VOLUME",
       "tooltip": {
         "shared": true,
-        "sort": 1,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -584,7 +591,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=~\"$namespace\", direction=\"inbound\"}[20s])) by (le, namespace))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=~\"$namespace\", direction=\"inbound\"}[30s])) by (le, namespace))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p95 ns/{{namespace}}",
@@ -714,7 +721,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (deployment) / sum(irate(response_total{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (deployment)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (deployment) / sum(irate(response_total{namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deploy/{{deployment}}",
@@ -798,11 +805,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (deployment)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", direction=\"inbound\", meshed=\"true\"}[30s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "deploy/{{deployment}}",
+          "legendFormat": "🔒deploy/{{deployment}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", direction=\"inbound\", meshed=\"false\"}[30s])) by (deployment)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "⚠️deploy/{{deployment}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -882,7 +896,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", direction=\"inbound\"}[20s])) by (le, deployment))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (le, deployment))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,


### PR DESCRIPTION
The Grafana dashboards currently show Request Volume by ns/deploy/pod.

Add a `meshed` dimension to the Request Volume graphs, in anticipation
of the `meshed`/`secured` label from the proxy. Also increase `irate`
time window queries from `20s` to `30s`, per recommendation from
Prometheus team.

Relates to #388.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![screen shot 2018-05-25 at 1 11 03 pm](https://user-images.githubusercontent.com/236915/40564360-3d41cefa-601d-11e8-8ee7-f3ef7b8e232b.png)
