### PR TITLE
Proxy: Map Kubernetes Pod Namespace/Name to TLS identity.

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -213,7 +213,7 @@ where
 
         // Map a socket address to a connection.
         let connect = self.sensors.connect(
-            transport::Connect::new(addr, ep.tls_identity()),
+            transport::Connect::new(addr, ep.tls_identity().map(|id| id.clone())),
             &client_ctx,
         );
 

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -213,7 +213,7 @@ where
 
         // Map a socket address to a connection.
         let connect = self.sensors.connect(
-            transport::Connect::new(addr, ep.tls_identity().map(|id| id.clone())),
+            transport::Connect::new(addr, ep.tls_identity().cloned()),
             &client_ctx,
         );
 

--- a/proxy/src/control/destination/endpoint.rs
+++ b/proxy/src/control/destination/endpoint.rs
@@ -1,7 +1,9 @@
 use std::net::SocketAddr;
 
 use telemetry::metrics::DstLabels;
-use super::{Metadata, TlsIdentity};
+use super::Metadata;
+use tls;
+use std::sync::Arc;
 
 /// An individual traffic target.
 ///
@@ -34,7 +36,7 @@ impl Endpoint {
         self.metadata.dst_labels()
     }
 
-    pub fn tls_identity(&self) -> Option<&TlsIdentity> {
+    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
         self.metadata.tls_identity()
     }
 }

--- a/proxy/src/control/destination/endpoint.rs
+++ b/proxy/src/control/destination/endpoint.rs
@@ -3,7 +3,6 @@ use std::net::SocketAddr;
 use telemetry::metrics::DstLabels;
 use super::Metadata;
 use tls;
-use std::sync::Arc;
 
 /// An individual traffic target.
 ///
@@ -36,7 +35,7 @@ impl Endpoint {
         self.metadata.dst_labels()
     }
 
-    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
+    pub fn tls_identity(&self) -> Option<&tls::Identity> {
         self.metadata.tls_identity()
     }
 }

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -95,7 +95,7 @@ pub struct Metadata {
     dst_labels: Option<DstLabels>,
 
     /// How to verify TLS for the endpoint.
-    tls_identity: Option<Arc<tls::Identity>>,
+    tls_identity: Option<tls::Identity>,
 }
 
 
@@ -250,7 +250,7 @@ impl Metadata {
     ) -> Self {
         Metadata {
             dst_labels,
-            tls_identity: tls_identity.map(Arc::new),
+            tls_identity,
         }
     }
 
@@ -259,7 +259,7 @@ impl Metadata {
         self.dst_labels.as_ref()
     }
 
-    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
+    pub fn tls_identity(&self) -> Option<&tls::Identity> {
         self.tls_identity.as_ref()
     }
 }

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -26,6 +26,7 @@
 
 use std::net::SocketAddr;
 use std::sync::{Arc, Weak};
