### PR TITLE
proxy: Reload TLS config on changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.3.0",
+ "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)",
  "h2 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -347,6 +348,15 @@ dependencies = [
 name = "futures-mpsc-lossy"
 version = "0.3.0"
 dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-watch"
+version = "0.1.0"
+source = "git+https://github.com/carllerche/better-future#07baa13e91fefe7a51533dfde7b4e69e109ebe14"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1477,6 +1487,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)" = "<none>"
 "checksum gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9fcfe1c9ee125342355b2467bc29b9dfcb2124fcae27edb9cee6f4cc5ecd40"
 "checksum h2 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "8111e316d0589775ee2bd671cdfdf3f63c9d97e21d8d16a88bb73dcf99bef7f5"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "0.4"
 deflate = {version = "0.7.18", features = ["gzip"] }
 env_logger = { version = "0.5", default-features = false }
 futures = "0.1"
+futures-watch = { git = "https://github.com/carllerche/better-future" }
 h2 = "0.1.7"
 http = "0.1"
 httparse = "1.2"

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -10,6 +10,7 @@ extern crate deflate;
 #[macro_use]
 extern crate futures;
 extern crate futures_mpsc_lossy;
+extern crate futures_watch;
 extern crate h2;
 extern crate http;
 extern crate httparse;

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -98,12 +98,13 @@ impl Control {
         use hyper;
 
         let log = ::logging::admin().server("metrics", bound_port.local_addr());
+        let (no_tls, _) = ::tls::ServerConfig::no_tls();
 
         let service = self.metrics_service.clone();
         let fut = {
             let log = log.clone();
             bound_port.listen_and_fold(
-                None, // TODO: No TLS
+                no_tls, // TODO: Serve over TLS.
                 hyper::server::conn::Http::new(),
                 move |hyper, (conn, remote)| {
                     let service = service.clone();

--- a/proxy/src/transport/tls/mod.rs
+++ b/proxy/src/transport/tls/mod.rs
@@ -10,6 +10,6 @@ mod cert_resolver;
 mod connection;
 
 pub use self::{
-    config::{CommonSettings, CommonConfig, Error, ServerConfig},
+    config::{CommonSettings, CommonConfig, Error, ServerConfig, ServerConfigWatch},
     connection::Connection,
 };


### PR DESCRIPTION
This PR modifies the proxy's TLS code so that the TLS config files are reloaded
when any of them has changed (including if they did not previously exist).

If reloading the configs returns an error, we log an error and continue using
the old config.

Currently, this is implemented by polling the file system for the time they
were last modified at a fixed interval. However, I've implemented this so 
that the changes are passed around as a `Stream`, and that reloading and
updating the config is in a separate function the one that detects changes.
Therefore, it should be fairly easy to plug in support for `inotify` (and 
other FS watch APIs) later, as long as we can use them to generate a 
`Stream` of changes.

Closes #369 