### PR TITLE
proxy: Detect config file changes with hashes rather than timestamps

### DIFF
--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -1,14 +1,16 @@
 use std::{
-    fs::File,
+    cell::RefCell,
+    fs::{self, File},
     io::{self, Cursor, Read},
     path::PathBuf,
     sync::Arc,
-    time::{Duration, Instant, SystemTime,},
+    time::{Duration, Instant},
 };
 
 use super::{
     cert_resolver::CertResolver,
 
+    ring::digest::{self, Digest},
     rustls,
     untrusted,
     webpki,
@@ -40,6 +42,15 @@ pub struct CommonSettings {
 
     /// The private key in DER-encoded PKCS#8 form.
     pub private_key: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct PathAndHash {
+    /// The path to the file.
+    path: PathBuf,
+
+    /// The last SHA-384 digest of the file, if we have previously hashed it.
+    last_hash: RefCell<Option<Digest>>,
 }
 
 /// Validated configuration common between TLS clients and TLS servers.
@@ -119,50 +130,38 @@ impl CommonSettings {
 
     /// Stream changes by polling the filesystem.
     ///
-    /// This will poll the filesystem for changes to the files at the paths
+    /// This will calculate the SHA-384 hash of each of files at the paths
     /// described by this `CommonSettings` every `interval`, and attempt to
-    /// load a new `CommonConfig` from the files again after each change.
+    /// load a new `CommonConfig` from the files again if any of the hashes
+    /// has changed.
     ///
     /// This is used on operating systems other than Linux, or on Linux if
     /// our attempt to use `inotify` failed.
     fn stream_changes_polling(&self, interval: Duration)
         -> impl Stream<Item = (), Error = ()>
     {
-        fn last_modified(path: &PathBuf) -> Option<SystemTime> {
-            // We have to canonicalize the path _every_ time we poll the fs,
-            // rather than once when we start watching, because if it's a
-            // symlink, the target may change. If that happened, and we
-            // continued watching the original canonical path, we wouldn't see
-            // any subsequent changes to the new symlink target.
-            path.canonicalize()
-                .and_then(|canonical| {
-                    trace!("last_modified: {:?} -> {:?}", path, canonical);
-                    canonical.symlink_metadata()
-                        .and_then(|meta| meta.modified())
-                })
-                .map_err(|e| if e.kind() != io::ErrorKind::NotFound {
-                    // Don't log if the files don't exist, since this
-                    // makes the logs *quite* noisy.
-                    warn!("error reading metadata for {:?}: {}", path, e)
-                })
-                .ok()
-        }
-
-        let paths = self.paths().iter()
-            .map(|&p| p.clone())
-            .collect::<Vec<PathBuf>>();
-
-        let mut max: Option<SystemTime> = None;
+        let files = self.paths().iter()
+            .map(|&p| PathAndHash::new(p.clone()))
+            .collect::<Vec<_>>();
 
         Interval::new(Instant::now(), interval)
             .map_err(|e| error!("timer error: {:?}", e))
             .filter_map(move |_| {
-                for path in &paths  {
-                    let t = last_modified(path);
-                    if t > max {
-                        max = t;
-                        trace!("{:?} changed at {:?}", path, t);
-                        return Some(());
+                for file in &files  {
+                    match file.has_changed() {
+                        Ok(true) => {
+                            trace!("{:?} changed", &file.path);
+                            return Some(());
+                        },
+                        Err(ref e) if e.kind() != io::ErrorKind::NotFound => {
+                            // Ignore file not found errors so the log doesn't
+                            // get too noisy.
+                            warn!("error hashing {:?}: {}", &file.path, e);
+                        },
+                        _ => {
+                            // If the file doesn't exist or the hash hasn't changed,
+                            // keep going.
+                        },
                     }
                 }
                 None
@@ -227,6 +226,30 @@ impl CommonSettings {
         trace!("started inotify watch");
 
         Ok(events)
+    }
+}
+
+impl PathAndHash {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            last_hash: RefCell::new(None),
+        }
+    }
+
+    fn has_changed(&self) -> io::Result<bool> {
+        let contents = fs::read(&self.path)?;
+        let hash = Some(digest::digest(&digest::SHA256, &contents[..]));
+        let changed = self.last_hash
+            .borrow().as_ref()
+            .map(Digest::as_ref) != hash.as_ref().map(Digest::as_ref);
+        if changed {
+            self.last_hash.replace(hash);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+
     }
 }
 


### PR DESCRIPTION
This PR changes the way the polling FS watcher detects changes in TLS
config files. Previously, we used the last modified timestamp to 
detect changes. However, this didn't work correctly on operating systems
which report timestamps with second precision. Now, we detect changes by
comparing the current and previous SHA-384 hashes of the file's contents.

This allows us to detect changes without relying on (unreliable) OS 
timestamps.

Closes #1090.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>