### PR TITLE
proxy: Add `tls="true"` metric label to connections accepted with TLS

### DIFF
--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -36,7 +36,7 @@ fn process() -> Arc<ctx::Process> {
 }
 
 fn server(proxy: &Arc<ctx::Proxy>) -> Arc<ctx::transport::Server> {
-    ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()))
+    ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), false)
 }
 
 fn client<L, S>(proxy: &Arc<ctx::Proxy>, labels: L) -> Arc<ctx::transport::Client>
@@ -49,6 +49,7 @@ where
         &addr(),
         destination::Metadata::new(metrics::DstLabels::new(labels), None),
     )
+    ctx::transport::Client::new(&proxy, &addr(), metrics::DstLabels::new(labels), false)
 }
 
 fn request(

--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -36,7 +36,10 @@ fn process() -> Arc<ctx::Process> {
 }
 
 fn server(proxy: &Arc<ctx::Proxy>) -> Arc<ctx::transport::Server> {
-    ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), false)
+    ctx::transport::Server::new(
+        &proxy, &addr(), &addr(), &Some(addr()),
+        ctx::transport::TlsStatus::Disabled,
+    )
 }
 
 fn client<L, S>(proxy: &Arc<ctx::Proxy>, labels: L) -> Arc<ctx::transport::Client>
@@ -48,7 +51,7 @@ where
         &proxy,
         &addr(),
         destination::Metadata::new(metrics::DstLabels::new(labels), None),
-        false
+        ctx::transport::TlsStatus::Disabled,
     )
 }
 

--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -48,8 +48,8 @@ where
         &proxy,
         &addr(),
         destination::Metadata::new(metrics::DstLabels::new(labels), None),
+        false
     )
-    ctx::transport::Client::new(&proxy, &addr(), metrics::DstLabels::new(labels), false)
 }
 
 fn request(

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -209,6 +209,9 @@ where
             &self.ctx,
             &addr,
             ep.metadata().clone(),
+            // TODO: when we can use TLS for client connections, indicate
+            //       whether or not the connection was TLS here.
+            false,
         );
 
         // Map a socket address to a connection.

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -211,7 +211,7 @@ where
             ep.metadata().clone(),
             // TODO: when we can use TLS for client connections, indicate
             //       whether or not the connection was TLS here.
