### PR TITLE
Handle an edge case when using bin/web

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -251,8 +251,7 @@ bin/web run
 
 The web server will be running on `localhost:8084`.
 
-Note the `web` process depends on a `public-api` server, for which you have
-three options:
+Note: by default, this requires a `public-api` server and assumes that it is running in a Kubernetes cluster. If that isn't the case, you have some other options:
 
 #### 1. Connect to `public-api` locally
 
@@ -270,29 +269,6 @@ docker-compose stop web
 bin/web run --api-addr=$DOCKER_IP:8085
 ```
 
-#### 3. Connect to `public-api` in Kubernetes
-
-If you are running the public API server in Kubernetes, forward `localhost:8085`
-to the Conduit controller pod:
-
-```bash
-kubectl --namespace=conduit port-forward $(
-  kubectl --namespace=conduit get po --selector=conduit.io/control-plane-component=controller -o jsonpath='{.items[*].metadata.name}'
-) 8085:8085
-```
-
-Note: you can also do this via:
-
-```bash
-bin/web port-forward
-```
-
-Then connect the local web process to the forwarded port:
-
-```bash
-bin/web run --api-addr=localhost:8085
-```
-
 ### Webpack dev server
 
 To develop with a webpack dev server, run:
@@ -300,6 +276,8 @@ To develop with a webpack dev server, run:
 ```bash
 bin/web dev
 ```
+
+Note: you'll want to install conduit on a Kubernetes cluster first.
 
 To add a JS dependency:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -251,7 +251,9 @@ bin/web run
 
 The web server will be running on `localhost:8084`.
 
-Note: by default, this requires a `public-api` server and assumes that it is running in a Kubernetes cluster. If that isn't the case, you have some other options:
+Note: by default, this requires a `public-api` server and assumes that it is
+running in a Kubernetes cluster. If that isn't the case, you have some other
+options:
 
 #### 1. Connect to `public-api` locally
 

--- a/bin/web
+++ b/bin/web
@@ -23,6 +23,15 @@ USAGE: web <command>
 USAGE
 }; function --help { -h ;}
 
+function check-for-conduit {
+  pod=$(get-pod)
+
+  if [[ -z "${pod// }" ]]; then
+    err "Controller is not running. Have you installed Conduit?"
+    exit 1
+  fi
+}
+
 function dev {
   build
 
@@ -32,7 +41,7 @@ function dev {
     esac
   done
 
-  port-forward &
+  check-for-conduit && (port-forward &)
 
   cd $ROOT/web/app && yarn webpack-dev-server --port $DEV_PORT &
   cd $ROOT/web && \
@@ -47,16 +56,11 @@ function build {
 function get-pod {
   kubectl --namespace=conduit get po \
     --selector=conduit.io/control-plane-component=controller \
+    --field-selector='status.phase==Running' \
     -o jsonpath='{.items[*].metadata.name}'
 }
 
 function port-forward {
-  pod=$(get-pod)
-
-  [[ ! -z "${pod// }" ]] || \
-    (printf "Controller is not running. Have you installed conduit?\n" && \
-    exit 1)
-
   nc -z localhost 8085 || \
     kubectl --namespace=conduit port-forward $(get-pod) 8085:8085
 }
@@ -64,7 +68,7 @@ function port-forward {
 function run {
   build
 
-  port-forward &
+  check-for-conduit && (port-forward &)
 
   cd $ROOT/web
   ../bin/go-run . $*

--- a/bin/web
+++ b/bin/web
@@ -44,12 +44,21 @@ function build {
   yarn webpack
 }
 
+function get-pod {
+  kubectl --namespace=conduit get po \
+    --selector=conduit.io/control-plane-component=controller \
+    -o jsonpath='{.items[*].metadata.name}'
+}
+
 function port-forward {
-  nc -z localhost 8085 || kubectl --namespace=conduit port-forward $(
-    kubectl --namespace=conduit get po \
-      --selector=conduit.io/control-plane-component=controller \
-      -o jsonpath='{.items[*].metadata.name}'
-  ) 8085:8085
+  pod=$(get-pod)
+
+  [[ ! -z "${pod// }" ]] || \
+    (printf "Controller is not running. Have you installed conduit?\n" && \
+    exit 1)
+
+  nc -z localhost 8085 || \
+    kubectl --namespace=conduit port-forward $(get-pod) 8085:8085
 }
 
 function run {


### PR DESCRIPTION
There's a weird error running `bin/web dev` if you don't have conduit installed on a kubernetes cluster. Nothing in the docs mention that you need to work on this.

Output a user friendly error when we can't find a pod and update the docs to remind folks to install conduit first. Fixes #1070