### PR TITLE
Add rule for protobuf files in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,7 @@ indent_style = space
 
 [*.yml]
 indent_size = 2
+
+[*.proto]
+indent_size = 2
+indent_stlye = space


### PR DESCRIPTION
This PR adds an editorconfig rule for `.proto` files indicating that they
should be indented with two spaces. This will prevent problems like
https://github.com/runconduit/conduit/pull/1041#discussion_r191930197
from happening again.