### PR TITLE
proxy: Add rich logging contexts

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -134,7 +134,7 @@ pub type HttpRequest<B> = http::Request<sensor::http::RequestBody<B>>;
 
 pub type Client<B> = transparency::Client<
     sensor::Connect<transport::Connect>,
-    ::logging::ContextualExecutor<BindCtx>,
+    ::logging::ContextualExecutor<Log>,
     B,
 >;
 
@@ -150,12 +150,12 @@ impl fmt::Display for BufferSpawnError {
     }
 }
 
-pub struct BindCtx {
+pub struct Log {
     ctx: Arc<ctx::transport::Client>,
     protocol: Protocol,
 }
 
-impl fmt::Display for BindCtx {
+impl fmt::Display for Log {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{")?;
 
@@ -246,7 +246,7 @@ where
         let client = transparency::Client::new(
             protocol,
             connect,
-            ::logging::context_executor(BindCtx {
+            ::logging::context_executor(Log {
                 ctx: client_ctx.clone(),
                 protocol: protocol.clone(),
             })

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -470,7 +470,6 @@ where
     }
 
     fn call(&mut self, request: Self::Request) -> Self::Future {
-        debug!("call");
         match self.binding {
             Binding::Bound(ref mut svc) => svc.call(request),
             Binding::BindsPerRequest { ref mut next } => {

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -155,8 +155,8 @@ pub struct BindCtx {
     protocol: Protocol,
 }
 
-impl ::logging::LogCtx for BindCtx {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for BindCtx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{")?;
 
         if self.ctx.proxy.is_inbound() {

--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -550,14 +550,9 @@ fn pb_to_addr_meta(
     set_labels: &HashMap<String, String>,
 ) -> Option<(SocketAddr, Metadata)> {
     let addr = pb.addr.and_then(pb_to_sock_addr)?;
-
-    let mut labels = set_labels.iter()
-        .chain(pb.metric_labels.iter())
-        .collect::<Vec<_>>();
-    labels.sort_by(|(k0, _), (k1, _)| k0.cmp(k1));
-
+    let label_iter = set_labels.iter().chain(pb.metric_labels.iter());
     let meta = Metadata {
-        metric_labels: DstLabels::new(labels.into_iter()),
+        metric_labels: DstLabels::new(label_iter),
     };
     Some((addr, meta))
 }

--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -609,10 +609,10 @@ fn pb_to_sock_addr(pb: TcpAddress) -> Option<SocketAddr> {
     }
 }
 
-impl ::logging::LogCtx for Ctx {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for Ctx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{controller=")?;
-        ::logging::LogCtx::fmt(&self.0, f)?;
+        fmt::Display::fmt(&self.0, f)?;
         write!(f, "}}")
     }
 }

--- a/proxy/src/control/mod.rs
+++ b/proxy/src/control/mod.rs
@@ -47,7 +47,7 @@ impl<S> Backoff<S> {
 impl<S> Service for Backoff<S>
 where
     S: Service,
-    S::Error: ::std::fmt::Debug,
+    S::Error: fmt::Debug,
 {
     type Request = S::Request;
     type Response = S::Response;

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -89,8 +89,11 @@ where
         let endpoint = (*addr).into();
         let binding = self.bind.bind_service(&endpoint, proto);
 
-        let ctx = Ctx { addr: *addr, protocol: proto.clone() };
-        Buffer::new(binding, &::logging::context_executor(ctx))
+        let executor = ::logging::context_executor(Log {
+            addr: *addr,
+            protocol: proto.clone()
+        });
+        Buffer::new(binding, &executor)
             .map(|buffer| {
                 InFlightLimit::new(buffer, MAX_IN_FLIGHT)
             })
@@ -98,12 +101,12 @@ where
     }
 }
 
-struct Ctx {
+struct Log {
     addr: SocketAddr,
     protocol: bind::Protocol
 }
 
-impl fmt::Display for Ctx {
+impl fmt::Display for Log {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{proxy=in;proto={:?};dst={:?}}}", self.protocol, self.addr)
     }

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -108,7 +108,7 @@ struct Log {
 
 impl fmt::Display for Log {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "client={{proxy=in;proto={:?};dst={:?}}}", self.protocol, self.addr)
+        write!(f, "client={{proxy=in;proto={:?};dst={}}}", self.protocol, self.addr)
     }
 }
 

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::net::{SocketAddr};
 use std::sync::Arc;
 
@@ -102,8 +103,8 @@ struct Ctx {
     protocol: bind::Protocol
 }
 
-impl ::logging::LogCtx for Ctx {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for Ctx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{proxy=in;proto={:?};dst={:?}}}", self.protocol, self.addr)
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -419,6 +419,7 @@ where
         (),
         move |(), (connection, remote_addr)| {
             let s = server.serve(connection, remote_addr);
+            // Logging context is configured by the server.
             let r = DefaultExecutor::current()
                 .spawn(Box::new(s))
                 .map_err(task::Error::into_io);

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -226,7 +226,7 @@ pub struct Client<C: fmt::Display, D: fmt::Display> {
 }
 
 #[derive(Clone)]
-pub struct Bg<> {
+pub struct Bg {
     section: Section,
     name: &'static str,
 }

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -338,10 +338,6 @@ impl<C: fmt::Display, D: fmt::Display> Client<C, D> {
     pub fn executor(self) -> ClientExecutor<C, D> {
         context_executor(self)
     }
-
-    // pub fn future<F: Future>(self, f: F) -> ContextualFuture<Self, F> {
-    //     context_future(self, f)
-    // }
 }
 
 impl<C: fmt::Display, D: fmt::Display> fmt::Display for Client<C, D> {

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -157,8 +157,7 @@ impl<'a> fmt::Display for Context<'a> {
         for item in self.0 {
             // See `fn context()` for comments about this unsafe.
             let item = unsafe { &**item };
-            item.fmt(f)?;
-            f.write_str(", ")?;
+            write!(f, "{} ", item)?;
         }
         Ok(())
     }
@@ -208,6 +207,7 @@ pub enum Section {
     Admin,
 }
 
+/// A utility for logging actions taken on behalf of a server task.
 #[derive(Clone)]
 pub struct Server {
     section: Section,
@@ -216,6 +216,7 @@ pub struct Server {
     remote: Option<SocketAddr>,
 }
 
+/// A utility for logging actions taken on behalf of a client task.
 #[derive(Clone)]
 pub struct Client<C: fmt::Display, D: fmt::Display> {
     section: Section,
@@ -225,6 +226,7 @@ pub struct Client<C: fmt::Display, D: fmt::Display> {
     remote: Option<SocketAddr>,
 }
 
+/// A utility for logging actions taken on behalf of a background task.
 #[derive(Clone)]
 pub struct Bg {
     section: Section,

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -59,7 +59,7 @@ pub fn context_future<T: fmt::Display, F>(context: T, future: F) -> ContextualFu
     }
 }
 
-/// Wrap an `Executor` to spawn futures that have a reference to the `Display`
+/// Wrap `task::LazyExecutor` to spawn futures that have a reference to the `Display`
 /// value, inserting it into all logs created by this future.
 pub fn context_executor<T: fmt::Display>(context: T) -> ContextualExecutor<T> {
     ContextualExecutor {

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -303,9 +303,9 @@ impl Server {
 
 impl fmt::Display for Server {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}={{server={};listen={}", self.section, self.name, self.listen)?;
+        write!(f, "{}={{server={} listen={}", self.section, self.name, self.listen)?;
         if let Some(remote) = self.remote {
-            write!(f, ";remote={}", remote)?;
+            write!(f, " remote={}", remote)?;
         }
         write!(f, "}}")
     }
@@ -344,12 +344,12 @@ impl<C: fmt::Display, D: fmt::Display> Client<C, D> {
 
 impl<C: fmt::Display, D: fmt::Display> fmt::Display for Client<C, D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}={{client={};dst={}", self.section, self.client, self.dst)?;
+        write!(f, "{}={{client={} dst={}", self.section, self.client, self.dst)?;
         if let Some(ref proto) = self.protocol {
-            write!(f, ";proto={:?}", proto)?;
+            write!(f, " proto={:?}", proto)?;
         }
         if let Some(remote) = self.remote {
-            write!(f, ";remote={}", remote)?;
+            write!(f, " remote={}", remote)?;
         }
         write!(f, "}}")
     }

--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -29,10 +29,10 @@ pub fn init() {
                 };
                 writeln!(
                    fmt,
-                    "{} {} {}{}",
+                    "{} {}{} {}",
                     level,
-                    record.target(),
                     Context(&ctxt.borrow()),
+                    record.target(),
                     record.args()
                 )
             })

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -154,8 +154,11 @@ where
         // `rand::thread_rng()` when it is *used*.
         let balance = tower_balance::power_of_two_choices(loaded, LazyThreadRng);
 
-        let ctx = Ctx { dest: dest.clone(), protocol: protocol.clone() };
-        let buffer = Buffer::new(balance, &::logging::context_executor(ctx))
+        let executor = ::logging::context_executor(Log {
+            dest: dest.clone(),
+            protocol: protocol.clone()
+        });
+        let buffer = Buffer::new(balance, &executor)
             .map_err(|_| bind::BufferSpawnError::Outbound)?;
 
         let timeout = Timeout::new(buffer, self.bind_timeout);
@@ -231,13 +234,13 @@ impl error::Error for BindError {
     fn cause(&self) -> Option<&error::Error> { None }
 }
 
-pub struct Ctx {
+struct Log {
     dest: Destination,
     protocol: bind::Protocol
 }
 
 
-impl fmt::Display for Ctx {
+impl fmt::Display for Log {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{proxy=out;proto={:?};dst={:?}}}", self.protocol, self.dest)
     }

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -237,8 +237,8 @@ pub struct Ctx {
 }
 
 
-impl ::logging::LogCtx for Ctx {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for Ctx {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "client={{proxy=out;proto={:?};dst={:?}}}", self.protocol, self.dest)
     }
 }

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -242,6 +242,15 @@ struct Log {
 
 impl fmt::Display for Log {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "client={{proxy=out;proto={:?};dst={:?}}}", self.protocol, self.dest)
+        write!(f, "client={{proxy=out;proto={:?}", self.protocol)?;
+        match self.dest {
+            Destination::Hostname(ref name) => {
+                write!(f, ";dst={{host={}:{}}}", name.host, name.port)?;
+            }
+            Destination::ImplicitOriginalDst(ref addr) => {
+                write!(f, ";dst={{orig={}}}", addr)?;
+            }
+        }
+        write!(f, "}}")
     }
 }

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -232,8 +232,8 @@ pub struct AcceptInfo {
 
 pub struct ServeInfo(Arc<ServerCtx>);
 
-impl ::logging::LogCtx for AcceptInfo {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for AcceptInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "server={{")?;
         if self.ctx.is_inbound() {
             write!(f, "proxy=in")?;
@@ -245,8 +245,8 @@ impl ::logging::LogCtx for AcceptInfo {
     }
 }
 
-impl ::logging::LogCtx for ServeInfo {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for ServeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "server={{")?;
         if self.0.proxy.is_inbound() {
             write!(f, "proxy=in")?;

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -1,7 +1,7 @@
 use futures::Future;
 use tokio_connect;
 
-use std::io;
+use std::{fmt, io};
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
@@ -75,6 +75,19 @@ impl<'a> From<&'a HostAndPort> for http::uri::Authority {
             Host::Ip(ref ip) => format!("{}:{}", ip, a.port),
         };
         http::uri::Authority::from_str(&s).unwrap()
+    }
+}
+
+impl fmt::Display for HostAndPort {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.host {
+            Host::DnsName(ref dns) => {
+                write!(f, "{}:{}", dns, self.port)
+            }
+            Host::Ip(ref ip) => {
+                write!(f, "{}:{}", ip, self.port)
+            }
+        }
     }
 }
 

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -1,7 +1,7 @@
 use futures::Future;
 use tokio_connect;
 
-use std::{fmt, io};
+use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
@@ -75,22 +75,6 @@ impl<'a> From<&'a HostAndPort> for http::uri::Authority {
             Host::Ip(ref ip) => format!("{}:{}", ip, a.port),
         };
         http::uri::Authority::from_str(&s).unwrap()
-    }
-}
-
-impl fmt::Display for HostAndPort {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{")?;
-        match self.host {
-            Host::DnsName(ref dns) => {
-                write!(f, "dns={}", dns)?;
-            }
-            Host::Ip(ref ip) => {
-                write!(f, "ip={}", ip)?;
-            }
-        }
-        write!(f, ";port={}", self.port)?;
-        write!(f, "}}")
     }
 }
 

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -1,7 +1,7 @@
 use futures::Future;
 use tokio_connect;
 
-use std::io;
+use std::{fmt, io};
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
@@ -78,8 +78,8 @@ impl<'a> From<&'a HostAndPort> for http::uri::Authority {
     }
 }
 
-impl ::logging::LogCtx for HostAndPort {
-    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+impl fmt::Display for HostAndPort {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{")?;
         match self.host {
             Host::DnsName(ref dns) => {

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -78,6 +78,22 @@ impl<'a> From<&'a HostAndPort> for http::uri::Authority {
     }
 }
 
+impl ::logging::LogCtx for HostAndPort {
+    fn fmt(&self, f: &mut ::logging::Formatter) -> ::logging::Result {
+        write!(f, "{{")?;
+        match self.host {
+            Host::DnsName(ref dns) => {
+                write!(f, "dns={}", dns)?;
+            }
+            Host::Ip(ref ip) => {
+                write!(f, "ip={}", ip)?;
+            }
+        }
+        write!(f, ";port={}", self.port)?;
+        write!(f, "}}")
+    }
+}
+
 // ===== impl Connect =====
 
 impl Connect {


### PR DESCRIPTION
While debugging proxy issues, I found it necessary to change how logging contexts are instrumented, especially for clients.

This change moves away from using `Debug` types to force us to implement LogCtx explicitly.  Some further testing and cleanup is needed before this could merge, but I'm sharing it in hopes of getting early feedback.