### PR TITLE
proxy: Fix bench tests and require bench tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     - language: rust
       # Run proxy benchmarks in development mode. Requires nightly.
       # Failures are not fatal.
-      rust: nightly
+      rust: nightly-2018-05-26
       cache: cargo
       script:
         - (cd proxy && cargo test --benches --locked --no-default-features)
@@ -143,9 +143,12 @@ jobs:
         - target/cli/linux/conduit install --conduit-version=$CONDUIT_TAG |tee conduit.yml
         - kubectl -n conduit apply -f conduit.yml --prune --selector='conduit.io/control-plane-component'
 
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
+  # If we want to start building everything against bleeding-edge Rust nightly, we'll have
+  # to enable:
+  #
+  # allow_failures:
+  #   - rust: nightly
+  # fast_finish: true
 
 notifications:
   email:

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -39,8 +39,6 @@ prost-types = "0.3.0"
 
 trust-dns-resolver = { default-features = false, git = "https://github.com/bluejekyll/trust-dns", branch = "master" }
 
-#futures-watch   = { git = "https://github.com/carllerche/better-future" }
-
 tokio-connect         = { git = "https://github.com/carllerche/tokio-connect" }
 tower-service         = { git = "https://github.com/tower-rs/tower" }
 tower-balance         = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -2,7 +2,6 @@
 #![deny(warnings)]
 
 extern crate conduit_proxy;
-extern crate futures_watch;
 extern crate http;
 extern crate test;
 
@@ -44,8 +43,7 @@ where
     L: IntoIterator<Item=(S, S)>,
     S: fmt::Display,
 {
-    let (labels_watch, _store) = futures_watch::Watch::new(metrics::DstLabels::new(labels));
-    ctx::transport::Client::new(&proxy, &addr(), Some(labels_watch))
+    ctx::transport::Client::new(&proxy, &addr(), metrics::DstLabels::new(labels))
 }
 
 fn request(


### PR DESCRIPTION
commit b197d7ba2eb847380347c03297311bd027b3a537
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed May 30 02:13:18 2018 +0000

    proxy: Fix bench tests
    
    b3170af changed the DstLabels api, but the bench test was not updated
    accordingly.
    
    This updates the benches/record.rs

commit 8ca8207bbfab36c827a0615a267f5a4665dd6f8f
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed May 30 02:25:36 2018 +0000

    travis: Make proxy bench tests fatal
    
    Since bench tests require a nightly rust version, we've avoided running
    them in CI. This makes it easy for these tests to break, however.
    
    If we pin the nightly version to a known-good version, we can reliably
    run these test without the fear of external changes breaking our build.