### PR TITLE
Start running integration tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,23 +93,12 @@ jobs:
         - |
           # Install gcloud and kubectl.
           dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
-          export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-          if [ -d "$dir/bin" ]; then
-              . "$dir/path.bash.inc"
-              gcloud components update
-          else
-              rm -rf "$dir"
-              curl https://sdk.cloud.google.com | bash
-              . "$dir/path.bash.inc"
-          fi
-          gcloud components install kubectl
+          (. bin/_gcp.sh ; install_gcloud_kubectl "$dir")
+          . "$dir/path.bash.inc"
         - |
           # Configure gcloud with a service account.
           openssl aes-256-cbc -K $encrypted_6af64675f81c_key -iv $encrypted_6af64675f81c_iv -in .gcp.json.enc -out .gcp.json -d
-          gcloud auth activate-service-account --key-file .gcp.json
-          gcloud config set core/project "$GCP_PROJECT"
-          gcloud config set compute/zone "$GCP_ZONE"
-          gcloud config set container/cluster "$GKE_CLUSTER"
+          (. bin/_gcp.sh ; set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER")
         - |
           # Get a kubernetes context.
           (. bin/_gcp.sh ; get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER")
@@ -164,23 +153,12 @@ jobs:
         - |
           # Install gcloud and kubectl.
           dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
-          export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-          if [ -d "$dir/bin" ]; then
-              . "$dir/path.bash.inc"
-              gcloud components update
-          else
-              rm -rf "$dir"
-              curl https://sdk.cloud.google.com | bash
-              . "$dir/path.bash.inc"
-          fi
-          gcloud components install kubectl
+          (. bin/_gcp.sh ; install_gcloud_kubectl "$dir")
+          . "$dir/path.bash.inc"
         - |
           # Configure gcloud with a service account.
           openssl aes-256-cbc -K $encrypted_6af64675f81c_key -iv $encrypted_6af64675f81c_iv -in .gcp.json.enc -out .gcp.json -d
-          gcloud auth activate-service-account --key-file .gcp.json
-          gcloud config set core/project "$GCP_PROJECT"
-          gcloud config set compute/zone "$GCP_ZONE"
-          gcloud config set container/cluster "$GKE_CLUSTER"
+          (. bin/_gcp.sh ; set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER")
         - |
           # Get a kubernetes context.
           (. bin/_gcp.sh ; get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER")

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,18 +167,15 @@ jobs:
 
       script:
         - |
-          # Run tests and cleanup afterward.
-          exit_code=0
-          cleanup_exit_code=0
+          # Run integration tests.
           version=$(./bin/go-run cli version --client --short)
           namespace=conduit-$(echo $version | tr -cd '[:alnum:]-')
-          ./bin/test-run $(pwd)/.gorun $namespace || exit_code=$?
-          ./bin/test-cleanup $namespace || cleanup_exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            exit $exit_code;
-          else
-            exit $cleanup_exit_code;
-          fi
+          ./bin/test-run $(pwd)/.gorun $namespace
+
+      after_script:
+        - |
+          # Cleanup after integration test run.
+          ./bin/test-cleanup "conduit-$(./bin/root-tag | tr -cd '[:alnum:]-')"
 
   # If we want to start building everything against bleeding-edge Rust nightly, we'll have
   # to enable:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ stages:
   - name: test
   - name: docker-deploy
     if: branch = master AND type != pull_request
+  - name: integration-test
+    if: branch = master AND type != pull_request
 
 jobs:
   include:
@@ -141,6 +143,64 @@ jobs:
         - bin/docker-retag-all $CONDUIT_TAG master && bin/docker-push master
         - target/cli/linux/conduit install --conduit-version=$CONDUIT_TAG |tee conduit.yml
         - kubectl -n conduit apply -f conduit.yml --prune --selector='conduit.io/control-plane-component'
+
+    # Run integration tests after container images have been published.
+    - stage: integration-test
+
+      language: go
+      go: "1.10.2"
+      go_import_path: github.com/runconduit/conduit
+
+      cache:
+        directories:
+          - vendor
+          - "$HOME/google-cloud-sdk/"
+          - "$HOME/.cache"
+
+      install:
+        - ./bin/dep ensure -vendor-only -v
+        - ./bin/dep status -v
+
+        - |
+          # Install gcloud and kubectl.
+          dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+          export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+          if [ -d "$dir/bin" ]; then
+              . "$dir/path.bash.inc"
+              gcloud components update
+          else
+              rm -rf "$dir"
+              curl https://sdk.cloud.google.com | bash
+              . "$dir/path.bash.inc"
+          fi
+          gcloud components install kubectl
+        - |
+          # Configure gcloud with a service account.
+          openssl aes-256-cbc -K $encrypted_6af64675f81c_key -iv $encrypted_6af64675f81c_iv -in .gcp.json.enc -out .gcp.json -d
+          gcloud auth activate-service-account --key-file .gcp.json
+          gcloud config set core/project "$GCP_PROJECT"
+          gcloud config set compute/zone "$GCP_ZONE"
+          gcloud config set container/cluster "$GKE_CLUSTER"
+        - |
+          # Get a kubernetes context.
+          (. bin/_gcp.sh ; get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER")
+        - gcloud version
+        - kubectl version --short
+
+      script:
+        - |
+          # Run tests and cleanup afterward.
+          exit_code=0
+          cleanup_exit_code=0
+          version=$(./bin/go-run cli version --client --short)
+          namespace=conduit-$(echo $version | tr -cd '[:alnum:]-')
+          ./bin/test-run $(pwd)/.gorun $namespace || exit_code=$?
+          ./bin/test-cleanup $namespace || cleanup_exit_code=$?
+          if [ $exit_code -ne 0 ]; then
+            exit $exit_code;
+          else
+            exit $cleanup_exit_code;
+          fi
 
   # If we want to start building everything against bleeding-edge Rust nightly, we'll have
   # to enable:

--- a/bin/_gcp.sh
+++ b/bin/_gcp.sh
@@ -1,5 +1,31 @@
 set -eu
 
+install_gcloud_kubectl() {
+    dir="$1"
+
+    export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+    if [ -d "$dir/bin" ]; then
+        . "$dir/path.bash.inc"
+        gcloud components update
+    else
+        rm -rf "$dir"
+        curl https://sdk.cloud.google.com | bash
+        . "$dir/path.bash.inc"
+    fi
+    gcloud components install kubectl
+}
+
+set_gcloud_config() {
+    project="$1"
+    zone="$2"
+    cluster="$3"
+
+    gcloud auth activate-service-account --key-file .gcp.json
+    gcloud config set core/project "$project"
+    gcloud config set compute/zone "$zone"
+    gcloud config set container/cluster "$cluster"
+}
+
 get_k8s_ctx() {
     project="$1"
     zone="$2"

--- a/bin/test-run
+++ b/bin/test-run
@@ -56,7 +56,7 @@ printf "Testing Conduit version [%s] namespace [%s]\\n" "$conduit_version" "$con
 
 exit_code=0
 run_test "$test_directory/install_test.go" || exit_code=$?
-for test in $(find "$test_directory" -name '*_test.go' -mindepth 2); do
+for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?
 done
 exit $exit_code


### PR DESCRIPTION
This branch updates the CI config with an additional "integration-test" stage that runs after the "docker-deploy". The integration-test stage runs all of the integration tests in the `test` directory, using the docker images that were published in the previous stage. This change only applies to commits to the master branch.

Fixes #620.
Fixes #715.