### PR TITLE
docker-test-proxy: Add RUST_LOG, pass args to `cargo test`

### DIFF
--- a/bin/docker-test-proxy
+++ b/bin/docker-test-proxy
@@ -4,11 +4,7 @@ set -eu
 
 # When set, causes docker's build output to be emitted to stderr.
 export DOCKER_TRACE="${DOCKER_TRACE:-}"
-
-if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
-    exit 64
-fi
+export RUST_LOG="${RUST_LOG:-}"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rootdir="$( cd $bindir/.. && pwd )"
@@ -22,4 +18,4 @@ docker build -f $rootdir/proxy/Dockerfile . \
     --target build \
     -t proxy-build \
     --build-arg=PROXY_UNOPTIMIZED=1 > "$output"
-docker run --rm -it proxy-build cargo test
+docker run --rm -it proxy-build env RUST_LOG="$RUST_LOG" cargo test "$@"


### PR DESCRIPTION
Some additional improvements to `bin/docker-test-proxy`:
It now honors the `RUST_LOG` environment variable, and allows
additional flags to be passed to the `cargo test` command run in
the docker container.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>