### PR TITLE
proxy: Forward TLS config to client watches

### DIFF
--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -126,7 +126,7 @@ impl BoundPort {
                     // libraries don't have the necessary API for that, so just
                     // do it here.
                     set_nodelay_or_warn(&socket);
-                    match tls_config.borrow().as_ref() {
+                    match tls_config.clone_current() {
                         Some(tls_config) => {
                             Either::A(
                                 tls::Connection::accept(socket, tls_config.clone())

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -126,7 +126,7 @@ impl BoundPort {
                     // libraries don't have the necessary API for that, so just
                     // do it here.
                     set_nodelay_or_warn(&socket);
-                    match tls_config.clone_current() {
+                    match tls_config.borrow().as_ref() {
                         Some(tls_config) => {
                             Either::A(
                                 tls::Connection::accept(socket, tls_config.clone())

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -232,7 +232,7 @@ where
 
         let bind = Bind::new().with_sensors(sensors.clone());
 
-        let (tls_server_config, tls_cfg_bg) =
+        let (_tls_client_config, tls_server_config, tls_cfg_bg) =
             tls::watch_for_config_changes(config.tls_settings.as_ref());
 
         // Setup the public listener. This will listen on a publicly accessible


### PR DESCRIPTION
This commit adds the initial wiring to forward TLS config changes to the 
watches used by TLS clients as well as TLS servers. As the TLS clients
are not yet implemented, the config type is currently `()`, but once
the client config is implemented, we should be able to drop it in 
seamlessly.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
Co-authored-by: Brian Smith <brian@briansmith.org>