### PR TITLE
proxy: unbox DNS futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
- "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)",
+ "trust-dns-resolver 0.9.0 (git+https://github.com/hawkw/trust-dns?branch=eliza/async-resolver-api-improvement)",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.4.0"
-source = "git+https://github.com/bluejekyll/trust-dns#660ca00c9b9ff0cbd675d3ff594bf072d87eb223"
+source = "git+https://github.com/hawkw/trust-dns?branch=eliza/async-resolver-api-improvement#bac275861377faca4686df264a7104da95301880"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.9.0"
-source = "git+https://github.com/bluejekyll/trust-dns#660ca00c9b9ff0cbd675d3ff594bf072d87eb223"
+source = "git+https://github.com/hawkw/trust-dns?branch=eliza/async-resolver-api-improvement#bac275861377faca4686df264a7104da95301880"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1254,7 +1254,7 @@ dependencies = [
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)",
+ "trust-dns-proto 0.4.0 (git+https://github.com/hawkw/trust-dns?branch=eliza/async-resolver-api-improvement)",
 ]
 
 [[package]]
@@ -1530,8 +1530,8 @@ dependencies = [
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
-"checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum trust-dns-proto 0.4.0 (git+https://github.com/hawkw/trust-dns?branch=eliza/async-resolver-api-improvement)" = "<none>"
+"checksum trust-dns-resolver 0.9.0 (git+https://github.com/hawkw/trust-dns?branch=eliza/async-resolver-api-improvement)" = "<none>"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,20 +31,6 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -156,7 +142,7 @@ dependencies = [
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
- "trust-dns-resolver 0.8.1 (git+https://github.com/bluejekyll/trust-dns)",
+ "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)",
 ]
 
 [[package]]
@@ -229,15 +215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbghelp-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "deflate"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,14 +250,6 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -293,6 +262,17 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -761,6 +741,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -869,12 +854,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
 version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1181,11 +1193,11 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.3.2"
-source = "git+https://github.com/bluejekyll/trust-dns#849453207c16e4f5639e321d213ac77595728981"
+version = "0.4.0"
+source = "git+https://github.com/bluejekyll/trust-dns#ee3e3f23514fc36f3f822752c2ff0bb75c307788"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1204,11 +1216,11 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.8.1"
-source = "git+https://github.com/bluejekyll/trust-dns#849453207c16e4f5639e321d213ac77595728981"
+version = "0.9.0"
+source = "git+https://github.com/bluejekyll/trust-dns#ee3e3f23514fc36f3f822752c2ff0bb75c307788"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1217,7 +1229,7 @@ dependencies = [
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-proto 0.3.2 (git+https://github.com/bluejekyll/trust-dns)",
+ "trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)",
 ]
 
 [[package]]
@@ -1246,6 +1258,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-segmentation"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1363,7 +1380,6 @@ dependencies = [
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
-"checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
@@ -1378,14 +1394,13 @@ dependencies = [
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
 "checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
-"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
-"checksum error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faa976b4fd2e4c2b2f3f486874b19e61944d3de3de8b61c9fcf835d583871bcc"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1440,6 +1455,7 @@ dependencies = [
 "checksum prost-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "49b4fc1adae913fff99daa455ca43750f90cbec6846369fb78b7ed8d3e727758"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13f4460d3daa06eb1c4b9a3c55dffe65cb030dd70cf1bfdd482532f48ab24f74"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
@@ -1455,7 +1471,10 @@ dependencies = [
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31f98b200e7caca9efca50fc0aa69cd58a5ec81d5f6e75b2f3ecaad2e998972a"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7d12ebcea3f1027a817b98e91cfe30805634ea1f63e36015f765960a7782494d"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
@@ -1483,13 +1502,14 @@ dependencies = [
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum trust-dns-proto 0.3.2 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
-"checksum trust-dns-resolver 0.8.1 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "codegen"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/codegen#9b2f81859e91931871456ad06437643585d35866"
@@ -142,7 +150,7 @@ dependencies = [
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
- "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)",
+ "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)",
 ]
 
 [[package]]
@@ -763,6 +771,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.4.0"
-source = "git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0#5c966b86e7d847ad14344e494237e162dc635de0"
+source = "git+https://github.com/bluejekyll/trust-dns#660ca00c9b9ff0cbd675d3ff594bf072d87eb223"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1202,7 +1227,7 @@ dependencies = [
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1217,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.9.0"
-source = "git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0#5c966b86e7d847ad14344e494237e162dc635de0"
+source = "git+https://github.com/bluejekyll/trust-dns#660ca00c9b9ff0cbd675d3ff594bf072d87eb223"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1229,7 +1254,7 @@ dependencies = [
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)",
+ "trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)",
 ]
 
 [[package]]
@@ -1389,6 +1414,7 @@ dependencies = [
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum codegen 0.1.0 (git+https://github.com/carllerche/codegen)" = "<none>"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
@@ -1458,6 +1484,8 @@ dependencies = [
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a89abf8d34faf9783692392dca7bcdc6e82fa84eca86ccb6301ec87f3497185"
+"checksum rand_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7a5f27547c49e5ccf8a586db3f3782fd93cf849780b21853b9d981db203302"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
@@ -1502,8 +1530,8 @@ dependencies = [
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)" = "<none>"
-"checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)" = "<none>"
+"checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
- "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)",
+ "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.4.0"
-source = "git+https://github.com/bluejekyll/trust-dns#ee3e3f23514fc36f3f822752c2ff0bb75c307788"
+source = "git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0#5c966b86e7d847ad14344e494237e162dc635de0"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.9.0"
-source = "git+https://github.com/bluejekyll/trust-dns#ee3e3f23514fc36f3f822752c2ff0bb75c307788"
+source = "git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0#5c966b86e7d847ad14344e494237e162dc635de0"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1229,7 +1229,7 @@ dependencies = [
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)",
+ "trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)",
 ]
 
 [[package]]
@@ -1502,8 +1502,8 @@ dependencies = [
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
-"checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
+"checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)" = "<none>"
+"checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns?rev=5c966b86e7d847ad14344e494237e162dc635de0)" = "<none>"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 
 [patch.crates-io]
 prost-derive = { git = "https://github.com/danburkert/prost" }
+
+[patch."https://github.com/bluejekyll/trust-dns"]
+trust-dns-resolver = { git = "https://github.com/hawkw/trust-dns", branch = "eliza/async-resolver-api-improvement" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -38,7 +38,7 @@ tokio-signal = "0.2"
 prost = "0.3.0"
 prost-types = "0.3.0"
 
-trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns", rev = "5c966b86e7d847ad14344e494237e162dc635de0" }
+trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns" }
 
 #futures-watch   = { git = "https://github.com/carllerche/better-future" }
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -38,7 +38,7 @@ tokio-signal = "0.2"
 prost = "0.3.0"
 prost-types = "0.3.0"
 
-trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns", branch = "master" }
+trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns", rev = "5c966b86e7d847ad14344e494237e162dc635de0" }
 
 #futures-watch   = { git = "https://github.com/carllerche/better-future" }
 

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -68,6 +68,9 @@ pub struct Config {
     pub bind_timeout: Duration,
 
     pub pod_namespace: String,
+
+    /// Optional minimum TTL for DNS lookups.
+    pub dns_min_ttl: Option<Duration>,
 }
 
 /// Configuration settings for binding a listener.
@@ -164,6 +167,11 @@ pub const ENV_POD_NAMESPACE: &str = "CONDUIT_PROXY_POD_NAMESPACE";
 pub const ENV_CONTROL_URL: &str = "CONDUIT_PROXY_CONTROL_URL";
 const ENV_RESOLV_CONF: &str = "CONDUIT_RESOLV_CONF";
 
+/// Configures a minimum value for the TTL of DNS lookups.
+///
+/// Lookups with TTLs below this value will use this value instead.
+const ENV_DNS_MIN_TTL: &str = "CONDUIT_PROXY_DNS_MIN_TTL";
+
 // Default values for various configuration fields
 const DEFAULT_EVENT_BUFFER_CAPACITY: usize = 10_000; // FIXME
 const DEFAULT_PRIVATE_LISTENER: &str = "tcp://127.0.0.1:4140";
@@ -218,6 +226,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
         let event_buffer_capacity = parse(strings, ENV_EVENT_BUFFER_CAPACITY, parse_number);
         let metrics_retain_idle = parse(strings, ENV_METRICS_RETAIN_IDLE, parse_duration);
+        let dns_min_ttl = parse(strings, ENV_DNS_MIN_TTL, parse_duration);
         let pod_namespace = strings.get(ENV_POD_NAMESPACE).and_then(|maybe_value| {
             // There cannot be a default pod namespace, and the pod namespace is required.
             maybe_value.ok_or_else(|| {
@@ -236,6 +245,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
             },
             Err(e) => Err(e),
         };
+
 
         Ok(Config {
             private_listener: Listener {
@@ -287,6 +297,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
             bind_timeout: bind_timeout?.unwrap_or(DEFAULT_BIND_TIMEOUT),
 
             pod_namespace: pod_namespace?,
+
+            dns_min_ttl: dns_min_ttl?,
         })
     }
 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -246,7 +246,6 @@ impl<'a> TryFrom<&'a Strings> for Config {
             Err(e) => Err(e),
         };
 
-
         Ok(Config {
             private_listener: Listener {
                 addr: private_listener_addr?

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use http;
 use indexmap::IndexSet;
+use trust_dns_resolver::config::ResolverOpts;
 
 use transport::{Host, HostAndPort, HostAndPortError};
 use convert::TryFrom;
@@ -208,6 +209,22 @@ const DEFAULT_PORTS_DISABLE_PROTOCOL_DETECTION: &[u16] = &[
 ];
 
 // ===== impl Config =====
+
+impl Config {
+    /// Modify a `trust-dns-resolver::config::ResolverOpts` to reflect
+    /// the configured minimum and maximum DNS TTL values.
+    pub fn configure_resolver_opts(&self, mut opts: ResolverOpts) -> ResolverOpts {
+        opts.min_positive_ttl = self.dns_min_ttl;
+        // TODO: When the Trust-DNS PR that adds support for maximum TTLs
+        //       is merged, use that as well.
+        // opts.positive_max_ttl = self.dns_max_ttl;
+        // TODO: Do we want to allow the positive and negative TTLs to be
+        //       configured separately?
+        opts.min_negative_ttl = self.dns_min_ttl;
+        // opts.negative_max_ttl = self.dns_max_ttl;
+        opts
+    }
+}
 
 impl<'a> TryFrom<&'a Strings> for Config {
     type Err = Error;

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -71,6 +71,9 @@ pub struct Config {
 
     /// Optional minimum TTL for DNS lookups.
     pub dns_min_ttl: Option<Duration>,
+
+    /// Optional maximum TTL for DNS lookups.
+    pub dns_max_ttl: Option<Duration>,
 }
 
 /// Configuration settings for binding a listener.
@@ -171,6 +174,10 @@ const ENV_RESOLV_CONF: &str = "CONDUIT_RESOLV_CONF";
 ///
 /// Lookups with TTLs below this value will use this value instead.
 const ENV_DNS_MIN_TTL: &str = "CONDUIT_PROXY_DNS_MIN_TTL";
+/// Configures a maximum value for the TTL of DNS lookups.
+///
+/// Lookups with TTLs above this value will use this value instead.
+const ENV_DNS_MAX_TTL: &str = "CONDUIT_PROXY_DNS_MAX_TTL";
 
 // Default values for various configuration fields
 const DEFAULT_EVENT_BUFFER_CAPACITY: usize = 10_000; // FIXME
@@ -227,6 +234,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let event_buffer_capacity = parse(strings, ENV_EVENT_BUFFER_CAPACITY, parse_number);
         let metrics_retain_idle = parse(strings, ENV_METRICS_RETAIN_IDLE, parse_duration);
         let dns_min_ttl = parse(strings, ENV_DNS_MIN_TTL, parse_duration);
+        let dns_max_ttl = parse(strings, ENV_DNS_MAX_TTL, parse_duration);
         let pod_namespace = strings.get(ENV_POD_NAMESPACE).and_then(|maybe_value| {
             // There cannot be a default pod namespace, and the pod namespace is required.
             maybe_value.ok_or_else(|| {
@@ -298,6 +306,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
             pod_namespace: pod_namespace?,
 
             dns_min_ttl: dns_min_ttl?,
+
+            dns_max_ttl: dns_max_ttl?,
         })
     }
 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -214,14 +214,12 @@ impl Config {
     /// Modify a `trust-dns-resolver::config::ResolverOpts` to reflect
     /// the configured minimum and maximum DNS TTL values.
     pub fn configure_resolver_opts(&self, mut opts: ResolverOpts) -> ResolverOpts {
-        opts.min_positive_ttl = self.dns_min_ttl;
-        // TODO: When the Trust-DNS PR that adds support for maximum TTLs
-        //       is merged, use that as well.
-        // opts.positive_max_ttl = self.dns_max_ttl;
+        opts.positive_min_ttl = self.dns_min_ttl;
+        opts.positive_max_ttl = self.dns_max_ttl;
         // TODO: Do we want to allow the positive and negative TTLs to be
         //       configured separately?
-        opts.min_negative_ttl = self.dns_min_ttl;
-        // opts.negative_max_ttl = self.dns_max_ttl;
+        opts.negative_min_ttl = self.dns_min_ttl;
+        opts.negative_max_ttl = self.dns_max_ttl;
         opts
     }
 }

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -27,6 +27,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use futures::{
     sync::mpsc,
@@ -139,6 +140,7 @@ pub trait Bind {
 /// to drive the background task.
 pub fn new(
     dns_resolver: dns::Resolver,
+    dns_min_ttl: Option<Duration>,
     default_destination_namespace: String,
     host_and_port: HostAndPort,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
@@ -147,6 +149,7 @@ pub fn new(
     let bg = background::task(
         rx,
         dns_resolver,
+        dns_min_ttl,
         default_destination_namespace,
         host_and_port,
     );

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -27,7 +27,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
 use futures::{
     sync::mpsc,
@@ -140,7 +139,6 @@ pub trait Bind {
 /// to drive the background task.
 pub fn new(
     dns_resolver: dns::Resolver,
-    dns_min_ttl: Option<Duration>,
     default_destination_namespace: String,
     host_and_port: HostAndPort,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
@@ -149,7 +147,6 @@ pub fn new(
     let bg = background::task(
         rx,
         dns_resolver,
-        dns_min_ttl,
         default_destination_namespace,
         host_and_port,
     );

--- a/proxy/src/dns.rs
+++ b/proxy/src/dns.rs
@@ -1,7 +1,7 @@
 use futures::prelude::*;
 use std::fmt;
 use std::net::IpAddr;
-use std::time::{Instant, Duration};
+use std::time::Instant;
 use tokio::timer::Delay;
 use transport;
 use trust_dns_resolver;
@@ -84,12 +84,12 @@ impl Resolver {
         }
     }
 
-    pub fn resolve_all_ips(&self, delay: Duration, host: &Name) -> IpAddrListFuture {
+    pub fn resolve_all_ips(&self, deadline: Instant, host: &Name) -> IpAddrListFuture {
         let name = host.clone();
         let name_clone = name.clone();
         trace!("resolve_all_ips {}", &name);
         let resolver = self.clone();
-        let f = Delay::new(Instant::now() + delay)
+        let f = Delay::new(deadline)
             .then(move |_| {
                 trace!("resolve_all_ips {} after delay", &name);
                 resolver.lookup_ip(&name)

--- a/proxy/src/dns.rs
+++ b/proxy/src/dns.rs
@@ -67,7 +67,13 @@ impl Resolver {
         Ok(Self::new(config, opts))
     }
 
-    pub fn new(config: ResolverConfig,  opts: ResolverOpts) -> Self {
+    pub fn new(config: ResolverConfig,  mut opts: ResolverOpts) -> Self {
+        // Disable Trust-DNS's caching.
+        // NOTE: testing the `lru-cache` crate that Trust-DNS depends on
+        //       to implement the LRU cache indicates that setting the
+        //       cache size to 0 is sufficient to prevent it from retaining
+        //       any entries.
+        opts.cache_size = 0;
         Resolver {
             config,
             opts,

--- a/proxy/src/dns.rs
+++ b/proxy/src/dns.rs
@@ -10,11 +10,12 @@ use trust_dns_resolver::{
     error::{ResolveError, ResolveErrorKind},
     lookup_ip::LookupIp,
     AsyncResolver,
+    BackgroundLookupIp,
 };
 
 use config::Config;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Resolver {
     resolver: AsyncResolver,
 }
@@ -29,13 +30,21 @@ pub enum Error {
     ResolutionFailed(ResolveError),
 }
 
+#[derive(Debug)]
 pub enum Response {
     Exists(LookupIp),
     DoesNotExist(Option<Instant>),
 }
 
-// `Box<Future>` implements `Future` so it doesn't need to be implemented manually.
-pub type IpAddrListFuture = Box<Future<Item=Response, Error=ResolveError> + Send>;
+pub struct IpAddrListFuture {
+    name: Name,
+    state: Option<State>,
+}
+
+enum State {
+    Delay { delay: Delay, lookup: BackgroundLookupIp },
+    Lookup(BackgroundLookupIp),
+}
 
 /// A DNS name.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -103,46 +112,17 @@ impl Resolver {
 
     pub fn resolve_all_ips(&self, deadline: Instant, host: &Name) -> IpAddrListFuture {
         let name = host.clone();
-        let name_clone = name.clone();
         trace!("resolve_all_ips {}", &name);
-        let resolver = self.clone();
-        let f = Delay::new(deadline)
-            .then(move |_| {
-                trace!("resolve_all_ips {} after delay", &name);
-                resolver.lookup_ip(&name)
-            })
-            .then(move |result| {
-                trace!("resolve_all_ips {}: completed with {:?}", name_clone, &result);
-                match result {
-                    Ok(ips) => Ok(Response::Exists(ips)),
-                    Err(e) => {
-                        if let &ResolveErrorKind::NoRecordsFound { valid_until, .. } = e.kind() {
-                            Ok(Response::DoesNotExist(valid_until))
-                        } else {
-                            Err(e)
-                        }
-                    }
-                }
-            });
-        Box::new(f)
+        let lookup = self.clone().lookup_ip(&name);
+        let delay = Delay::new(deadline);
+        IpAddrListFuture {
+            name,
+            state: Some(State::Delay { delay, lookup }),
+        }
     }
 
-    // `ResolverFuture` can only be used for one lookup, so we have to clone all
-    // the state during each resolution.
-    fn lookup_ip(self, &Name(ref name): &Name)
-        -> impl Future<Item = LookupIp, Error = ResolveError>
-    {
+    fn lookup_ip(self, &Name(ref name): &Name) -> BackgroundLookupIp {
         self.resolver.lookup_ip(name.as_str())
-    }
-}
-
-/// Note: `AsyncResolver` does not implement `Debug`, so we must manually
-///       implement this.
-impl fmt::Debug for Resolver {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Resolver")
-            .field("resolver", &"...")
-            .finish()
     }
 }
 
@@ -169,6 +149,67 @@ impl Future for IpAddrFuture {
                 Err(e) => Err(Error::ResolutionFailed(e)),
             },
             IpAddrFuture::Fixed(addr) => Ok(Async::Ready(addr)),
+        }
+    }
+}
+
+impl Future for IpAddrListFuture {
+    type Item = Response;
+    type Error = ResolveError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            match self.state.take().expect("state taken twice!") {
+                State::Delay { mut delay, lookup } => match delay.poll() {
+                    Ok(Async::Ready(())) => {
+                        trace!(
+                            "resolve_all_ips {}: looking up IP after delay",
+                            &self.name
+                        );
+                        self.state = Some(State::Lookup(lookup));
+                    },
+                    Err(e) => {
+                        warn!(
+                            "resolve_all_ips {}: timer failed ({:?}), \
+                             advancing to lookup anyway",
+                             self.name,
+                             e
+                            );
+                        self.state = Some(State::Lookup(lookup));
+                    },
+                    Ok(Async::NotReady) => {
+                        self.state = Some(State::Delay { delay, lookup });
+                        return Ok(Async::NotReady);
+                    },
+                },
+                State::Lookup(ref mut lookup) => {
+                    return match lookup.poll() {
+                        Ok(Async::NotReady) => Ok(Async::NotReady),
+                        Ok(Async::Ready(ips)) => {
+                            trace!(
+                                "resolve_all_ips {}: completed with {:?}",
+                                &self.name, ips
+                            );
+                            Ok(Async::Ready(Response::Exists(ips)))
+                        },
+                        Err(e) => if let &ResolveErrorKind::NoRecordsFound {
+                            valid_until, ..
+                        } = e.kind() {
+                            trace!(
+                                "resolve_all_ips {}: completed with {:?}",
+                                self.name, e
+                            );
+                            Ok(Async::Ready(Response::DoesNotExist(valid_until)))
+                        } else {
+                            warn!(
+                                "resolve_all_ips {}: failed with: {:?}",
+                                self.name, e
+                            );
+                            Err(e)
+                        }
+                    };
+                }
+            }
         }
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -211,7 +211,7 @@ where
             &taps,
         );
 
-        let dns_resolver = dns::Resolver::from_system_config()
+        let dns_resolver = dns::Resolver::from_system_config_and_env(&config)
             .unwrap_or_else(|e| {
                 // TODO: Make DNS configuration infallible.
                 panic!("invalid DNS configuration: {:?}", e);
@@ -219,7 +219,6 @@ where
 
         let (control, control_bg) = control::destination::new(
             dns_resolver.clone(),
-            config.dns_min_ttl,
             config.pod_namespace.clone(),
             control_host_and_port
         );

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -211,7 +211,7 @@ where
             &taps,
         );
 
-        let dns_resolver = dns::Resolver::from_system_config_and_env(&config)
+        let (dns_resolver, dns_bg) = dns::Resolver::from_system_config_and_env(&config)
             .unwrap_or_else(|e| {
                 // TODO: Make DNS configuration infallible.
                 panic!("invalid DNS configuration: {:?}", e);
@@ -298,10 +298,11 @@ where
                     let metrics_server = telemetry
                         .serve_metrics(metrics_listener);
 
-                    let fut = control_bg.join4(
+                    let fut = control_bg.join5(
                         server.map_err(|_| {}),
                         telemetry,
                         metrics_server.map_err(|_| {}),
+                        dns_bg,
                     ).map(|_| {});
                     let fut = ::logging::context_future("controller-client", fut);
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -219,6 +219,7 @@ where
 
         let (control, control_bg) = control::destination::new(
             dns_resolver.clone(),
+            config.dns_min_ttl,
             config.pod_namespace.clone(),
             control_host_and_port
         );


### PR DESCRIPTION
Depends on #1032 (and therefore also #974).

This PR refactors the proxy's `dns` module to avoid `Box`ing `Future`s, by
replacing `IpAddrListFuture` with a custom `struct` implementing `Future` 
(rather than chaining combinators). It should not change any behaviour.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>