### PR TITLE
Add install flag for sending tls identity info to proxies

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -31,6 +31,7 @@ type installConfig struct {
 	ControllerComponentLabel string
 	CreatedByAnnotation      string
 	ProxyAPIPort             uint
+	EnableTLS                bool
 }
 
 type installOptions struct {
@@ -39,6 +40,7 @@ type installOptions struct {
 	webReplicas        uint
 	prometheusReplicas uint
 	controllerLogLevel string
+	enableTLS          bool
 	*proxyConfigOptions
 }
 
@@ -49,6 +51,7 @@ func newInstallOptions() *installOptions {
 		webReplicas:        1,
 		prometheusReplicas: 1,
 		controllerLogLevel: "info",
+		enableTLS:          false,
 		proxyConfigOptions: newProxyConfigOptions(),
 	}
 }
@@ -75,6 +78,8 @@ func newCmdInstall() *cobra.Command {
 	cmd.PersistentFlags().UintVar(&options.webReplicas, "web-replicas", options.webReplicas, "Replicas of the web server to deploy")
 	cmd.PersistentFlags().UintVar(&options.prometheusReplicas, "prometheus-replicas", options.prometheusReplicas, "Replicas of prometheus to deploy")
 	cmd.PersistentFlags().StringVar(&options.controllerLogLevel, "controller-log-level", options.controllerLogLevel, "Log level for the controller and web components")
+	cmd.PersistentFlags().BoolVar(&options.enableTLS, "enable-tls", options.enableTLS, "Enable TLS connections among pods in the service mesh")
+	cmd.PersistentFlags().MarkHidden("enable-tls")
 
 	return cmd
 }
@@ -99,6 +104,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		ControllerComponentLabel: k8s.ControllerComponentLabel,
 		CreatedByAnnotation:      k8s.CreatedByAnnotation,
 		ProxyAPIPort:             options.proxyAPIPort,
+		EnableTLS:                options.enableTLS,
 	}, nil
 }
 

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -36,6 +36,7 @@ func TestRender(t *testing.T) {
 		ControllerComponentLabel: "ControllerComponentLabel",
 		CreatedByAnnotation:      "CreatedByAnnotation",
 		ProxyAPIPort:             123,
+		EnableTLS:                true,
 	}
 
 	testCases := []struct {

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -157,6 +157,7 @@ spec:
         resources: {}
       - args:
         - destination
+        - -enable-tls=false
         - -log-level=info
         - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -158,6 +158,7 @@ spec:
         resources: {}
       - args:
         - destination
+        - -enable-tls=true
         - -log-level=ControllerLogLevel
         - -logtostderr=true
         image: ControllerImage

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -162,6 +162,7 @@ spec:
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - "destination"
+        - "-enable-tls={{.EnableTLS}}"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
       - name: proxy-api

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -18,6 +18,7 @@ func main() {
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
 	logLevel := flag.String("log-level", log.InfoLevel.String(), "log level, must be one of: panic, fatal, error, warn, info, debug")
+	enableTLS := flag.Bool("enable-tls", false, "Enable TLS connections among pods in the service mesh")
 	printVersion := version.VersionFlag()
 	flag.Parse()
 
@@ -35,7 +36,7 @@ func main() {
 
 	done := make(chan struct{})
 
-	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, *k8sDNSZone, done)
+	server, lis, err := destination.NewServer(*addr, *kubeConfigPath, *k8sDNSZone, *enableTLS, done)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/script/destination-client/main.go
+++ b/controller/script/destination-client/main.go
@@ -51,9 +51,14 @@ func main() {
 		switch updateType := update.Update.(type) {
 		case *pb.Update_Add:
 			log.Println("Add:")
-			log.Printf("metric_labels: %v", updateType.Add.MetricLabels)
+			log.Printf("labels: %v", updateType.Add.MetricLabels)
 			for _, addr := range updateType.Add.Addrs {
-				log.Printf("- %s:%d - %v", util.IPToString(addr.Addr.GetIp()), addr.Addr.Port, addr.MetricLabels)
+				log.Printf("- %s:%d", util.IPToString(addr.Addr.GetIp()), addr.Addr.Port)
+				log.Printf("  - labels: %v", addr.MetricLabels)
+				switch identityType := addr.GetTlsIdentity().GetStrategy().(type) {
+				case *pb.TlsIdentity_K8SPodNamespace_:
+					log.Printf("  - tls:    %v", identityType.K8SPodNamespace)
+				}
 			}
 			log.Println()
 		case *pb.Update_Remove:

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -94,6 +94,10 @@ func GetOwnerLabels(objectMeta meta.ObjectMeta) map[string]string {
 	return labels
 }
 
+func GetControllerNs(objectMeta meta.ObjectMeta) string {
+	return objectMeta.Labels[ControllerNSLabel]
+}
+
 // toOwnerLabel converts a proxy label to a prometheus label, following the
 // relabel conventions from the prometheus scrape config file
 func toOwnerLabel(proxyLabel string) string {


### PR DESCRIPTION
This branch adds a (hidden) `--enable-tls` flag to the conduit install command, which configures the destination service to start populating the `TlsIdentity` message that was added in #1041 when streaming addresses to the proxy. I've also updated the the destination-client script to start printing TLS identity information when it's available. It looks like this:

```
$ ./bin/go-run controller/script/destination-client -path web.conduit.svc.cluster.local:8084
INFO[0000] Add:                                         
INFO[0000] labels: map[service:web namespace:conduit]   
INFO[0000] - 172.17.0.7:8084                            
INFO[0000]   - labels: map[conduit_io_control_plane_ns:conduit deployment:web pod_template_hash:2827457025 pod:web-6d6c89c469-hsfck] 
INFO[0000]   - tls:    controller_ns:"conduit" pod_ns:"conduit" pod_name:"web-6d6c89c469-hsfck"  
```

Fixes #1040.