-            false,
+            ctx::transport::TlsStatus::Disabled,
         );
 
         // Map a socket address to a connection.

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -145,8 +145,7 @@ impl BoundPort {
                         if let Some(config) = &*config_watch.borrow() {
                             let f = tls::Connection::accept(socket, config.clone())
                                 .map(move |tls| {
-                                    let conn = Connection::new(tls, TlsStatus::Success);
-                                    (conn, remote_addr)
+                                    (Connection::tls(tls), remote_addr)
                                 });
                             return Either::A(f);
                         } else {
@@ -196,6 +195,14 @@ impl Connection {
             io: Box::new(io),
             peek_buf: BytesMut::new(),
             tls_status,
+        }
+    }
+
+    fn tls(tls: tls::Connection) -> Self {
+            Connection {
+            io: Box::new(tls),
+            peek_buf: BytesMut::new(),
+            tls_status: TlsStatus::Success,
         }
     }
 

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -150,7 +150,8 @@ impl BoundPort {
                                 });
                             return Either::A(f);
                         } else {
-                            TlsStatus::Disabled
+                            // No valid TLS configuration.
+                            TlsStatus::NoConfig
                         }
                     } else {
                         TlsStatus::Disabled

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -22,11 +22,19 @@ pub struct BoundPort {
 
 /// Initiates a client connection to the given address.
 pub fn connect(addr: &SocketAddr) -> Connecting {
-    Connecting(PlaintextSocket::connect(addr))
+    Connecting {
+        inner: PlaintextSocket::connect(addr),
+        // TODO: when we can open TLS client connections, this is where we will
+        //       indicate that for telemetry.
+        is_tls: false,
+    }
 }
 
 /// A socket that is in the process of connecting.
-pub struct Connecting(ConnectFuture);
+pub struct Connecting {
+    inner: ConnectFuture,
+    is_tls: bool,
+}
 
 /// Abstracts a plaintext socket vs. a TLS decorated one.
 ///
@@ -44,6 +52,9 @@ pub struct Connection {
     /// When calling `read`, it's important to consume bytes from this buffer
     /// before calling `io.read`.
     peek_buf: BytesMut,
+
+    /// Whether or not the connection is secured with TLS.
+    is_tls: bool,
 }
 
 /// A trait describing that a type can peek bytes.
@@ -133,11 +144,11 @@ impl BoundPort {
                         if let Some(config) = &*config_watch.borrow() {
                             return Either::A(
                                 tls::Connection::accept(socket, config.clone())
-                                    .map(move |tls| (Connection::new(Box::new(tls)), remote_addr)));
+                                    .map(move |tls| (Connection::new(Box::new(tls), true), remote_addr)));
                         }
                     }
 
-                    Either::B(future::ok((Connection::new(Box::new(socket)), remote_addr)))
+                    Either::B(future::ok((Connection::new(Box::new(socket), false), remote_addr)))
                 })
                 .then(|r| {
                     future::ok(match r {
@@ -162,9 +173,9 @@ impl Future for Connecting {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let socket = try_ready!(self.0.poll());
+        let socket = try_ready!(self.inner.poll());
         set_nodelay_or_warn(&socket);
-        Ok(Async::Ready(Connection::new(Box::new(socket))))
+        Ok(Async::Ready(Connection::new(Box::new(socket), self.is_tls)))
     }
 }
 
@@ -172,10 +183,11 @@ impl Future for Connecting {
 
 impl Connection {
     /// A constructor of `Connection` with a plain text TCP socket.
-    fn new(io: Box<Io>) -> Self {
+    fn new(io: Box<Io>, is_tls: bool) -> Self {
         Connection {
             io,
             peek_buf: BytesMut::new(),
+            is_tls,
         }
     }
 
@@ -185,6 +197,10 @@ impl Connection {
 
     pub fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
         self.io.local_addr()
+    }
+
+    pub fn is_tls(&self) -> bool {
+        self.is_tls
     }
 }
 

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -80,6 +80,19 @@ impl Request {
         self.client.tls_identity()
     }
 
+    /// Returns `true` if the request was secured with TLS.
+    pub fn is_tls(&self) -> bool {
+        if self.server.proxy.is_outbound() {
+            // If the request is in the outbound direction, then we opened the
+            // client connection, so check if it was secured.
+            self.client.is_tls
+        } else {
+            // Otherwise, the request is inbound, so check if we accepted it
+            // over TLS.
+            self.server.is_tls
+        }
+    }
+
     pub fn dst_labels(&self) -> Option<&DstLabels> {
         self.client.dst_labels()
     }
@@ -93,6 +106,11 @@ impl Response {
         };
 
         Arc::new(r)
+    }
+
+    /// Returns `true` if the response was secured with TLS.
+    pub fn is_tls(&self) -> bool {
+        self.request.is_tls()
     }
 
     pub fn dst_labels(&self) -> Option<&DstLabels> {

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -80,7 +80,7 @@ impl Request {
         self.client.tls_identity()
     }
 
-    /// Returns `true` if the request was secured with TLS.
+    /// Returns a `TlsStatus` indicating if the request was sent was over TLS.
     pub fn tls_status(&self) -> ctx::transport::TlsStatus {
         if self.server.proxy.is_outbound() {
             // If the request is in the outbound direction, then we opened the
@@ -108,7 +108,7 @@ impl Response {
         Arc::new(r)
     }
 
-    /// Returns `true` if the response was secured with TLS.
+    /// Returns a `TlsStatus` indicating if the response was sent was over TLS.
     pub fn tls_status(&self) -> ctx::transport::TlsStatus {
         self.request.tls_status()
     }

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -81,15 +81,15 @@ impl Request {
     }
 
     /// Returns `true` if the request was secured with TLS.
-    pub fn is_tls(&self) -> bool {
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
         if self.server.proxy.is_outbound() {
             // If the request is in the outbound direction, then we opened the
             // client connection, so check if it was secured.
-            self.client.is_tls
+            self.client.tls_status
         } else {
             // Otherwise, the request is inbound, so check if we accepted it
             // over TLS.
-            self.server.is_tls
+            self.server.tls_status
         }
     }
 
@@ -109,8 +109,8 @@ impl Response {
     }
 
     /// Returns `true` if the response was secured with TLS.
-    pub fn is_tls(&self) -> bool {
-        self.request.is_tls()
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
+        self.request.tls_status()
     }
 
     pub fn dst_labels(&self) -> Option<&DstLabels> {

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -100,17 +100,21 @@ pub mod test_util {
         })
     }
 
-    pub fn server(proxy: &Arc<ctx::Proxy>) -> Arc<ctx::transport::Server> {
-        ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), false)
+    pub fn server(proxy: &Arc<ctx::Proxy>, tls: bool) -> Arc<ctx::transport::Server> {
+        ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), tls)
     }
 
-    pub fn client<L, S>(proxy: &Arc<ctx::Proxy>, labels: L) -> Arc<ctx::transport::Client>
+    pub fn client<L, S>(
+        proxy: &Arc<ctx::Proxy>,
+        labels: L,
+        tls: bool,
+    ) -> Arc<ctx::transport::Client>
     where
         L: IntoIterator<Item=(S, S)>,
         S: fmt::Display,
     {
         let meta = destination::Metadata::new(DstLabels::new(labels), None);
-        ctx::transport::Client::new(&proxy, &addr(), meta, false)
+        ctx::transport::Client::new(&proxy, &addr(), meta, tls)
     }
 
     pub fn request(

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -101,7 +101,7 @@ pub mod test_util {
     }
 
     pub fn server(proxy: &Arc<ctx::Proxy>) -> Arc<ctx::transport::Server> {
-        ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()))
+        ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), false)
     }
 
     pub fn client<L, S>(proxy: &Arc<ctx::Proxy>, labels: L) -> Arc<ctx::transport::Client>

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -110,7 +110,7 @@ pub mod test_util {
         S: fmt::Display,
     {
         let meta = destination::Metadata::new(DstLabels::new(labels), None);
-        ctx::transport::Client::new(&proxy, &addr(), meta)
+        ctx::transport::Client::new(&proxy, &addr(), meta, false)
     }
 
     pub fn request(

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -100,14 +100,17 @@ pub mod test_util {
         })
     }
 
