### PR TITLE
Don't show namespace filter on the namespace page

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -182,8 +182,8 @@ class MetricsTable extends BaseTable {
     let columns = _.compact(columnDefinitions(
       this.props.sortable,
       this.props.resource,
-      namespaceFilterText,
-      this.onFilterDropdownVisibleChange,
+      this.props.showNamespaceFilter ? namespaceFilterText : undefined,
+      this.props.showNamespaceFilter ? this.onFilterDropdownVisibleChange : undefined,
       this.props.linkifyNsColumn,
       this.api.ConduitLink
     ));
@@ -202,5 +202,9 @@ class MetricsTable extends BaseTable {
       size="middle" />);
   }
 }
+
+MetricsTable.defaultProps = {
+  showNamespaceFilter: true
+};
 
 export default withContext(MetricsTable);

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -89,7 +89,8 @@ class Namespaces extends React.Component {
         <h1>{friendlyTitle}s</h1>
         <MetricsTable
           resource={friendlyTitle}
-          metrics={metrics} />
+          metrics={metrics}
+          showNamespaceFilter={false} />
       </div>
     );
   }


### PR DESCRIPTION
On the individual namespace pages, the filter should not be shown, as all results that appear on the that page will be for on namespace.

Added a boolean property, showNamespaceFilter, to MetricsTable that allows you to define if the filter should be shown.

Tested that the filter is not shown on namespace pages.

Fixes #972

Signed-off-by: Kim Christensen <kimworking@gmail.com>