### PR TITLE
proxy: Change `DEFAULT_OUTBOUND_ROUTER_CAPACITY` from 10,000 to 100

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -201,7 +201,7 @@ const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 /// It's assumed that a typical proxy can serve inbound traffic for up to 100 pod-local
 /// HTTP services and may communicate with up to 10K external HTTP domains.
 const DEFAULT_INBOUND_ROUTER_CAPACITY:  usize = 100;
-const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 10_000;
+const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 100;
 
 const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE:  Duration = Duration::from_secs(60);
 const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);


### PR DESCRIPTION
@olix0r wanted this changed prior to release.