-    pub fn server(proxy: &Arc<ctx::Proxy>, tls: bool) -> Arc<ctx::transport::Server> {
+    pub fn server(
+        proxy: &Arc<ctx::Proxy>,
+        tls: ctx::transport::TlsStatus
+    ) -> Arc<ctx::transport::Server> {
         ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), tls)
     }
 
     pub fn client<L, S>(
         proxy: &Arc<ctx::Proxy>,
         labels: L,
-        tls: bool,
+        tls: ctx::transport::TlsStatus,
     ) -> Arc<ctx::transport::Client>
     where
         L: IntoIterator<Item=(S, S)>,

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -28,6 +28,7 @@ pub struct Client {
     pub proxy: Arc<ctx::Proxy>,
     pub remote: SocketAddr,
     pub metadata: destination::Metadata,
+    pub is_tls: bool,
 }
 
 impl Ctx {
@@ -87,11 +88,13 @@ impl Client {
         proxy: &Arc<ctx::Proxy>,
         remote: &SocketAddr,
         metadata: destination::Metadata,
+        is_tls: bool,
     ) -> Arc<Client> {
         let c = Client {
             proxy: Arc::clone(proxy),
             remote: *remote,
             metadata,
+            is_tls,
         };
 
         Arc::new(c)
@@ -105,7 +108,6 @@ impl Client {
         self.metadata.dst_labels()
     }
 }
-
 impl From<Arc<Client>> for Ctx {
     fn from(c: Arc<Client>) -> Self {
         Ctx::Client(c)

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -19,6 +19,7 @@ pub struct Server {
     pub remote: SocketAddr,
     pub local: SocketAddr,
     pub orig_dst: Option<SocketAddr>,
+    pub is_tls: bool,
 }
 
 /// Identifies a connection from the proxy to another process.
@@ -44,12 +45,14 @@ impl Server {
         local: &SocketAddr,
         remote: &SocketAddr,
         orig_dst: &Option<SocketAddr>,
+        is_tls: bool,
     ) -> Arc<Server> {
         let s = Server {
             proxy: Arc::clone(proxy),
             local: *local,
             remote: *remote,
             orig_dst: *orig_dst,
+            is_tls,
         };
 
         Arc::new(s)

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -38,6 +38,13 @@ impl Ctx {
             Ctx::Server(ref ctx) => &ctx.proxy,
         }
     }
+
+    pub fn is_tls(&self) -> bool {
+        match *self {
+            Ctx::Client(ref ctx) => ctx.is_tls,
+            Ctx::Server(ref ctx) => ctx.is_tls,
+        }
+    }
 }
 
 impl Server {

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -32,7 +32,7 @@ pub struct Client {
 }
 
 /// Identifies whether or not a connection was secured with TLS,
-/// and the reason why not.
+/// and, if it was not, the reason why.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum TlsStatus {
     /// The TLS handshake was successful.
@@ -42,6 +42,8 @@ pub enum TlsStatus {
     /// TLS was enabled for this connection, but we have no valid
     /// config.
     NoConfig,
+    // TODO: When the proxy falls back to plaintext on handshake
+    // failures, we'll want to add a variant for that here as well.
 }
 
 impl Ctx {
@@ -53,9 +55,9 @@ impl Ctx {
     }
 
     pub fn tls_status(&self) -> TlsStatus {
-        match *self {
-            Ctx::Client(ref ctx) => ctx.tls_status,
-            Ctx::Server(ref ctx) => ctx.tls_status,
+        match self {
+            Ctx::Client(ctx)  => ctx.tls_status,
+            Ctx::Server(ctx) => ctx.tls_status,
         }
     }
 }

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -39,8 +39,9 @@ pub enum TlsStatus {
     Success,
     /// TLS was not enabled for this connection.
     Disabled,
-    // TODO: Add `NoConfig` variant for when TLS was enabled,
-    // but we had no valid configuration.
+    /// TLS was enabled for this connection, but we have no valid
+    /// config.
+    NoConfig,
 }
 
 impl Ctx {

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -133,7 +133,9 @@ mod tests {
 
             let inbound = new_inbound(None, &ctx);
 
-            let srv_ctx = ctx::transport::Server::new(&ctx, &local, &remote, &Some(orig_dst));
+            let srv_ctx = ctx::transport::Server::new(
+                &ctx, &local, &remote, &Some(orig_dst), false,
+            );
 
             let rec = srv_ctx.orig_dst_if_not_local().map(make_key_http1);
 
@@ -160,6 +162,7 @@ mod tests {
                     &local,
                     &remote,
                     &None,
+                    false,
                 ));
 
             inbound.recognize(&req) == default.map(make_key_http1)
@@ -191,6 +194,7 @@ mod tests {
                     &local,
                     &remote,
                     &Some(local),
+                    false,
                 ));
 
             inbound.recognize(&req) == default.map(make_key_http1)

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -134,7 +134,8 @@ mod tests {
             let inbound = new_inbound(None, &ctx);
 
             let srv_ctx = ctx::transport::Server::new(
-                &ctx, &local, &remote, &Some(orig_dst), false,
+                &ctx, &local, &remote, &Some(orig_dst),
+                ctx::transport::TlsStatus::Disabled,
             );
 
             let rec = srv_ctx.orig_dst_if_not_local().map(make_key_http1);
@@ -162,7 +163,7 @@ mod tests {
                     &local,
                     &remote,
                     &None,
-                    false,
+                    ctx::transport::TlsStatus::Disabled,
                 ));
 
             inbound.recognize(&req) == default.map(make_key_http1)
@@ -194,7 +195,7 @@ mod tests {
                     &local,
                     &remote,
                     &Some(local),
-                    false,
+                    ctx::transport::TlsStatus::Disabled,
                 ));
 
             inbound.recognize(&req) == default.map(make_key_http1)

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -104,6 +104,11 @@ impl RequestLabels {
             is_tls: req.is_tls(),
         }
     }
+
+    #[cfg(test)]
+    pub fn is_tls(&self) -> bool {
+        self.is_tls
+    }
 }
 
 impl fmt::Display for RequestLabels {
@@ -155,6 +160,11 @@ impl ResponseLabels {
             grpc_status_code: None,
             classification: Classification::Failure,
         }
+    }
+
+    #[cfg(test)]
+    pub fn is_tls(&self) -> bool {
+        self.request_labels.is_tls
     }
 }
 
