### PR TITLE
Add a call to action when there are unadded resources

### DIFF
--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -24,7 +24,6 @@
   font-size: 16;
   border-radius: calc(var(--base-width)/2);
   font-weight: var(--font-weight-extra-bold);
-  border-radius: var
 }
 
 .service-mesh-table {

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -125,6 +125,16 @@ h2, h3, h4, h5, h6 {
   color: var(--neutralgrey);
 }
 
+.add-resources-message {
+  margin-bottom: calc(var(--base-width) * 2);
+  background-color: var(--silver);
+  color: white;
+  padding: calc(var(--base-width) * 2);
+  font-size: 16;
+  border-radius: calc(var(--base-width) / 2);
+  font-weight: var(--font-weight-extra-bold);
+}
+
 .action {
   font-size: 14px;
   font-weight: var(--font-weight-bold);

--- a/web/app/js/components/AddResourcesMessage.jsx
+++ b/web/app/js/components/AddResourcesMessage.jsx
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+import { incompleteMeshMessage } from './util/CopyUtils.jsx';
+import React from 'react';
+
+export default class AddResourcesMessage extends React.Component {
+  render() {
+    let unadded = this.props.unadded;
+    let resource = this.props.resource;
+
+    if (unadded === 0) {
+      return null;
+    } else {
+      return (
+        <div className="add-resources-message">
+          {_.isNil(unadded) ? "Some" : unadded} {resource}{unadded === 1 ? " has" : "s have"} not been added to the mesh.
+          <div className="clearfix">
+            {incompleteMeshMessage()}
+          </div>
+        </div>
+      );
+    }
+  }
+}

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -1,9 +1,10 @@
 import _ from 'lodash';
+import AddResourcesMessage from "./AddResourcesMessage.jsx";
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
-import { processMultiResourceRollup } from './util/MetricUtils.js';
+import { countUnadded, processMultiResourceRollup } from './util/MetricUtils.js';
 import React from 'react';
 import { withContext } from './util/AppContext.jsx';
 import './../../css/list.css';
@@ -96,6 +97,8 @@ class Namespaces extends React.Component {
 
   render() {
     let noMetrics = _.isEmpty(this.state.metrics.pods);
+    let unaddedResources = countUnadded(this.state.metrics.deployments) +
+      countUnadded(this.state.metrics.replicationcontrollers);
 
     return (
       <div className="page-content">
@@ -104,6 +107,8 @@ class Namespaces extends React.Component {
           <div>
             <PageHeader header={`Namespace: ${this.state.ns}`} />
             { noMetrics ? <div>No resources detected.</div> : null}
+            <AddResourcesMessage unadded={unaddedResources} resource="resource" />
+
             {this.renderResourceSection("Deployment", this.state.metrics.deployments)}
             {this.renderResourceSection("Replication Controller", this.state.metrics.replicationcontrollers)}
             {this.renderResourceSection("Pod", this.state.metrics.pods)}

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -1,9 +1,10 @@
 import _ from 'lodash';
+import AddResourcesMessage from "./AddResourcesMessage.jsx";
 import ConduitSpinner from "./ConduitSpinner.jsx";
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import PageHeader from './PageHeader.jsx';
-import { processSingleResourceRollup } from './util/MetricUtils.js';
+import { countUnadded, processSingleResourceRollup } from './util/MetricUtils.js';
 import React from 'react';
 import { withContext } from './util/AppContext.jsx';
 import './../../css/list.css';
@@ -91,6 +92,7 @@ class ResourceList extends React.Component {
 
   render() {
     let friendlyTitle = _.startCase(this.props.resource);
+    let unadded = countUnadded(this.state.metrics);
 
     return (
       <div className="page-content">
@@ -98,6 +100,7 @@ class ResourceList extends React.Component {
         { !this.state.loaded ? <ConduitSpinner />  :
           <div>
             <PageHeader header={friendlyTitle + "s"} />
+            <AddResourcesMessage unadded={unadded} resource={friendlyTitle} />
             <MetricsTable
               resource={friendlyTitle}
               metrics={this.state.metrics}

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -151,3 +151,7 @@ export const processMultiResourceRollup = rawMetrics => {
   });
   return metricsByResource;
 };
+
+export const countUnadded = processedMetrics => {
+  return _.countBy(processedMetrics, "added")["false"] || 0;
+};


### PR DESCRIPTION
Add a call to action on the Namespace overview page and the per resources pages when there are unadded resources.

This is a WIP, but I wanted to put the branch up so someone can take it over next week.

There's still some things to think through:
- do we want to display the CTA on the `kube-*` namespace pages?
- there may always be some resources that are unadded, do we even want this message? it might be annoying and take up screen real estate when there's nothing the user can do
- would this be better as a per-row indicator, with adding instructions showing up in a modal?

![screen shot 2018-05-25 at 3 36 41 pm](https://user-images.githubusercontent.com/549258/40568798-9fcfdc56-6031-11e8-95d1-f6f47a93700a.png)
![screen shot 2018-05-25 at 3 36 55 pm](https://user-images.githubusercontent.com/549258/40568799-9fed49b2-6031-11e8-9f80-545dbfa4e238.png)

Part of #1023
