### PR TITLE
proxy: Fix docker build

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -16,19 +16,17 @@ WORKDIR /usr/src/conduit
 #
 # Mock out all local code and fetch external dependencies to ensure that external sources
 # are cached.
-RUN for d in proxy proxy/controller-grpc proxy/convert proxy/futures-mpsc-lossy proxy/router ; \
+RUN for d in proxy proxy/controller-grpc proxy/futures-mpsc-lossy proxy/router ; \
     do mkdir -p "${d}/src" && touch "${d}/src/lib.rs" ; \
     done
 COPY Cargo.toml Cargo.lock ./
 COPY proxy/Cargo.toml                       proxy/Cargo.toml
 COPY proxy/controller-grpc/Cargo.toml       proxy/controller-grpc/Cargo.toml
-COPY proxy/convert/Cargo.toml               proxy/convert/Cargo.toml
 COPY proxy/futures-mpsc-lossy/Cargo.toml    proxy/futures-mpsc-lossy/Cargo.toml
 COPY proxy/router/Cargo.toml                proxy/router/Cargo.toml
 RUN cargo fetch --locked
 
 # Build libraries, leaving the proxy and gRPC bindings mocked out.
-COPY proxy/convert             proxy/convert
 COPY proxy/futures-mpsc-lossy  proxy/futures-mpsc-lossy
 COPY proxy/router              proxy/router
 ARG PROXY_UNOPTIMIZED


### PR DESCRIPTION
fb8d054e removed the `convert` crate, but did not remove references to
it from the proxy's Dockerfile.