### PR TITLE
Fix conduit health grafana dashboard

### DIFF
--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -85,7 +85,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod) / sum(irate(response_total{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod)",
+          "expr": "sum(irate(response_total{classification=\"success\", deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (deployment, pod) / sum(irate(response_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (deployment, pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "po/{{pod}}",
@@ -169,7 +169,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod)",
+          "expr": "sum(irate(request_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (deployment, pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "po/{{pod}}",
@@ -253,21 +253,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
+          "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p50 po/{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p95 po/{{pod}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
+          "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}[30s])) by (le, deployment, pod))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 po/{{pod}}",
@@ -405,7 +405,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tcp_close_total{deployment=\"$deployment\", direction=\"inbound\",classification=\"failure\"}",
+              "expr": "tcp_close_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\",classification=\"failure\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -488,7 +488,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tcp_open_connections{deployment=\"$deployment\", direction=\"inbound\"}",
+              "expr": "tcp_open_connections{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{peer}}",
@@ -571,7 +571,7 @@
           },
           "targets": [
             {
-              "expr": "tcp_connection_duration_ms_bucket{deployment=\"$deployment\", direction=\"inbound\"}",
+              "expr": "tcp_connection_duration_ms_bucket{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -1446,6 +1446,26 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Conduit Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(request_total{conduit_io_control_plane_ns!=\"\"},  conduit_io_control_plane_ns)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -1481,5 +1501,5 @@
   "timezone": "",
   "title": "Conduit Health",
   "uid": "Og9nanzmk",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
*Problem*
In the conduit health dashboard, we were making queries such as:
```
sum(irate(request_total{deployment=\"$deployment\", direction=\"inbound\"}[30s])) by (deployment, pod)
```
for every `$deployment` associated with conduit. Unfortunately, if another deployment in another namespace was present with the same name as a conduit controller deployment, its stats would get included as well.

*Fix*
Scope the prometheus queries to a conduit controller namespace by adding `namespace=\"$namespace\"` to the queries.

Adds a `Conduit Namespace` grafana variable on this page, so that we can use a prometheus query to determine the conduit namespace(s) available to get data from. (If there is more than one conduit install, you can switch between conduit namespaces)

![screen shot 2018-06-07 at 4 31 25 pm](https://user-images.githubusercontent.com/549258/41131853-70219a6c-6a72-11e8-9927-e810d9403411.png)

Fixes #852
