### PR TITLE
CLI: print resources in the same order every time `stat all` is run

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -224,15 +224,18 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 	}
 
 	lastDisplayedStat := true // don't print a newline after the final stat
-	for resourceType, stats := range statTables {
-		if !lastDisplayedStat {
-			fmt.Fprint(w, "\n")
-		}
-		lastDisplayedStat = false
-		if reqResourceType == k8s.All {
-			printStatTable(stats, resourceType, w, maxNameLength, maxNamespaceLength, options)
-		} else {
-			printStatTable(stats, "", w, maxNameLength, maxNamespaceLength, options)
+
+	for _, resourceType := range k8s.StatAllResourceTypes {
+		if stats, ok := statTables[resourceType]; ok {
+			if !lastDisplayedStat {
+				fmt.Fprint(w, "\n")
+			}
+			lastDisplayedStat = false
+			if reqResourceType == k8s.All {
+				printStatTable(stats, resourceType, w, maxNameLength, maxNamespaceLength, options)
+			} else {
+				printStatTable(stats, "", w, maxNameLength, maxNamespaceLength, options)
+			}
 		}
 	}
 }

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -47,9 +47,6 @@ const (
 
 var promTypes = []promType{promRequests, promLatencyP50, promLatencyP95, promLatencyP99}
 
-// resources to query when Resource.Type is "all"
-var resourceTypes = []string{k8s.Pods, k8s.Deployments, k8s.ReplicationControllers, k8s.Services}
-
 type podCount struct {
 	inMesh uint64
 	total  uint64
@@ -83,7 +80,7 @@ func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest
 
 	var resourcesToQuery []string
 	if req.Selector.Resource.Type == k8s.All {
-		resourcesToQuery = resourceTypes
+		resourcesToQuery = k8s.StatAllResourceTypes
 	} else {
 		resourcesToQuery = []string{req.Selector.Resource.Type}
 	}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -27,6 +27,9 @@ var ResourceTypesToProxyLabels = map[string]string{
 	Services:               "service",
 }
 
+// resources to query in StatSummary when Resource.Type is "all"
+var StatAllResourceTypes = []string{Deployments, ReplicationControllers, Pods, Services}
+
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
 	if string(extraPathStartingWithSlash[0]) != "/" {
 		return nil, fmt.Errorf("Path must start with a [/], was [%s]", extraPathStartingWithSlash)


### PR DESCRIPTION
Previously, in `conduit stat all` we would just print the map of stat results, which resulted in the order in which stats were displayed varying between prints.

Fix:
Define an array, `k8s.StatAllResourceTypes` and use the order in this array to print the map; ensuring a consistent print order every time the command is run.

Fixes #1014 

```
$ go run cli/main.go stat all --all-namespaces
NAMESPACE     NAME                                            MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   SECURED
conduit       deploy/controller                                  1/1   100.00%   0.5rps          35ms         875ms         975ms        0%
conduit       deploy/grafana                                     1/1   100.00%   0.1rps          15ms          20ms          20ms        0%
conduit       deploy/prometheus                                  1/1   100.00%   0.4rps         500ms         950ms         990ms        0%
conduit       deploy/web                                         1/1   100.00%   0.1rps           5ms          10ms          10ms        0%
docker        deploy/compose                                     0/1         -        -             -             -             -         -
docker        deploy/compose-api                                 0/1         -        -             -             -             -         -
emojivoto     deploy/emoji                                       2/2   100.00%   1.8rps           7ms         362ms         392ms        0%
emojivoto     deploy/vote-bot                                    1/1         -        -             -             -             -         -
emojivoto     deploy/voting                                      2/2    88.89%   0.9rps           7ms         460ms         492ms        0%
emojivoto     deploy/web                                         2/2    92.73%   1.8rps          23ms         126ms         185ms        0%
kube-system   deploy/kube-dns                                    0/1         -        -             -             -             -         -

NAMESPACE     NAME                                            MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   SECURED
conduit       po/controller-5fdffd78f5-vq7sq                     1/1   100.00%   0.5rps          35ms         875ms         975ms        0%
conduit       po/grafana-794d476894-wm6zb                        1/1   100.00%   0.1rps          15ms          20ms          20ms        0%
conduit       po/prometheus-88864f954-2xckm                      1/1   100.00%   0.4rps         500ms         950ms         990ms        0%
conduit       po/web-55b88fbb5-6x5s2                             1/1   100.00%   0.1rps           5ms          10ms          10ms        0%
docker        po/compose-5d4f4d67b6-b2xc4                        0/1         -        -             -             -             -         -
docker        po/compose-api-7bb7b5968f-tnk5b                    0/1         -        -             -             -             -         -
emojivoto     po/emoji-86ccdcd948-gk695                          1/1   100.00%   0.8rps           6ms          80ms          96ms        0%
emojivoto     po/emoji-86ccdcd948-vmdz2                          1/1   100.00%   1.0rps           9ms         382ms         397ms        0%
emojivoto     po/vote-bot-6b444cd764-tqsfv                       1/1         -        -             -             -             -         -
emojivoto     po/voting-548db956c4-529zw                         1/1    90.91%   0.4rps           8ms         475ms         495ms        0%
emojivoto     po/voting-548db956c4-vrxl8                         1/1    87.50%   0.5rps           5ms          10ms          10ms        0%
emojivoto     po/web-5df7f5d886-7wngw                            1/1    87.50%   0.9rps          25ms         175ms         195ms        0%
emojivoto     po/web-5df7f5d886-gmpzj                            1/1    98.15%   0.9rps          20ms          88ms          98ms        0%
kube-system   po/etcd-docker-for-desktop                         0/1         -        -             -             -             -         -
kube-system   po/kube-apiserver-docker-for-desktop               0/1         -        -             -             -             -         -
kube-system   po/kube-controller-manager-docker-for-desktop      0/1         -        -             -             -             -         -
kube-system   po/kube-dns-6f4fd4bdf-nb9h2                        0/1         -        -             -             -             -         -
kube-system   po/kube-proxy-6bxpw                                0/1         -        -             -             -             -         -
kube-system   po/kube-scheduler-docker-for-desktop               0/1         -        -             -             -             -         -

NAMESPACE     NAME                                            MESHED   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   SECURED
conduit       svc/api                                            1/1         -     -             -             -             -         -
conduit       svc/grafana                                        1/1         -     -             -             -             -         -
conduit       svc/prometheus                                     1/1         -     -             -             -             -         -
conduit       svc/proxy-api                                      1/1         -     -             -             -             -         -
conduit       svc/web                                            1/1         -     -             -             -             -         -
default       svc/kubernetes                                     0/0         -     -             -             -             -         -
docker        svc/compose-api                                    0/1         -     -             -             -             -         -
emojivoto     svc/emoji-svc                                      2/2         -     -             -             -             -         -
emojivoto     svc/voting-svc                                     2/2         -     -             -             -             -         -
emojivoto     svc/web-svc                                        2/2         -     -             -             -             -         -
kube-system   svc/kube-dns                                       0/1         -     -             -             -             -         -
```
