### PR TITLE
Rename Lister to API and expose both listers and informers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -626,6 +626,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "182f004a05ea72c10f21d5a5db33bee9f09655ddcca855a2c920f8bdd7516753"
+  inputs-digest = "922a86ea6ed3714e04961054105a5a701729d4650fdd552ee64111b2636197f3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/runconduit/go-deps:69ba71ed as golang
+FROM gcr.io/runconduit/go-deps:23e16ad5 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/runconduit/go-deps:69ba71ed as golang
+FROM gcr.io/runconduit/go-deps:23e16ad5 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -25,7 +25,7 @@ type (
 	grpcServer struct {
 		prometheusAPI       promv1.API
 		tapClient           tapPb.TapClient
-		lister              *k8s.Lister
+		k8sAPI              *k8s.API
 		controllerNamespace string
 		ignoredNamespaces   []string
 	}
@@ -42,14 +42,14 @@ const (
 func newGrpcServer(
 	promAPI promv1.API,
 	tapClient tapPb.TapClient,
-	lister *k8s.Lister,
+	k8sAPI *k8s.API,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *grpcServer {
 	return &grpcServer{
 		prometheusAPI:       promAPI,
 		tapClient:           tapClient,
-		lister:              lister,
+		k8sAPI:              k8sAPI,
 		controllerNamespace: controllerNamespace,
 		ignoredNamespaces:   ignoredNamespaces,
 	}
@@ -78,7 +78,7 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.Empty) (*pb.ListPodsR
 		reports[pod] = time.Unix(0, int64(timestamp)*int64(time.Millisecond))
 	}
 
-	pods, err := s.lister.Pod.List(labels.Everything())
+	pods, err := s.k8sAPI.Pod.Lister().List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (s *grpcServer) SelfCheck(ctx context.Context, in *healthcheckPb.SelfCheckR
 		CheckDescription: K8sClientCheckDescription,
 		Status:           healthcheckPb.CheckStatus_OK,
 	}
-	_, err := s.lister.Pod.List(labels.Everything())
+	_, err := s.k8sAPI.Pod.Lister().List(labels.Everything())
 	if err != nil {
 		k8sClientCheck.Status = healthcheckPb.CheckStatus_ERROR
 		k8sClientCheck.FriendlyMessageToUser = fmt.Sprintf("Error talking to Kubernetes from control plane: %s", err.Error())
@@ -209,7 +209,7 @@ func (s *grpcServer) getDeploymentFor(pod *k8sV1.Pod) (string, error) {
 		return "", fmt.Errorf("Pod %s parent is not a ReplicaSet", pod.Name)
 	}
 
-	rs, err := s.lister.RS.GetPodReplicaSets(pod)
+	rs, err := s.k8sAPI.RS.Lister().GetPodReplicaSets(pod)
 	if err != nil {
 		return "", err
 	}

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -195,7 +195,7 @@ func NewServer(
 	addr string,
 	prometheusClient promApi.Client,
 	tapClient tapPb.TapClient,
-	lister *k8s.Lister,
+	k8sAPI *k8s.API,
 	controllerNamespace string,
 	ignoredNamespaces []string,
 ) *http.Server {
@@ -203,7 +203,7 @@ func NewServer(
 		grpcServer: newGrpcServer(
 			promv1.NewAPI(prometheusClient),
 			tapClient,
-			lister,
+			k8sAPI,
 			controllerNamespace,
 			ignoredNamespaces,
 		),

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -131,7 +131,7 @@ func statSummaryError(req *pb.StatSummaryRequest, message string) *pb.StatSummar
 }
 
 func (s *grpcServer) resourceQuery(ctx context.Context, req *pb.StatSummaryRequest) resourceResult {
-	objects, err := s.lister.GetObjects(req.Selector.Resource.Namespace, req.Selector.Resource.Type, req.Selector.Resource.Name)
+	objects, err := s.k8sAPI.GetObjects(req.Selector.Resource.Namespace, req.Selector.Resource.Type, req.Selector.Resource.Name)
 	if err != nil {
 		return resourceResult{res: nil, err: err}
 	}
@@ -410,7 +410,7 @@ func metricToKey(metric model.Metric, groupBy model.LabelNames) string {
 }
 
 func (s *grpcServer) getMeshedPodCount(obj runtime.Object) (*podCount, error) {
-	pods, err := s.lister.GetPodsFor(obj, true)
+	pods, err := s.k8sAPI.GetPodsFor(obj, true)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -51,8 +51,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-
-	lister := k8s.NewLister(k8sClient)
+	k8sAPI := k8s.NewAPI(k8sClient)
 
 	prometheusClient, err := promApi.NewClient(promApi.Config{Address: *prometheusUrl})
 	if err != nil {
@@ -63,15 +62,15 @@ func main() {
 		*addr,
 		prometheusClient,
 		tapClient,
-		lister,
+		k8sAPI,
 		*controllerNamespace,
 		strings.Split(*ignoredNamespaces, ","),
 	)
 
 	go func() {
-		err := lister.Sync()
+		err := k8sAPI.Sync()
 		if err != nil {
-			log.Fatalf("timed out wait for caches to sync: %s", err)
+			log.Fatal(err.Error())
 		}
 	}()
 

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -38,17 +38,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create Kubernetes client: %s", err)
 	}
-	lister := k8s.NewLister(clientSet)
+	k8sAPI := k8s.NewAPI(clientSet)
 
-	server, lis, err := tap.NewServer(*addr, *tapPort, lister)
+	server, lis, err := tap.NewServer(*addr, *tapPort, k8sAPI)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
 	go func() {
-		err := lister.Sync()
+		err := k8sAPI.Sync()
 		if err != nil {
-			log.Fatalf("timed out wait for caches to sync: %s", err)
+			log.Fatal(err.Error())
 		}
 	}()
 

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/runconduit/go-deps:69ba71ed as golang
+FROM gcr.io/runconduit/go-deps:23e16ad5 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV production
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/runconduit/go-deps:69ba71ed as golang
+FROM gcr.io/runconduit/go-deps:23e16ad5 as golang
 WORKDIR /go/src/github.com/runconduit/conduit
 COPY web web
 COPY controller controller


### PR DESCRIPTION
All of our controller services except the destination service use [Lister](https://github.com/runconduit/conduit/blob/master/controller/k8s/lister.go) to do cached reads against the Kubernetes API, leveraging shared informers from the [k8s.io/client-go/informers](https://github.com/kubernetes/client-go/tree/master/informers) package. The [GenericInformer](https://godoc.org/k8s.io/client-go/informers#GenericInformer) interface provides both an `Informer()` func for accessing the [SharedIndexInformer](https://godoc.org/k8s.io/client-go/tools/cache#SharedIndexInformer) interface and a `Lister()` func for accessing the [GenericLister](https://godoc.org/k8s.io/client-go/tools/cache#GenericLister) interface. To date, however, our `Lister` implementation has only provided access to the `GenericLister` interface for each resource type.

In order to move the destination service over to using shared informers, it's going to require access to the `SharedIndexInformer` interface for the endpoint and pod resources. In this branch, I'm renaming `Lister` to `API` and refactoring it to provide access to the `GenericInformer` interface instead of the `GenericLister` interface for each resource, which will allow us to use `API` for both listers and informers.

As part of this change I've added some test helpers to remove some of the redundancy that we had using shared informers in our tests.