@@ -315,6 +325,11 @@ impl TransportLabels {
             is_tls: ctx.is_tls(),
         }
     }
+
+    #[cfg(test)]
+    pub fn is_tls(&self) -> bool {
+        self.is_tls
+    }
 }
 
 impl fmt::Display for TransportLabels {
@@ -343,6 +358,11 @@ impl TransportCloseLabels {
             transport: TransportLabels::new(ctx),
             classification: Classification::transport_close(close),
         }
+    }
+
+    #[cfg(test)]
+    pub fn is_tls(&self) -> bool {
+        self.transport.is_tls()
     }
 }
 

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -23,7 +23,7 @@ pub struct RequestLabels {
     authority: Option<http::uri::Authority>,
 
     /// Whether or not the request was made over TLS.
-    is_tls: bool,
+    tls_status: ctx::transport::TlsStatus,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -51,7 +51,7 @@ pub struct TransportLabels {
     peer: Peer,
 
     /// Was the transport secured with TLS?
-    is_tls: bool,
+    tls_status: ctx::transport::TlsStatus,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -101,13 +101,13 @@ impl RequestLabels {
             direction,
             outbound_labels,
             authority,
-            is_tls: req.is_tls(),
+            tls_status: req.tls_status(),
         }
     }
 
     #[cfg(test)]
-    pub fn is_tls(&self) -> bool {
-        self.is_tls
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
+        self.tls_status
     }
 }
 
