### PR TITLE
proxy: detect TLS configuration changes using inotify on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/fix-einval)",
+ "inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -460,7 +460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "inotify"
 version = "0.5.2-dev"
-source = "git+https://github.com/hawkw/inotify?branch=eliza/fix-einval#cf728feba40d363c1d8e59ac9baffe7114827e52"
+source = "git+https://github.com/inotify-rs/inotify#901abf4e076e2c96bc4d485d235b7f732bf01b36"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1517,7 +1517,7 @@ dependencies = [
 "checksum hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6416251e6672bff06fe96a3337570772845a44500fba2d178e2e55e0fab58a86"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
-"checksum inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/fix-einval)" = "<none>"
+"checksum inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)" = "<none>"
 "checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec4e18c0a0d4340870c14284293632d8421f419008371422dd327892b88877c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/fix-einval)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -455,6 +456,25 @@ dependencies = [
 name = "indexmap"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "inotify"
+version = "0.5.2-dev"
+source = "git+https://github.com/hawkw/inotify?branch=eliza/fix-einval#cf728feba40d363c1d8e59ac9baffe7114827e52"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iovec"
@@ -1497,6 +1517,8 @@ dependencies = [
 "checksum hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6416251e6672bff06fe96a3337570772845a44500fba2d178e2e55e0fab58a86"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
+"checksum inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/fix-einval)" = "<none>"
+"checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec4e18c0a0d4340870c14284293632d8421f419008371422dd327892b88877c"
 "checksum ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -59,6 +59,7 @@ untrusted = "0.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
+inotify = { git = "https://github.com/hawkw/inotify", branch = "eliza/fix-einval" }
 
 [dev-dependencies]
 net2 = "0.2"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -59,7 +59,8 @@ untrusted = "0.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-inotify = { git = "https://github.com/hawkw/inotify", branch = "eliza/fix-einval" }
+# We can use the `crates.io` version of `inotify` once 0.5.2 has been released.
+inotify = { git = "https://github.com/inotify-rs/inotify" }
 
 [dev-dependencies]
 net2 = "0.2"

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -15,6 +15,8 @@ extern crate h2;
 extern crate http;
 extern crate httparse;
 extern crate hyper;
+#[cfg(target_os = "linux")]
+extern crate inotify;
 extern crate ipnet;
 #[cfg(target_os = "linux")]
 extern crate libc;

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -173,13 +173,13 @@ impl CommonSettings {
         -> Result<impl Stream<Item = (), Error = ()>, Error>
     {
         use inotify::{Inotify, WatchMask};
-        // NOTE: If we used a less broad watch mask, we could probably avoid
-        //       reloading the certs multiple times when k8s modifies a
-        //       ConfigMap (a multi-step process that we see as a series of
-        //       CREATE, MOVED_TO, MOVED_FROM, and DELETE events). However,
-        //       this may not catch changes if the files we're watching *don't*
-        //       live in a k8s ConfigMap, and I think false positives are
-        //       much less harmful here than false negatives.
+        // If we used a less broad watch mask, we could avoid reloading the
+        // certs multiple times when k8s modifies a ConfigMap or Secret (a
+        // multi-step process that we see as a series of CREATE, MOVED_TO,
+        // MOVED_FROM, and DELETE events). However, this may not catch changes
+        // if the files we're watching *don't* live in a k8s ConfigMap/Secret,
+        // and I think false positives are much less harmful here than false
+        // negatives.
         let mask = WatchMask::CREATE
                  | WatchMask::MODIFY
                  | WatchMask::DELETE
@@ -190,8 +190,8 @@ impl CommonSettings {
         for path in &self.paths() {
             // If the path we want to watch has a parent, watch that instead.
             // This will allow us to pick up events to files in k8s ConfigMaps
-            // (which we wouldn't detect if we watch the file itself, as they
-            // are double-symlinked).
+            // or Secrets (which we wouldn't detect if we watch the file itself,
+            // as they are double-symlinked).
             //
             // This may also result in some false positives (if a file we
             // *don't* care about in the same dir changes, we'll still reload),

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{self, Cursor, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant, SystemTime,},
 };


### PR DESCRIPTION
This branch adds an inotify-based implementation of filesystem watches
for the TLS config files. On Linux, where inotify is available, this is
used instead of the polling-based code I added in #1056 and #1076.

In order to avoid the issues detecting changes to files in Kubernetes 
ConfigMaps described in #1061, we watch the directory _containing_ the
files we care about rather than the files themselves. I've tested this 
manually in Docker for Mac Kubernetes and can confirm that ConfigMap
changes are detected successfully.

Note that this currently depends on code added to the `inotify` crate in 
my upstream pull request inotify-rs/inotify#103, rather than the version
on crates.io.

Closes #1061. Closes #369.