### PR TITLE
proxy: Ensure labels are reliably ordered

### DIFF
--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -550,9 +550,14 @@ fn pb_to_addr_meta(
     set_labels: &HashMap<String, String>,
 ) -> Option<(SocketAddr, Metadata)> {
     let addr = pb.addr.and_then(pb_to_sock_addr)?;
-    let label_iter = set_labels.iter().chain(pb.metric_labels.iter());
+
+    let mut labels = set_labels.iter()
+        .chain(pb.metric_labels.iter())
+        .collect::<Vec<_>>();
+    labels.sort_by(|(k0, _), (k1, _)| k0.cmp(k1));
+
     let meta = Metadata {
-        metric_labels: DstLabels::new(label_iter),
+        metric_labels: DstLabels::new(labels.into_iter()),
     };
     Some((addr, meta))
 }


### PR DESCRIPTION
The proxy receives a hash map of endpoint labels from the destination
service. As this map is serialized into a string, its keys and values
do not have a stable ordering.

To fix this, we sort the keys for all labels before constructing an
instance of `DstLabels`.

This change was much more difficult to test than it was to fix, so tests
this change was tested manually.

Fixes #1015