@@ -126,7 +126,9 @@ impl fmt::Display for RequestLabels {
             write!(f, ",{}", outbound)?;
         }
 
-        if self.is_tls {
+        if self.tls_status == ctx::transport::TlsStatus::Success {
+            // TODO: Handle status variant for `NoConfig` when that
+            // is added.
             f.pad(",tls=\"true\"")?;
         }
 
@@ -163,8 +165,8 @@ impl ResponseLabels {
     }
 
     #[cfg(test)]
-    pub fn is_tls(&self) -> bool {
-        self.request_labels.is_tls
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
+        self.request_labels.tls_status
     }
 }
 
@@ -322,13 +324,13 @@ impl TransportLabels {
                 ctx::transport::Ctx::Server(_) => Peer::Src,
                 ctx::transport::Ctx::Client(_) => Peer::Dst,
             },
-            is_tls: ctx.is_tls(),
+            tls_status: ctx.tls_status(),
         }
     }
 
     #[cfg(test)]
-    pub fn is_tls(&self) -> bool {
-        self.is_tls
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
+        self.tls_status
     }
 }
 
@@ -340,7 +342,9 @@ impl fmt::Display for TransportLabels {
             Peer::Dst => ",peer=\"dst\"",
         })?;
 
-        if self.is_tls {
+        if self.tls_status == ctx::transport::TlsStatus::Success {
+            // TODO: Handle status variant for `NoConfig` when that
+            // is added.
             f.pad(",tls=\"true\"")?;
         }
 
@@ -361,8 +365,8 @@ impl TransportCloseLabels {
     }
 
     #[cfg(test)]
-    pub fn is_tls(&self) -> bool {
-        self.transport.is_tls()
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus  {
+        self.transport.tls_status()
     }
 }
 

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -379,7 +379,7 @@ impl fmt::Display for ctx::transport::TlsStatus {
         use ctx::transport::TlsStatus;
         match *self {
             TlsStatus::Disabled => Ok(()),
-            TlsStatus::NoConfig => f.pad(",tls=\"no config\""),
+            TlsStatus::NoConfig => f.pad(",tls=\"no_config\""),
             TlsStatus::Success  => f.pad(",tls=\"true\""),
         }
     }

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -126,7 +126,7 @@ impl fmt::Display for RequestLabels {
             write!(f, ",{}", outbound)?;
         }
 
-        write!(f, ",{}", self.tls_status)?;
+        write!(f, "{}", self.tls_status)?;
 
         Ok(())
     }
@@ -332,7 +332,7 @@ impl TransportLabels {
 
 impl fmt::Display for TransportLabels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{},{},{}", self.direction, self.peer, self.tls_status)
+        write!(f, "{},{}{}", self.direction, self.peer, self.tls_status)
     }
 }
 
@@ -369,13 +369,18 @@ impl fmt::Display for TransportCloseLabels {
     }
 }
 
+// TLS status is the only label that prints its own preceding comma, because
+// there is a case when we don't print a label. If the comma was added by
+// whatever owns a TlsStatus, and the status is Disabled, we might sometimes
+// get double commas.
+// TODO: There's got to be a nicer way to handle this.
 impl fmt::Display for ctx::transport::TlsStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ctx::transport::TlsStatus;
         match *self {
             TlsStatus::Disabled => Ok(()),
-            TlsStatus::NoConfig => f.pad("tls=\"no config\""),
-            TlsStatus::Success  => f.pad("tls=\"true\""),
+            TlsStatus::NoConfig => f.pad(",tls=\"no config\""),
+            TlsStatus::Success  => f.pad(",tls=\"true\""),
         }
     }
 }

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -126,11 +126,7 @@ impl fmt::Display for RequestLabels {
             write!(f, ",{}", outbound)?;
         }
 
-        if self.tls_status == ctx::transport::TlsStatus::Success {
-            // TODO: Handle status variant for `NoConfig` when that
-            // is added.
-            f.pad(",tls=\"true\"")?;
-        }
+        write!(f, ",{}", self.tls_status)?;
 
         Ok(())
     }
