### PR TITLE
Fix unbound `DOCKER_TRACE` var in `bin/docker-test-proxy`

### DIFF
--- a/bin/docker-test-proxy
+++ b/bin/docker-test-proxy
@@ -2,6 +2,9 @@
 
 set -eu
 
+# When set, causes docker's build output to be emitted to stderr.
+export DOCKER_TRACE="${DOCKER_TRACE:-}"
+
 if [ $# -ne 0 ]; then
     echo "no arguments allowed for $(basename $0), given: $@" >&2
     exit 64


### PR DESCRIPTION
I forgot to export this since the script no longer sources `. bin/_docker.sh`.