### PR TITLE
Upgrade web docker build base image to node:10

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 ## bundle web assets
-FROM node:6.7.0 as webpack-bundle
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+FROM node:10 as webpack-bundle
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
 
 ENV HOME /root
 ENV PATH $HOME/.yarn/bin:$PATH


### PR DESCRIPTION
We were using a very old node base image when building web assets in docker, which wasn't compatible with the dependency upgrades from #1059. As part of this change I'm also pinning the yarn version to 1.7.0, to match what we're doing in CI as of #1067.