### PR TITLE
proxy: Update Rust to 1.26.2

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -4,7 +4,7 @@
 # This reduces build time and produces binaries with debug symbols, at the expense of
 # runtime perforamnce.
 
-ARG RUST_IMAGE=rust:1.26.0
+ARG RUST_IMAGE=rust:1.26.2
 ARG RUNTIME_IMAGE=gcr.io/runconduit/base:2017-10-30.01
 
 ## Builds the proxy as incrementally as possible.


### PR DESCRIPTION
Rust 1.26.2 addresses a correctness bug in the borrow checker.

See: https://blog.rust-lang.org/2018/06/05/Rust-1.26.2.html