### PR TITLE
Filter out failed and completed pods from stats summary result

### DIFF
--- a/controller/k8s/lister.go
+++ b/controller/k8s/lister.go
@@ -248,6 +248,9 @@ func (l *Lister) getPods(namespace, name string) ([]runtime.Object, error) {
 
 	objects := []runtime.Object{}
 	for _, pod := range pods {
+		if !isPendingOrRunning(pod) {
+			continue
+		}
 		objects = append(objects, pod)
 	}
 


### PR DESCRIPTION
Per [conversation with @klingerf](https://github.com/runconduit/conduit/issues/1010#issuecomment-394455265), this PR updates the `getPods()` function to filter out failed and completed pods from the stats summary result. Also, added some relevant unit tests.

Fixes #1010
