### PR TITLE
Move from /api/stat to /api/tps-reports

### DIFF
--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -84,7 +84,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
       type = "replicationcontroller";
     }
 
-    let baseUrl = '/api/stat?resource_type=' + type;
+    let baseUrl = '/api/tps-reports?resource_type=' + type;
     return !namespace ? baseUrl : baseUrl + '&namespace=' + namespace;
   };
 

--- a/web/app/test/ApiHelpersTest.jsx
+++ b/web/app/test/ApiHelpersTest.jsx
@@ -250,24 +250,24 @@ describe('ApiHelpers', () => {
     });
 
     it('adds a ?window= if metricsWindow is the only param', () => {
-      api.fetchMetrics('/api/stat');
+      api.fetchMetrics('/api/tps-reports');
 
       expect(fetchStub.calledOnce).to.be.true;
-      expect(fetchStub.args[0][0]).to.equal('/api/stat?window=1m');
+      expect(fetchStub.args[0][0]).to.equal('/api/tps-reports?window=1m');
     });
 
     it('adds &window= if metricsWindow is not the only param', () => {
-      api.fetchMetrics('/api/stat?foo=3&bar="me"');
+      api.fetchMetrics('/api/tps-reports?foo=3&bar="me"');
 
       expect(fetchStub.calledOnce).to.be.true;
-      expect(fetchStub.args[0][0]).to.equal('/api/stat?foo=3&bar="me"&window=1m');
+      expect(fetchStub.args[0][0]).to.equal('/api/tps-reports?foo=3&bar="me"&window=1m');
     });
 
     it('does not add another &window= if there is already a window param', () => {
-      api.fetchMetrics('/api/stat?foo=3&window=24h&bar="me"');
+      api.fetchMetrics('/api/tps-reports?foo=3&window=24h&bar="me"');
 
       expect(fetchStub.calledOnce).to.be.true;
-      expect(fetchStub.args[0][0]).to.equal('/api/stat?foo=3&window=24h&bar="me"');
+      expect(fetchStub.args[0][0]).to.equal('/api/tps-reports?foo=3&window=24h&bar="me"');
     });
   });
 
@@ -285,19 +285,19 @@ describe('ApiHelpers', () => {
     it('returns the correct rollup url for deployment overviews', () => {
       api = ApiHelpers('/go/my/own/way');
       let deploymentUrl = api.urlsForResource("deployment");
-      expect(deploymentUrl).to.equal('/api/stat?resource_type=deployment');
+      expect(deploymentUrl).to.equal('/api/tps-reports?resource_type=deployment');
     });
 
     it('returns the correct rollup url for pod overviews', () => {
       api = ApiHelpers('/go/my/own/way');
       let deploymentUrls = api.urlsForResource("pod");
-      expect(deploymentUrls).to.equal('/api/stat?resource_type=pod');
+      expect(deploymentUrls).to.equal('/api/tps-reports?resource_type=pod');
     });
 
     it('scopes the query to the provided namespace', () => {
       api = ApiHelpers('/go/my/own/way');
       let deploymentUrls = api.urlsForResource("pod", "my-ns");
-      expect(deploymentUrls).to.equal('/api/stat?resource_type=pod&namespace=my-ns');
+      expect(deploymentUrls).to.equal('/api/tps-reports?resource_type=pod&namespace=my-ns');
     });
   });
 });

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -95,7 +95,7 @@ func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackD
 
 	// webapp api routes
 	server.router.GET("/api/version", handler.handleApiVersion)
-	server.router.GET("/api/stat", handler.handleApiStat)
+	server.router.GET("/api/tps-reports", handler.handleApiStat)
 	server.router.GET("/api/pods", handler.handleApiPods)
 
 	return httpServer


### PR DESCRIPTION
Common blacklists have `/api/stat` in them. This causes the dashboard to not load.

`/api/tps-reports` is not in any blacklists, suggests what this route does and is slightly tongue in cheek. Fixes #970