### PR TITLE
Fix location of raw pointer comment in `ContextGuard`.

### DIFF
--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -46,12 +46,6 @@ where
     T: ::std::fmt::Debug + 'static,
     F: FnMut() -> U,
 {
-    // This is a raw pointer because of lifetime conflicts that require
-    // the thread local to have a static lifetime.
-    //
-    // We don't want to require a static lifetime, and in fact,
-    // only use the reference within this closure, so converting
-    // to a raw pointer is safe.
     let _guard = ContextGuard::new(context);
     closure()
 }
@@ -146,6 +140,12 @@ struct ContextGuard<'a>(&'a (fmt::Debug + 'static));
 
 impl<'a> ContextGuard<'a> {
     fn new(context: &'a (fmt::Debug + 'static)) -> Self {
+        // This is a raw pointer because of lifetime conflicts that require
+        // the thread local to have a static lifetime.
+        //
+        // We don't want to require a static lifetime, and in fact,
+        // only use the reference within this closure, so converting
+        // to a raw pointer is safe.
         let raw = context as *const fmt::Debug;
         CONTEXT.with(|ctxt| {
             ctxt.borrow_mut().push(raw);


### PR DESCRIPTION
Commit b861a6df317c937123825098a7ef0b50cf52e281 moved the code the
comment was describing, but didn't move the comment.

Signed-off-by: Brian Smith <brian@briansmith.org>