### PR TITLE
Ensure Request IDs are unique & avoid `Arc`ing.

### DIFF
--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -55,13 +55,11 @@ fn request(
     uri: &str,
     server: &Arc<ctx::transport::Server>,
     client: &Arc<ctx::transport::Client>,
-    id: ctx::http::RequestId,
 ) -> (Arc<ctx::http::Request>, Arc<ctx::http::Response>) {
     let req = ctx::http::Request::new(
         &http::Request::get(uri).body(()).unwrap(),
         &server,
         &client,
-        id,
     );
     let rsp = ctx::http::Response::new(
         &http::Response::builder().status(http::StatusCode::OK).body(()).unwrap(),
@@ -82,7 +80,7 @@ fn record_response_end(b: &mut Bencher) {
         ("pod", "klay"),
     ]);
 
-    let (_, rsp) = request("http://buoyant.io", &server, &client, ctx::http::RequestId::from(1));
+    let (_, rsp) = request("http://buoyant.io", &server, &client);
 
     let request_open_at = Instant::now();
     let response_open_at = request_open_at + Duration::from_millis(100);
@@ -114,7 +112,7 @@ fn record_one_conn_request(b: &mut Bencher) {
         ("pod", "klay"),
     ]);
 
-    let (req, rsp) = request("http://buoyant.io", &server, &client, ctx::http::RequestId::from(1));
+    let (req, rsp) = request("http://buoyant.io", &server, &client);
 
     let server_transport = Arc::new(ctx::transport::Ctx::Server(server));
     let client_transport = Arc::new(ctx::transport::Ctx::Client(client));
@@ -191,7 +189,7 @@ fn record_many_dsts(b: &mut Bencher) {
             ("pod".into(), format!("pod{}", n)),
         ]);
         let uri = format!("http://test{}.local", n);
-        let (req, rsp) = request(&uri, &server, &client, ctx::http::RequestId::from(1));
+        let (req, rsp) = request(&uri, &server, &client);
         let client_transport = Arc::new(ctx::transport::Ctx::Client(client));
 
         events.push(TransportOpen(client_transport.clone()));

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -27,7 +27,6 @@ use transport;
 pub struct Bind<C, B> {
     ctx: C,
     sensors: telemetry::Sensors,
-    req_ids: Arc<ctx::http::RequestIdSequence>,
     _p: PhantomData<fn() -> B>,
 }
 
@@ -168,7 +167,6 @@ impl<B> Bind<(), B> {
         Self {
             ctx: (),
             sensors: telemetry::Sensors::null(),
-            req_ids: ctx::http::RequestIdSequence::new(),
             _p: PhantomData,
         }
     }
@@ -184,7 +182,6 @@ impl<B> Bind<(), B> {
         Bind {
             ctx,
             sensors: self.sensors,
-            req_ids: self.req_ids,
             _p: PhantomData,
         }
     }
@@ -195,7 +192,6 @@ impl<C: Clone, B> Clone for Bind<C, B> {
         Self {
             ctx: self.ctx.clone(),
             sensors: self.sensors.clone(),
-            req_ids: self.req_ids.clone(),
             _p: PhantomData,
         }
     }
@@ -230,7 +226,6 @@ where
         );
 
         let sensors = self.sensors.http(
-            self.req_ids.clone(),
             client,
             &client_ctx
         );

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -1,10 +1,8 @@
 use std::error::Error;
 use std::fmt;
-use std::default::Default;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
 
 use futures::{Async, Future, Poll, future, task};
 use http::{self, uri};
@@ -29,7 +27,7 @@ use transport;
 pub struct Bind<C, B> {
     ctx: C,
     sensors: telemetry::Sensors,
-    req_ids: Arc<AtomicUsize>,
+    req_ids: Arc<ctx::http::RequestIdSequence>,
     _p: PhantomData<fn() -> B>,
 }
 
@@ -170,7 +168,7 @@ impl<B> Bind<(), B> {
         Self {
             ctx: (),
             sensors: telemetry::Sensors::null(),
-            req_ids: Default::default(),
+            req_ids: ctx::http::RequestIdSequence::new(),
             _p: PhantomData,
         }
     }

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -117,13 +117,11 @@ pub mod test_util {
         uri: &str,
         server: &Arc<ctx::transport::Server>,
         client: &Arc<ctx::transport::Client>,
-        id: ctx::http::RequestId,
     ) -> (Arc<ctx::http::Request>, Arc<ctx::http::Response>) {
         let req = ctx::http::Request::new(
             &http::Request::get(uri).body(()).unwrap(),
             &server,
             &client,
-            id,
         );
         let rsp = ctx::http::Response::new(
             &http::Response::builder().status(http::StatusCode::OK).body(()).unwrap(),

--- a/proxy/src/telemetry/metrics/mod.rs
+++ b/proxy/src/telemetry/metrics/mod.rs
@@ -286,8 +286,7 @@ mod tests {
         team: &str
     ) {
         let client = client(&proxy, vec![("team", team)]);
-        let (req, rsp) = request("http://nba.com", &server, &client,
-                                 ctx::http::RequestId::from(1));
+        let (req, rsp) = request("http://nba.com", &server, &client);
 
         let client_transport = Arc::new(ctx::transport::Ctx::Client(client));
         let transport = TransportLabels::new(&client_transport);

--- a/proxy/src/telemetry/metrics/record.rs
+++ b/proxy/src/telemetry/metrics/record.rs
@@ -108,8 +108,7 @@ mod test {
             ("pod", "klay"),
         ]);
 
-        let (_, rsp) = request("http://buoyant.io", &server, &client,
-                               ctx::http::RequestId::from(1));
+        let (_, rsp) = request("http://buoyant.io", &server, &client);
 
         let request_open_at = Instant::now();
         let response_open_at = request_open_at + Duration::from_millis(100);
@@ -169,8 +168,7 @@ mod test {
             ("pod", "klay"),
         ]);
 
-        let (req, rsp) = request("http://buoyant.io", &server, &client,
-                                 ctx::http::RequestId::from(1));
+        let (req, rsp) = request("http://buoyant.io", &server, &client);
         let server_transport =
             Arc::new(ctx::transport::Ctx::Server(server.clone()));
         let client_transport =

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
 use std::time::Instant;
 
 use futures_mpsc_lossy::Sender;
@@ -77,7 +76,7 @@ impl Sensors {
 
     pub fn http<N, A, B>(
         &self,
-        next_id: Arc<AtomicUsize>,
+        next_id: Arc<ctx::http::RequestIdSequence>,
         new_service: N,
         client_ctx: &Arc<ctx::transport::Client>,
     ) -> NewHttp<N, A, B>

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -76,7 +76,6 @@ impl Sensors {
 
     pub fn http<N, A, B>(
         &self,
-        next_id: Arc<ctx::http::RequestIdSequence>,
         new_service: N,
         client_ctx: &Arc<ctx::transport::Client>,
     ) -> NewHttp<N, A, B>
@@ -90,6 +89,6 @@ impl Sensors {
         >
             + 'static,
     {
-        NewHttp::new(next_id, new_service, &self.0, client_ctx)
+        NewHttp::new(new_service, &self.0, client_ctx)
     }
 }


### PR DESCRIPTION
Request IDs need to be globally unique, so there can only be one request ID
sequence per process. Simplify the request ID generation with that in mind,
and make it more efficient.

Signed-off-by: Brian Smith <brian@briansmith.org>