### PR TITLE
Fix CI: upgrade CI node and yarn to latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,12 @@ jobs:
 
     - language: node_js
       node_js:
-        - "8"
+        - "10"
       cache:
         directories:
           - web/app/node_modules
       before_install:
-        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
         - export PATH="$HOME/.yarn/bin:$PATH"
       install:
         - ./bin/web


### PR DESCRIPTION
In https://github.com/runconduit/conduit/pull/1059 I upgraded a few css packages, but CI uses a version of node that is too old for some of those packages.

Error:
```
error url-loader@1.0.1: The engine "node" is incompatible with this module. Expected version ">= 6.9.0 || >= 8.9.0".
```

Fix:
Upgrade node in CI. (I also upgraded yarn because the latest is 1.7.0 and we were on 1.3.2).

Alternative fix:
Revert https://github.com/runconduit/conduit/pull/1059