### PR TITLE
Allow k8s API clients to watch a subset of resources

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -78,7 +78,7 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.Empty) (*pb.ListPodsR
 		reports[pod] = time.Unix(0, int64(timestamp)*int64(time.Millisecond))
 	}
 
-	pods, err := s.k8sAPI.Pod.Lister().List(labels.Everything())
+	pods, err := s.k8sAPI.Pod().Lister().List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (s *grpcServer) SelfCheck(ctx context.Context, in *healthcheckPb.SelfCheckR
 		CheckDescription: K8sClientCheckDescription,
 		Status:           healthcheckPb.CheckStatus_OK,
 	}
-	_, err := s.k8sAPI.Pod.Lister().List(labels.Everything())
+	_, err := s.k8sAPI.Pod().Lister().List(labels.Everything())
 	if err != nil {
 		k8sClientCheck.Status = healthcheckPb.CheckStatus_ERROR
 		k8sClientCheck.FriendlyMessageToUser = fmt.Sprintf("Error talking to Kubernetes from control plane: %s", err.Error())
@@ -209,7 +209,7 @@ func (s *grpcServer) getDeploymentFor(pod *k8sV1.Pod) (string, error) {
 		return "", fmt.Errorf("Pod %s parent is not a ReplicaSet", pod.Name)
 	}
 
-	rs, err := s.k8sAPI.RS.Lister().GetPodReplicaSets(pod)
+	rs, err := s.k8sAPI.RS().Lister().GetPodReplicaSets(pod)
 	if err != nil {
 		return "", err
 	}

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -39,7 +39,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	k8sAPI := k8s.NewAPI(k8sClient)
+	k8sAPI := k8s.NewAPI(
+		k8sClient,
+		k8s.Endpoint,
+		k8s.Pod,
+		k8s.Svc,
+	)
 
 	done := make(chan struct{})
 

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -51,7 +51,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	k8sAPI := k8s.NewAPI(k8sClient)
+	k8sAPI := k8s.NewAPI(
+		k8sClient,
+		k8s.Deploy,
+		k8s.NS,
+		k8s.Pod,
+		k8s.RC,
+		k8s.RS,
+		k8s.Svc,
+	)
 
 	prometheusClient, err := promApi.NewClient(promApi.Config{Address: *prometheusUrl})
 	if err != nil {

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -38,7 +38,14 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create Kubernetes client: %s", err)
 	}
-	k8sAPI := k8s.NewAPI(clientSet)
+	k8sAPI := k8s.NewAPI(
+		clientSet,
+		k8s.Deploy,
+		k8s.NS,
+		k8s.Pod,
+		k8s.RC,
+		k8s.Svc,
+	)
 
 	server, lis, err := tap.NewServer(*addr, *tapPort, k8sAPI)
 	if err != nil {

--- a/controller/destination/endpoints_watcher.go
+++ b/controller/destination/endpoints_watcher.go
@@ -37,20 +37,20 @@ type endpointsWatcher struct {
 
 func newEndpointsWatcher(k8sAPI *k8s.API) *endpointsWatcher {
 	watcher := &endpointsWatcher{
-		serviceLister:  k8sAPI.Svc.Lister(),
-		endpointLister: k8sAPI.Endpoint.Lister(),
+		serviceLister:  k8sAPI.Svc().Lister(),
+		endpointLister: k8sAPI.Endpoint().Lister(),
 		servicePorts:   make(map[serviceId]map[uint32]*servicePort),
 		mutex:          sync.RWMutex{},
 	}
 
-	k8sAPI.Svc.Informer().AddEventHandler(
+	k8sAPI.Svc().Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    watcher.addService,
 			UpdateFunc: watcher.updateService,
 		},
 	)
 
-	k8sAPI.Endpoint.Informer().AddEventHandler(
+	k8sAPI.Endpoint().Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    watcher.addEndpoints,
 			UpdateFunc: watcher.updateEndpoints,

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -35,7 +35,7 @@ type server struct {
 // Addresses for the given destination are fetched from the Kubernetes Endpoints
 // API.
 func NewServer(addr, k8sDNSZone string, enableTLS bool, k8sAPI *k8s.API, done chan struct{}) (*grpc.Server, net.Listener, error) {
-	k8sAPI.Pod.Informer().AddIndexers(cache.Indexers{podIpIndexName: indexPodByIp})
+	k8sAPI.Pod().Informer().AddIndexers(cache.Indexers{podIpIndexName: indexPodByIp})
 	resolvers, err := buildResolversList(k8sDNSZone, k8sAPI)
 	if err != nil {
 		return nil, nil, err
@@ -101,7 +101,7 @@ func indexPodByIp(obj interface{}) ([]string, error) {
 }
 
 func (s *server) podsByIp(ip string) ([]*v1.Pod, error) {
-	objs, err := s.k8sAPI.Pod.Informer().GetIndexer().ByIndex(podIpIndexName, ip)
+	objs, err := s.k8sAPI.Pod().Informer().GetIndexer().ByIndex(podIpIndexName, ip)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -23,5 +23,15 @@ func NewFakeAPI(configs ...string) (*API, error) {
 	}
 
 	clientSet := fake.NewSimpleClientset(objs...)
-	return NewAPI(clientSet), nil
+	return NewAPI(
+		clientSet,
+		NS,
+		Deploy,
+		RS,
+		Pod,
+		RC,
+		Svc,
+		Endpoint,
+		CM,
+	), nil
 }

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -25,13 +25,13 @@ func NewFakeAPI(configs ...string) (*API, error) {
 	clientSet := fake.NewSimpleClientset(objs...)
 	return NewAPI(
 		clientSet,
-		NS,
+		CM,
 		Deploy,
-		RS,
+		Endpoint,
+		NS,
 		Pod,
 		RC,
+		RS,
 		Svc,
-		Endpoint,
-		CM,
 	), nil
 }

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -558,7 +558,7 @@ func newSimulatedProxy(
 }
 
 func getDeploymentByPod(k8sAPI *k8s.API, maxPods int) map[*v1.Pod]*v1beta2.Deployment {
-	deployList, err := k8sAPI.Deploy.Lister().List(labels.Everything())
+	deployList, err := k8sAPI.Deploy().Lister().List(labels.Everything())
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -615,7 +615,11 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	k8sAPI := k8s.NewAPI(clientSet)
+	k8sAPI := k8s.NewAPI(
+		clientSet,
+		k8s.Deploy,
+		k8s.Pod,
+	)
 	err = k8sAPI.Sync()
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
In this branch I'm updating `k8s.NewAPI` to accept a list of resource types to watch when configuring a new API client. This will allow clients to only watch the resource types that they require, resulting in fewer API calls overall. It will also allow us to more tightly scope RBAC configurations for these components when they're running under different service accounts.

As part of this change, I'm also adding a config map resource type, which is required for #675.

Fixes #1114.