### PR TITLE
Remove the ⚠️ emoji from non-TLS grafana stat labels

### DIFF
--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -514,7 +514,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\", tls!=\"true\"}[30s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️deploy/{{deployment}}",
+          "legendFormat": "deploy/{{deployment}}",
           "refId": "B"
         }
       ],
@@ -1078,7 +1078,7 @@
               "expr": "sum(irate(request_total{deployment!=\"\", deployment=\"$inbound\", dst_namespace=\"$namespace\", dst_deployment=\"$deployment\", direction=\"outbound\", tls!=\"true\"}[30s])) by (deployment, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "⚠️po/{{pod}}",
+              "legendFormat": "po/{{pod}}",
               "refId": "B"
             }
           ],
@@ -1387,7 +1387,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️deploy/{{dst_deployment}}",
+          "legendFormat": "deploy/{{dst_deployment}}",
           "refId": "B"
         }
       ],
@@ -1942,7 +1942,7 @@
               "expr": "sum(irate(request_total{namespace=\"$namespace\", deployment=\"$deployment\", dst_deployment=\"$outbound\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_deployment)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "⚠️deploy/{{dst_deployment}}",
+              "legendFormat": "deploy/{{dst_deployment}}",
               "refId": "B"
             }
           ],

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -515,7 +515,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"inbound\", tls!=\"true\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️po/{{pod}}",
+          "legendFormat": "po/{{pod}}",
           "refId": "B"
         }
       ],
@@ -808,7 +808,7 @@
           "expr": "sum(irate(request_total{dst_namespace=\"$namespace\", dst_pod!=\"\", dst_pod=\"$pod\", direction=\"outbound\", tls!=\"true\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️po/{{pod}}",
+          "legendFormat": "po/{{pod}}",
           "refId": "B"
         }
       ],
@@ -1101,7 +1101,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\", tls!=\"true\"}[30s])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️po/{{pod}}",
+          "legendFormat": "po/{{pod}}",
           "refId": "B"
         }
       ],
@@ -1394,7 +1394,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", pod=\"$pod\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️po/{{dst_pod}}",
+          "legendFormat": "po/{{dst_pod}}",
           "refId": "B"
         }
       ],

--- a/grafana/dashboards/replication-controller.json
+++ b/grafana/dashboards/replication-controller.json
@@ -514,7 +514,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\", tls!=\"true\"}[30s])) by (replication_controller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️rc/{{replication_controller}}",
+          "legendFormat": "rc/{{replication_controller}}",
           "refId": "B"
         }
       ],
@@ -832,7 +832,7 @@
               "expr": "sum(irate(request_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\", tls!=\"true\"}[30s])) by (replication_controller, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "⚠️po/{{pod}}",
+              "legendFormat": "po/{{pod}}",
               "refId": "B"
             }
           ],
@@ -1141,7 +1141,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replication_controller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️rc/{{dst_replication_controller}}",
+          "legendFormat": "rc/{{dst_replication_controller}}",
           "refId": "B"
         }
       ],
@@ -1441,7 +1441,7 @@
               "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replication_controller)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "⚠️rc/{{dst_replication_controller}}",
+              "legendFormat": "rc/{{dst_replication_controller}}",
               "refId": "B"
             }
           ],

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -433,7 +433,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_service)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️svc/{{dst_service}}",
+          "legendFormat": "svc/{{dst_service}}",
           "refId": "B"
         }
       ],
@@ -725,7 +725,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_service, deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️deploy/{{deployment}}",
+          "legendFormat": "deploy/{{deployment}}",
           "refId": "B"
         }
       ],
@@ -1000,7 +1000,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", dst_service=\"$service\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_service, pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️po/{{pod}}",
+          "legendFormat": "po/{{pod}}",
           "refId": "B"
         }
       ],

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -510,7 +510,7 @@
           "expr": "sum(irate(request_total{namespace=~\"$namespace\", direction=\"inbound\", tls!=\"true\"}[30s])) by (namespace)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️ns/{{namespace}}",
+          "legendFormat": "ns/{{namespace}}",
           "refId": "B"
         }
       ],
@@ -815,7 +815,7 @@
           "expr": "sum(irate(request_total{namespace=\"$namespace\", direction=\"inbound\", tls!=\"true\"}[30s])) by (deployment)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "⚠️deploy/{{deployment}}",
+          "legendFormat": "deploy/{{deployment}}",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
Removes the ⚠️ emoji from graph labels for traffic that is non-TLS.

TLSed traffic will continue to have the 🔒 emoji in the label. 