### PR TITLE
web: Update service mesh overview to include grafana

### DIFF
--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -86,6 +86,7 @@ const namespacesColumns = ConduitLink => [
 
 const componentNames = {
   "prometheus":   "Prometheus",
+  "grafana":      "Grafana",
   "destination":  "Destination",
   "proxy-api":    "Proxy API",
   "public-api":   "Public API",
@@ -95,6 +96,7 @@ const componentNames = {
 
 const componentDeploys = {
   "prometheus":   "prometheus",
+  "grafana":      "grafana",
   "destination":  "controller",
   "proxy-api":    "controller",
   "public-api":   "controller",


### PR DESCRIPTION
Grafana was missing from the service mesh overview page. This branch adds it, and it looks like this:

![screen shot 2018-05-31 at 2 31 23 pm](https://user-images.githubusercontent.com/9226/40809648-0e160e26-64e0-11e8-840a-a0420492b009.png)

Fixes #1011