+use tls;
 
 use futures::{
     sync::mpsc,
@@ -46,6 +47,7 @@ pub mod background;
 mod endpoint;
 
 pub use self::endpoint::Endpoint;
+use config::Namespaces;
 
 /// A handle to request resolutions from the background discovery task.
 #[derive(Clone, Debug)]
@@ -93,21 +95,7 @@ pub struct Metadata {
     dst_labels: Option<DstLabels>,
 
     /// How to verify TLS for the endpoint.
-    tls_identity: Option<Arc<TlsIdentity>>,
-}
-
-/// How to verify TLS for an endpoint.
-///
-/// XXX: This currently derives `PartialEq  and `Eq`, which is not entirely
-/// correct, as domain name equality ought to be case insensitive. However,
-/// `Metadata` must be `Eq`.
-#[derive(Debug, PartialEq, Eq)]
-pub enum TlsIdentity {
-    K8sPodNamespace {
-        controller_ns: String,
-        pod_ns: String,
-        pod_name: String,
-    },
+    tls_identity: Option<Arc<tls::Identity>>,
 }
 
 
@@ -153,7 +141,7 @@ pub trait Bind {
 /// to drive the background task.
 pub fn new(
     dns_resolver: dns::Resolver,
-    default_destination_namespace: String,
+    namespaces: Namespaces,
     host_and_port: HostAndPort,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
     let (request_tx, rx) = mpsc::unbounded();
@@ -161,7 +149,7 @@ pub fn new(
     let bg = background::task(
         rx,
         dns_resolver,
-        default_destination_namespace,
+        namespaces,
         host_and_port,
     );
     (disco, bg)
@@ -258,7 +246,7 @@ impl Metadata {
 
     pub fn new(
         dst_labels: Option<DstLabels>,
-        tls_identity: Option<TlsIdentity>
+        tls_identity: Option<tls::Identity>
     ) -> Self {
         Metadata {
             dst_labels,
@@ -271,7 +259,7 @@ impl Metadata {
         self.dst_labels.as_ref()
     }
 
-    pub fn tls_identity(&self) -> Option<&TlsIdentity> {
-        self.tls_identity.as_ref().map(Arc::as_ref)
+    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
+        self.tls_identity.as_ref()
     }
 }

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -2,9 +2,9 @@ use http;
 use std::sync::{Arc, atomic::AtomicUsize};
 
 use ctx;
-use control::destination;
 use telemetry::metrics::DstLabels;
 use std::sync::atomic::Ordering;
+use transport::tls;
 
 
 /// A `RequestId` can be mapped to a `u64`. No `RequestId`s will map to the
@@ -76,7 +76,7 @@ impl Request {
         Arc::new(r)
     }
 
-    pub fn tls_identity(&self) -> Option<&destination::TlsIdentity> {
+    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
         self.client.tls_identity()
     }
 
@@ -93,10 +93,6 @@ impl Response {
         };
 
         Arc::new(r)
-    }
-
-    pub fn tls_identity(&self) -> Option<&destination::TlsIdentity> {
-        self.request.tls_identity()
     }
 
     pub fn dst_labels(&self) -> Option<&DstLabels> {

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -76,7 +76,7 @@ impl Request {
         Arc::new(r)
     }
 
-    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
+    pub fn tls_identity(&self) -> Option<&tls::Identity> {
         self.client.tls_identity()
     }
 

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -48,7 +48,7 @@ impl Process {
     pub fn new(config: &config::Config) -> Arc<Self> {
         let start_time = SystemTime::now();
         Arc::new(Self {
-            scheduled_namespace: config.pod_namespace.clone(),
+            scheduled_namespace: config.namespaces.pod.clone(),
             start_time,
         })
     }

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use ctx;
 use control::destination;
 use telemetry::metrics::DstLabels;
+use transport::tls;
 
 #[derive(Debug)]
 pub enum Ctx {
@@ -93,7 +94,7 @@ impl Client {
         Arc::new(c)
     }
 
-    pub fn tls_identity(&self) -> Option<&destination::TlsIdentity> {
+    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
         self.metadata.tls_identity()
     }
 

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -94,7 +94,7 @@ impl Client {
         Arc::new(c)
     }
 
-    pub fn tls_identity(&self) -> Option<&Arc<tls::Identity>> {
+    pub fn tls_identity(&self) -> Option<&tls::Identity> {
         self.metadata.tls_identity()
     }
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -222,7 +222,7 @@ where
 
         let (resolver, resolver_bg) = control::destination::new(
             dns_resolver.clone(),
-            config.pod_namespace.clone(),
+            config.namespaces.clone(),
             control_host_and_port
         );
 

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -8,9 +8,10 @@ use std::str::FromStr;
 use http;
 
 use connection;
-use control::destination;
 use convert::TryFrom;
 use dns;
+use std::sync::Arc;
+use transport::tls;
 
 #[derive(Debug, Clone)]
 pub struct Connect {
@@ -102,7 +103,7 @@ impl Connect {
     /// Returns a `Connect` to `addr`.
     pub fn new(
         addr: SocketAddr,
-        tls_identity: Option<&destination::TlsIdentity>,
+        tls_identity: Option<Arc<tls::Identity>>,
     ) -> Self {
         // TODO: this is currently unused.
         let _ = tls_identity;

--- a/proxy/src/transport/connect.rs
+++ b/proxy/src/transport/connect.rs
@@ -10,7 +10,6 @@ use http;
 use connection;
 use convert::TryFrom;
 use dns;
-use std::sync::Arc;
 use transport::tls;
 
 #[derive(Debug, Clone)]
@@ -103,7 +102,7 @@ impl Connect {
     /// Returns a `Connect` to `addr`.
     pub fn new(
         addr: SocketAddr,
-        tls_identity: Option<Arc<tls::Identity>>,
+        tls_identity: Option<tls::Identity>,
     ) -> Self {
         // TODO: this is currently unused.
         let _ = tls_identity;

--- a/proxy/src/transport/tls/identity.rs
+++ b/proxy/src/transport/tls/identity.rs
@@ -1,0 +1,73 @@
+use conduit_proxy_controller_grpc;
+use convert::TryFrom;
+use super::{DnsName, InvalidDnsName};
+
+/// An endpoint's identity.
+///
+/// `Clone` isn't derived because `Identity` should be `Arc`ed.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Identity(DnsName);
+
+impl Identity {
+    /// Parses the given TLS identity, if provided.
+    ///
+    /// `controller_namespace` will be None if TLS is disabled.
+    ///
+    /// In the event of an error, the error is logged, so no detailed error
+    /// information is returned.
+    pub fn maybe_from(
+        pb: conduit_proxy_controller_grpc::destination::TlsIdentity,
+        controller_namespace: Option<&str>)
+        -> Result<Option<Self>, ()>
+    {
+        // Verifies that the string doesn't contain '.' so that it is safe to
+        // join it using '.' to try to form a DNS name. The rest of the DNS
+        // name rules will be enforced by `DnsName::try_from`.
+        fn check_single_label(value: &str, name: &str) -> Result<(), ()> {
+            if !value.contains('.') {
+                Ok(())
+            } else {
+                error!("Invalid {}: {:?}", name, value);
+                Err(())
+            }
+        }
+
+        use conduit_proxy_controller_grpc::destination::tls_identity::Strategy;
+        match pb.strategy {
+            Some(Strategy::K8sPodNamespace(i)) => {
+                // Log any/any per-component errors before returning.
+                let controller_ns_check = check_single_label(&i.controller_ns, "controller_ms");
+                let pod_ns_check = check_single_label(&i.pod_ns, "pod_ns");
+                let pod_name_check = check_single_label(&i.pod_name, "pod_name");
+                if controller_ns_check.is_err() || pod_ns_check.is_err() || pod_name_check.is_err() {
+                    return Err(());
+                }
+
+                // XXX: If we don't know the controller's namespace or we don't
+                // share the same controller then we won't be able to validate
+                // the certificate yet. TODO: Support cross-controller
+                // certificate validation and lock this down.
+                if controller_namespace != Some(i.controller_ns.as_ref()) {
+                    return Ok(None)
+                }
+
+                // We reserve all names under a fake "managed-pods" service in
+                // our namespace for identifying pods by name.
+                let mut name = i.pod_name;
+                name.push('.');
+                name.push_str(&i.pod_ns);
+                name.push_str(".conduit-managed-pods.");
+                name.push_str(&i.controller_ns);
+                name.push_str(".svc.cluster.local.");
+
+                DnsName::try_from(&name)
+                    .map(|name| Some(Identity(name)))
+                    .map_err(|InvalidDnsName| {
+                        error!("Invalid DNS name: {:?}", name);
+                        ()
+                    })
+            },
+            None => Ok(None), // No TLS.
+        }
+    }
+}

--- a/proxy/src/transport/tls/mod.rs
+++ b/proxy/src/transport/tls/mod.rs
@@ -9,9 +9,11 @@ mod config;
 mod cert_resolver;
 mod connection;
 mod dns_name;
+mod identity;
 
 pub use self::{
     config::{CommonSettings, CommonConfig, Error, ServerConfig, ServerConfigWatch},
     connection::Connection,
-    dns_name::DnsName,
+    dns_name::{DnsName, InvalidDnsName},
+    identity::Identity,
 };


### PR DESCRIPTION
Map the Kubernetes identity into a DNS name that can be used to
validate the peer's certificate. The final mapping is TBD; the
important thing for now is that the mapped name doesn't collide
with any real DNS name.

Encapsulate the mapping logic within the TLS submodule.

Minimize `Arc`ing and `Clone`ing of TLS identities.

This has no effect in default configurations since the settings that
enable the functionality are not set by default.

Signed-off-by: Brian Smith <brian@briansmith.org>