### PR TITLE
Upgrade enzyme-context-patch to its latest version

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -42,7 +42,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react-app": "^3.1.1",
     "css-loader": "^0.28.7",
-    "enzyme-context-patch": "^0.0.7",
+    "enzyme-context-patch": "^0.0.8",
     "eslint": "^4.12.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-loader": "^1.9.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -2650,9 +2650,9 @@ enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
-enzyme-context-patch@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/enzyme-context-patch/-/enzyme-context-patch-0.0.7.tgz#24559e8ed25e83ced33bfc72fe7e1678a5d90a28"
+enzyme-context-patch@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/enzyme-context-patch/-/enzyme-context-patch-0.0.8.tgz#ef47acae52f1dc755b92c8b2b8a35b8cc5eb924b"
 
 enzyme@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
I've been getting test failures on #1104 and on master of `Error: Enzyme Internal Error: unknown node with tag 12`... not sure why these tests are failing out of the blue. Upgrading the patch for this bug seems to fix it.

https://www.npmjs.com/package/enzyme-context-patch

This is a temporary fix until enzyme releases with the fix for the
`Error: Enzyme Internal Error: unknown node with tag 12` bug