### PR TITLE
proxy-init: remove global vars, fix validation, add tests

### DIFF
--- a/proxy-init/cmd/root_test.go
+++ b/proxy-init/cmd/root_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/runconduit/conduit/proxy-init/iptables"
+)
+
+func TestBuildFirewallConfiguration(t *testing.T) {
+	t.Run("It produces a FirewallConfiguration for the default config", func(t *testing.T) {
+		expectedIncomingProxyPort := 1234
+		expectedOutgoingProxyPort := 2345
+		expectedProxyUserId := 33
+		expectedConfig := &iptables.FirewallConfiguration{
+			Mode: iptables.RedirectAllMode,
+			PortsToRedirectInbound: make([]int, 0),
+			InboundPortsToIgnore:   make([]int, 0),
+			OutboundPortsToIgnore:  make([]int, 0),
+			ProxyInboundPort:       expectedIncomingProxyPort,
+			ProxyOutgoingPort:      expectedOutgoingProxyPort,
+			ProxyUid:               expectedProxyUserId,
+			SimulateOnly:           false,
+		}
+
+		options := newRootOptions()
+		options.incomingProxyPort = expectedIncomingProxyPort
+		options.outgoingProxyPort = expectedOutgoingProxyPort
+		options.proxyUserId = expectedProxyUserId
+
+		config, err := buildFirewallConfiguration(options)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		if !reflect.DeepEqual(config, expectedConfig) {
+			t.Fatalf("Expected config [%v] but got [%v]", expectedConfig, config)
+		}
+	})
+
+	t.Run("It rejects invalid config options", func(t *testing.T) {
+		for _, tt := range []struct {
+			options      *rootOptions
+			errorMessage string
+		}{
+			{
+				options: &rootOptions{
+					incomingProxyPort: -1,
+					outgoingProxyPort: 1234,
+				},
+				errorMessage: "--incoming-proxy-port must be a valid TCP port number",
+			},
+			{
+				options: &rootOptions{
+					incomingProxyPort: 100000,
+					outgoingProxyPort: 1234,
+				},
+				errorMessage: "--incoming-proxy-port must be a valid TCP port number",
+			},
+			{
+				options: &rootOptions{
+					incomingProxyPort: 1234,
+					outgoingProxyPort: -1,
+				},
+				errorMessage: "--outgoing-proxy-port must be a valid TCP port number",
+			},
+			{
+				options: &rootOptions{
+					incomingProxyPort: 1234,
+					outgoingProxyPort: 100000,
+				},
+				errorMessage: "--outgoing-proxy-port must be a valid TCP port number",
+			},
+		} {
+			_, err := buildFirewallConfiguration(tt.options)
+			if err == nil {
+				t.Fatalf("Expected error for config [%v], got nil", tt.options)
+			}
+			if err.Error() != tt.errorMessage {
+				t.Fatalf("Expected error [%s] for config [%v], got [%s]",
+					tt.errorMessage, tt.options, err.Error())
+			}
+		}
+	})
+}

--- a/proxy-init/integration_test/iptables/Dockerfile-tester
+++ b/proxy-init/integration_test/iptables/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM golang:1.10.0
+FROM golang:1.10.2
 
 ADD iptables/ /go
 # Kubernetes Jobs will be retried until they return status 0,

--- a/proxy-init/main.go
+++ b/proxy-init/main.go
@@ -3,5 +3,5 @@ package main
 import "github.com/runconduit/conduit/proxy-init/cmd"
 
 func main() {
-	cmd.RootCmd.Execute()
+	cmd.NewRootCmd().Execute()
 }


### PR DESCRIPTION
This branch fixes the validation issue reported in #1057 and adds tests. In the process of writing the tests, I also restructured the proxy-init cobra setup to remove the use of init funcs and global variables, similar to how I modified the main conduit CLI setup in #975.

Fixes #1057.