@@ -336,19 +332,16 @@ impl TransportLabels {
 
 impl fmt::Display for TransportLabels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.direction, f)?;
-        f.pad(match self.peer {
-            Peer::Src => ",peer=\"src\"",
-            Peer::Dst => ",peer=\"dst\"",
-        })?;
+        write!(f, "{},{},{}", self.direction, self.peer, self.tls_status)
+    }
+}
 
-        if self.tls_status == ctx::transport::TlsStatus::Success {
-            // TODO: Handle status variant for `NoConfig` when that
-            // is added.
-            f.pad(",tls=\"true\"")?;
+impl fmt::Display for Peer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Peer::Src => f.pad("peer=\"src\""),
+            Peer::Dst => f.pad("peer=\"dst\""),
         }
-
-        Ok(())
     }
 }
 
@@ -376,3 +369,13 @@ impl fmt::Display for TransportCloseLabels {
     }
 }
 
+impl fmt::Display for ctx::transport::TlsStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ctx::transport::TlsStatus;
+        match *self {
+            TlsStatus::Disabled => Ok(()),
+            TlsStatus::NoConfig => f.pad("tls=\"no config\""),
+            TlsStatus::Success  => f.pad("tls=\"true\""),
+        }
+    }
+}

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -285,7 +285,7 @@ mod tests {
         server: &Arc<ctx::transport::Server>,
         team: &str
     ) {
-        let client = client(&proxy, vec![("team", team)]);
+        let client = client(&proxy, vec![("team", team)], false);
         let (req, rsp) = request("http://nba.com", &server, &client);
 
         let client_transport = Arc::new(ctx::transport::Ctx::Client(client));
@@ -310,7 +310,7 @@ mod tests {
         let process = process();
         let proxy = ctx::Proxy::outbound(&process);
 
-        let server = server(&proxy);
+        let server = server(&proxy, false);
         let server_transport = Arc::new(ctx::transport::Ctx::Server(server.clone()));
 
         let mut root = Root::default();

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -285,7 +285,7 @@ mod tests {
         server: &Arc<ctx::transport::Server>,
         team: &str
     ) {
-        let client = client(&proxy, vec![("team", team)], false);
+        let client = client(&proxy, vec![("team", team)], ctx::transport::TlsStatus::Disabled);
         let (req, rsp) = request("http://nba.com", &server, &client);
 
         let client_transport = Arc::new(ctx::transport::Ctx::Client(client));
@@ -310,7 +310,7 @@ mod tests {
         let process = process();
         let proxy = ctx::Proxy::outbound(&process);
 
-        let server = server(&proxy, false);
+        let server = server(&proxy, ctx::transport::TlsStatus::Disabled);
         let server_transport = Arc::new(ctx::transport::Ctx::Server(server.clone()));
 
         let mut root = Root::default();

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -96,17 +96,17 @@ mod test {
     use ctx::{self, test_util::* };
     use std::time::{Duration, Instant};
 
-    #[test]
-    fn record_response_end() {
+
+    fn test_record_response_end_outbound(client_tls: bool, server_tls: bool) {
         let process = process();
         let proxy = ctx::Proxy::outbound(&process);
-        let server = server(&proxy);
+        let server = server(&proxy, server_tls);
 
         let client = client(&proxy, vec![
             ("service", "draymond"),
             ("deployment", "durant"),
             ("pod", "klay"),
-        ]);
+        ], client_tls);
 
         let (_, rsp) = request("http://buoyant.io", &server, &client);
 
@@ -127,6 +127,8 @@ mod test {
         let (mut r, _) = metrics::new(&process, Duration::from_secs(100));
         let ev = Event::StreamResponseEnd(rsp.clone(), end.clone());
         let labels = labels::ResponseLabels::new(&rsp, None);
+
+        assert_eq!(labels.is_tls(), client_tls);
 
         assert!(r.metrics.lock()
             .expect("lock")
@@ -152,21 +154,20 @@ mod test {
 
     }
 
-    #[test]
-    fn record_one_conn_request() {
+    fn test_record_one_conn_request_outbound(client_tls: bool, server_tls: bool) {
         use self::Event::*;
         use self::labels::*;
         use std::sync::Arc;
 
         let process = process();
         let proxy = ctx::Proxy::outbound(&process);
-        let server = server(&proxy);
+        let server = server(&proxy, server_tls);
 
         let client = client(&proxy, vec![
             ("service", "draymond"),
             ("deployment", "durant"),
             ("pod", "klay"),
-        ]);
+        ], client_tls);
 
         let (req, rsp) = request("http://buoyant.io", &server, &client);
         let server_transport =
@@ -231,6 +232,13 @@ mod test {
             &ctx::transport::Ctx::Client(client.clone()),
             &transport_close,
         );
+
+        assert_eq!(client_tls, req_labels.is_tls());
+        assert_eq!(client_tls, rsp_labels.is_tls());
+        assert_eq!(client_tls, client_open_labels.is_tls());
+        assert_eq!(client_tls, client_close_labels.is_tls());
+        assert_eq!(server_tls, srv_open_labels.is_tls());
+        assert_eq!(server_tls, srv_close_labels.is_tls());
 
         {
             let lock = r.metrics.lock()
@@ -315,4 +323,43 @@ mod test {
         }
     }
 
+    #[test]
+    fn record_one_conn_request_outbound_client_tls() {
+        test_record_one_conn_request_outbound(true, false)
+    }
+
+    #[test]
+    fn record_one_conn_request_outbound_server_tls() {
+        test_record_one_conn_request_outbound(false, true)
+    }
+
+    #[test]
+    fn record_one_conn_request_outbound_both_tls() {
+        test_record_one_conn_request_outbound(true, true)
+    }
+
+    #[test]
+    fn record_one_conn_request_outbound_no_tls() {
+        test_record_one_conn_request_outbound(false, false)
+    }
+
+    #[test]
+    fn record_response_end_outbound_client_tls() {
+        test_record_response_end_outbound(true, false)
+    }
+
+    #[test]
+    fn record_response_end_outbound_server_tls() {
+        test_record_response_end_outbound(false, true)
+    }
+
+    #[test]
+    fn record_response_end_outbound_both_tls() {
+        test_record_response_end_outbound(true, true)
+    }
+
+    #[test]
+    fn record_response_end_outbound_no_tls() {
+        test_record_response_end_outbound(false, false)
+    }
 }

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -93,11 +93,11 @@ mod test {
         metrics::{self, labels},
         Event,
     };
-    use ctx::{self, test_util::* };
+    use ctx::{self, test_util::*, transport::TlsStatus};
     use std::time::{Duration, Instant};
 
 
-    fn test_record_response_end_outbound(client_tls: bool, server_tls: bool) {
+    fn test_record_response_end_outbound(client_tls: TlsStatus, server_tls: TlsStatus) {
         let process = process();
         let proxy = ctx::Proxy::outbound(&process);
         let server = server(&proxy, server_tls);
@@ -128,7 +128,7 @@ mod test {
         let ev = Event::StreamResponseEnd(rsp.clone(), end.clone());
         let labels = labels::ResponseLabels::new(&rsp, None);
 
-        assert_eq!(labels.is_tls(), client_tls);
+        assert_eq!(labels.tls_status(), client_tls);
 
         assert!(r.metrics.lock()
             .expect("lock")
@@ -154,7 +154,7 @@ mod test {
 
     }
 
-    fn test_record_one_conn_request_outbound(client_tls: bool, server_tls: bool) {
+    fn test_record_one_conn_request_outbound(client_tls: TlsStatus, server_tls: TlsStatus) {
         use self::Event::*;
         use self::labels::*;
         use std::sync::Arc;
@@ -233,12 +233,12 @@ mod test {
             &transport_close,
         );
 
-        assert_eq!(client_tls, req_labels.is_tls());
-        assert_eq!(client_tls, rsp_labels.is_tls());
-        assert_eq!(client_tls, client_open_labels.is_tls());
-        assert_eq!(client_tls, client_close_labels.is_tls());
-        assert_eq!(server_tls, srv_open_labels.is_tls());
-        assert_eq!(server_tls, srv_close_labels.is_tls());
+        assert_eq!(client_tls, req_labels.tls_status());
+        assert_eq!(client_tls, rsp_labels.tls_status());
+        assert_eq!(client_tls, client_open_labels.tls_status());
+        assert_eq!(client_tls, client_close_labels.tls_status());
+        assert_eq!(server_tls, srv_open_labels.tls_status());
+        assert_eq!(server_tls, srv_close_labels.tls_status());
 
         {
             let lock = r.metrics.lock()
@@ -325,41 +325,41 @@ mod test {
 
     #[test]
     fn record_one_conn_request_outbound_client_tls() {
-        test_record_one_conn_request_outbound(true, false)
+        test_record_one_conn_request_outbound(TlsStatus::Success, TlsStatus::Disabled)
     }
 
     #[test]
     fn record_one_conn_request_outbound_server_tls() {
-        test_record_one_conn_request_outbound(false, true)
+        test_record_one_conn_request_outbound(TlsStatus::Disabled, TlsStatus::Success)
     }
 
     #[test]
     fn record_one_conn_request_outbound_both_tls() {
-        test_record_one_conn_request_outbound(true, true)
+        test_record_one_conn_request_outbound(TlsStatus::Success, TlsStatus::Success)
     }
 
     #[test]
     fn record_one_conn_request_outbound_no_tls() {
-        test_record_one_conn_request_outbound(false, false)
+        test_record_one_conn_request_outbound(TlsStatus::Disabled, TlsStatus::Disabled)
     }
 
     #[test]
     fn record_response_end_outbound_client_tls() {
-        test_record_response_end_outbound(true, false)
+        test_record_response_end_outbound(TlsStatus::Success, TlsStatus::Disabled)
     }
 
     #[test]
     fn record_response_end_outbound_server_tls() {
-        test_record_response_end_outbound(false, true)
+        test_record_response_end_outbound(TlsStatus::Disabled, TlsStatus::Success)
     }
 
     #[test]
     fn record_response_end_outbound_both_tls() {
-        test_record_response_end_outbound(true, true)
+        test_record_response_end_outbound(TlsStatus::Success, TlsStatus::Success)
     }
 
     #[test]
     fn record_response_end_outbound_no_tls() {
-        test_record_response_end_outbound(false, false)
+        test_record_response_end_outbound(TlsStatus::Disabled, TlsStatus::Disabled)
     }
 }

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -126,6 +126,7 @@ where
             &local_addr,
             &remote_addr,
             &orig_dst,
+            connection.is_tls(),
         );
         let log = self.log.clone()
             .with_remote(remote_addr);

--- a/proxy/src/transparency/server.rs
+++ b/proxy/src/transparency/server.rs
@@ -126,7 +126,7 @@ where
             &local_addr,
             &remote_addr,
             &orig_dst,
-            connection.is_tls(),
+            connection.tls_status(),
         );
         let log = self.log.clone()
             .with_remote(remote_addr);

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -59,6 +59,10 @@ impl Proxy {
             &srv_ctx.proxy,
             &orig_dst,
             destination::Metadata::no_metadata(),
+            // A raw TCP client connection may be or may not be TLS traffic,
+            // but the `is_tls` field indicates whether _the proxy_ is
+            // responsible for the encryption, so set this to false.
+            false,
         );
         let c = Timeout::new(
             transport::Connect::new(orig_dst, None), // No TLS.

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -8,7 +8,11 @@ use tokio_connect::Connect;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use control::destination;
-use ctx::transport::{Client as ClientCtx, Server as ServerCtx};
+use ctx::transport::{
+    Client as ClientCtx,
+    Server as ServerCtx,
+    TlsStatus,
+};
 use telemetry::Sensors;
 use timeout::Timeout;
 use transport;
@@ -62,7 +66,7 @@ impl Proxy {
             // A raw TCP client connection may be or may not be TLS traffic,
             // but the `is_tls` field indicates whether _the proxy_ is
             // responsible for the encryption, so set this to false.
-            false,
+            TlsStatus::Disabled,
         );
         let c = Timeout::new(
             transport::Connect::new(orig_dst, None), // No TLS.

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -64,8 +64,10 @@ impl Proxy {
             &orig_dst,
             destination::Metadata::no_metadata(),
             // A raw TCP client connection may be or may not be TLS traffic,
-            // but the `is_tls` field indicates whether _the proxy_ is
-            // responsible for the encryption, so set this to false.
+            // but the `TlsStatus` field indicates whether _the proxy_ is
+            // responsible for the encryption, so set this to "Disabled".
+            // XXX: Should raw TCP connections have a different TLS status
+            // from HTTP connections for which TLS is disabled?
             TlsStatus::Disabled,
         );
         let c = Timeout::new(


### PR DESCRIPTION
Depends on #1047.

This PR adds a `tls="true"` label to metrics produced by TLS connections and
requests/responses on those connections. Currently, this is only set on 
accepted connections, as we are not yet opening encrypted connections, but I 
wired through the `is_tls` flag on the `Client` transport context as well, so
when we start opening client connections with TLS, the label will be applied to
their metrics as well.

Closes #1046