### PR TITLE
Grafana: remove fill and stack from individual resource breakouts

### DIFF
--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -1037,7 +1037,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -1064,7 +1064,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {
@@ -1901,7 +1901,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -1928,7 +1928,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {

--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -473,7 +473,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -500,7 +500,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -756,7 +756,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -783,7 +783,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {
@@ -1346,7 +1346,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -1373,7 +1373,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -1616,7 +1616,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -1643,7 +1643,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -138,7 +138,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -165,7 +165,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -457,7 +457,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -484,7 +484,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -474,7 +474,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -501,7 +501,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -1060,7 +1060,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -1087,7 +1087,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -767,7 +767,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -794,7 +794,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -1353,7 +1353,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -1380,7 +1380,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {

--- a/grafana/dashboards/replication-controller.json
+++ b/grafana/dashboards/replication-controller.json
@@ -473,7 +473,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -500,7 +500,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -1100,7 +1100,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -1127,7 +1127,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {

--- a/grafana/dashboards/replication-controller.json
+++ b/grafana/dashboards/replication-controller.json
@@ -791,7 +791,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -818,7 +818,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {
@@ -1400,7 +1400,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "fill": 1,
+          "fill": 0,
           "gridPos": {
             "h": 7,
             "w": 8,
@@ -1427,7 +1427,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -684,7 +684,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -711,7 +711,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -959,7 +959,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -986,7 +986,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -392,7 +392,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -419,7 +419,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -469,7 +469,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -496,7 +496,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
@@ -774,7 +774,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -801,7 +801,7 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {


### PR DESCRIPTION
At the request of @olix0r, remove the filling and stacking in request rate graphs that combine resources, to make it easier to spot outliers.

![screen shot 2018-06-08 at 3 32 27 pm](https://user-images.githubusercontent.com/549258/41183765-339ad7ce-6b31-11e8-9f33-514ba3109517.png)
