### PR TITLE
proxy: add HTTP/1.1 Upgrade support automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
  "h2 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,6 +165,7 @@ dependencies = [
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
  "trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)",
+ "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.18.0-alpha4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -416,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +436,7 @@ dependencies = [
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1328,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1399,12 +1400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "want"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1534,7 +1535,7 @@ dependencies = [
 "checksum hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "58fab6e177434b0bb4cd344a4dabaa5bd6d7a8d792b1885aebcae7af1091d1cb"
 "checksum http 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75df369fd52c60635208a4d3e694777c099569b3dcf4844df8f652dc004644ab"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6416251e6672bff06fe96a3337570772845a44500fba2d178e2e55e0fab58a86"
+"checksum hyper 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ad39a4f15051ccd4ea6adf44df851e00fd9062c71734391d806246b94e69dc1f"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
 "checksum inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)" = "<none>"
@@ -1631,7 +1632,7 @@ dependencies = [
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum trust-dns-proto 0.4.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
 "checksum trust-dns-resolver 0.9.0 (git+https://github.com/bluejekyll/trust-dns)" = "<none>"
-"checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
+"checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
@@ -1643,7 +1644,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
+"checksum want 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2fffe09593e18ed34950d66dbf44c27deb2e03f3905c493f0641f9f99a3f2349"
 "checksum webpki 0.18.0-alpha4 (registry+https://github.com/rust-lang/crates.io-index)" = "724897af4bb44f3e0142b9cca300eb15f61b9b34fa559440bed8c43f2ff7afc0"
 "checksum which 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49c4f580e93079b70ac522e7bdebbe1568c8afa7d8d05ee534ee737ca37d2f51"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -22,13 +22,14 @@ futures-watch = { git = "https://github.com/carllerche/better-future" }
 h2 = "0.1.10"
 http = "0.1"
 httparse = "1.2"
-hyper = "0.12"
+hyper = "0.12.2"
 ipnet = "1.0"
 log = "0.4.1"
 indexmap = "1.0.0"
 prost = "0.4.0"
 prost-types = "0.4.0"
 rand = "0.5.1"
+try-lock = "0.2"
 
 # for config parsing
 regex = "1.0.0"

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -47,6 +47,7 @@ extern crate conduit_proxy_router;
 extern crate tower_util;
 extern crate tower_in_flight_limit;
 extern crate trust_dns_resolver;
+extern crate try_lock;
 
 use futures::*;
 

--- a/proxy/src/task.rs
+++ b/proxy/src/task.rs
@@ -40,6 +40,9 @@ pub struct LazyExecutor;
 pub struct BoxExecutor<E: TokioExecutor>(E);
 
 /// A `futures::executor::Executor` with any generics erased.
+///
+/// This is useful when some code cannot be generic over any executor,
+/// and instead needs a trait object. An example is `Http11Upgrade`.
 pub struct ErasedExecutor(Box<Executor<BoxSendFuture> + Send + Sync>);
 
 /// Indicates which Tokio `Runtime` should be used for the main proxy.

--- a/proxy/src/task.rs
+++ b/proxy/src/task.rs
@@ -3,8 +3,9 @@ use futures::future::{
     Future,
     ExecuteError,
     ExecuteErrorKind,
-    Executor,
 };
+pub use futures::future::Executor;
+
 use tokio::{
     executor::{
         DefaultExecutor,
@@ -19,6 +20,8 @@ use std::{
     fmt,
     io,
 };
+
+pub type BoxSendFuture = Box<Future<Item = (), Error = ()> + Send>;
 
 /// An empty type which implements `Executor` by lazily  calling
 /// `tokio::executor::DefaultExecutor::current().execute(...)`.
@@ -35,6 +38,9 @@ pub struct LazyExecutor;
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BoxExecutor<E: TokioExecutor>(E);
+
+/// A `futures::executor::Executor` with any generics erased.
+pub struct ErasedExecutor(Box<Executor<BoxSendFuture> + Send + Sync>);
 
 /// Indicates which Tokio `Runtime` should be used for the main proxy.
 ///
@@ -71,7 +77,7 @@ pub enum Error {
 impl TokioExecutor for LazyExecutor {
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + 'static + Send>
+        future: BoxSendFuture,
     ) -> Result<(), SpawnError>
     {
         DefaultExecutor::current().spawn(future)
@@ -118,7 +124,7 @@ impl<E: TokioExecutor> BoxExecutor<E> {
 impl<E: TokioExecutor> TokioExecutor for BoxExecutor<E> {
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + 'static + Send>
+        future: BoxSendFuture,
     ) -> Result<(), SpawnError> {
         self.0.spawn(future)
     }
@@ -132,7 +138,7 @@ impl<F, E> Executor<F> for BoxExecutor<E>
 where
     F: Future<Item = (), Error = ()> + 'static + Send,
     E: TokioExecutor,
-    E: Executor<Box<Future<Item = (), Error = ()> + Send + 'static>>,
+    E: Executor<BoxSendFuture>,
 {
     fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
         // Check the status of the executor first, so that we can return the
@@ -151,6 +157,30 @@ where
         self.0.execute(Box::new(future))
             .expect("spawn() errored but status() was Ok");
         Ok(())
+    }
+}
+
+// ===== impl ErasedExecutor =====;
+
+impl ErasedExecutor {
+    pub fn erase<E: Executor<BoxSendFuture> + Send + Sync + 'static>(exe: E) -> ErasedExecutor {
+        ErasedExecutor(Box::new(exe))
+    }
+}
+
+impl<F> Executor<F> for ErasedExecutor
+where
+    F: Future<Item = (), Error = ()> + 'static + Send,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        self.0.execute(Box::new(future))
+            .map_err(|_| panic!("erased executor error"))
+    }
+}
+
+impl fmt::Debug for ErasedExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("ErasedExecutor")
     }
 }
 

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -1,10 +1,9 @@
-use std::cell::RefCell;
 use std::fmt;
 use std::io;
 use std::sync::Arc;
 
 use bytes::{Bytes, IntoBuf};
-use futures::{future, Async, Future, Poll, Stream};
+use futures::{future, Async, Future, Poll};
 use futures::future::Either;
 use h2;
 use http;
@@ -15,26 +14,39 @@ use tower_service::{Service, NewService};
 use tower_h2;
 
 use ctx::transport::{Server as ServerCtx};
+use drain;
 use super::h1;
+use super::upgrade::Http11Upgrade;
+use task::{BoxSendFuture, ErasedExecutor, Executor};
 
 /// Glue between `hyper::Body` and `tower_h2::RecvBody`.
 #[derive(Debug)]
 pub enum HttpBody {
-    Http1(hyper::Body),
+    Http1 {
+        /// In HttpBody::drop, if this was an HTTP upgrade, the body is taken
+        /// to be sent on the oneshot::Sender.
+        body: Option<hyper::Body>,
+        upgrade: Option<Http11Upgrade>
+    },
     Http2(tower_h2::RecvBody),
 }
 
 /// Glue for `tower_h2::Body`s to be used in hyper.
 #[derive(Debug)]
-pub(super) struct BodyStream<B> {
+pub(super) struct BodyPayload<B> {
     body: B,
 }
 
 /// Glue for a `tower::Service` to used as a `hyper::server::Service`.
 #[derive(Debug)]
-pub(super) struct HyperServerSvc<S> {
-    service: RefCell<S>,
+pub(super) struct HyperServerSvc<S, E> {
+    service: S,
     srv_ctx: Arc<ServerCtx>,
+    /// Watch any spawned HTTP/1.1 upgrade tasks.
+    upgrade_drain_signal: drain::Watch,
+    /// Executor used to spawn HTTP/1.1 upgrade tasks, and TCP proxies
+    /// after they succeed.
+    upgrade_executor: E,
 }
 
 /// Future returned by `HyperServerSvc`.
@@ -78,16 +90,21 @@ impl tower_h2::Body for HttpBody {
     type Data = Bytes;
 
     fn is_end_stream(&self) -> bool {
-        match *self {
-            HttpBody::Http1(ref b) => b.is_end_stream(),
-            HttpBody::Http2(ref b) => b.is_end_stream(),
+        match self {
+            HttpBody::Http1 { body, .. } => {
+                body
+                    .as_ref()
+                    .expect("only taken in drop")
+                    .is_end_stream()
+            },
+            HttpBody::Http2(b) => b.is_end_stream(),
         }
     }
 
     fn poll_data(&mut self) -> Poll<Option<Self::Data>, h2::Error> {
-        match *self {
-            HttpBody::Http1(ref mut b) => {
-                match b.poll() {
+        match self {
+            HttpBody::Http1 { body, .. } => {
+                match body.as_mut().expect("only taken in drop").poll_data() {
                     Ok(Async::Ready(Some(chunk))) => Ok(Async::Ready(Some(chunk.into()))),
                     Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
                     Ok(Async::NotReady) => Ok(Async::NotReady),
@@ -97,14 +114,19 @@ impl tower_h2::Body for HttpBody {
                     }
                 }
             },
-            HttpBody::Http2(ref mut b) => b.poll_data().map(|async| async.map(|opt| opt.map(|data| data.into()))),
+            HttpBody::Http2(b) => b.poll_data()
+                .map(|async| {
+                    async.map(|opt| {
+                        opt.map(Bytes::from)
+                    })
+                })
         }
     }
 
     fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, h2::Error> {
-        match *self {
-            HttpBody::Http1(_) => Ok(Async::Ready(None)),
-            HttpBody::Http2(ref mut b) => b.poll_trailers(),
+        match self {
+            HttpBody::Http1 { .. } => Ok(Async::Ready(None)),
+            HttpBody::Http2(b) => b.poll_trailers(),
         }
     }
 }
@@ -137,18 +159,36 @@ impl Default for HttpBody {
     }
 }
 
-// ===== impl BodyStream =====
+impl Drop for HttpBody {
+    fn drop(&mut self) {
+        // If HTTP/1, and an upgrade was wanted, send the upgrade future.
+        match self {
+            HttpBody::Http1 { body, upgrade } => {
+                if let Some(upgrade) = upgrade.take() {
+                    let on_upgrade = body
+                        .take()
+                        .expect("take only on drop")
+                        .on_upgrade();
+                    upgrade.insert_half(on_upgrade);
+                }
+            },
+            HttpBody::Http2(_) => (),
+        }
+    }
+}
 
-impl<B> BodyStream<B> {
+// ===== impl BodyPayload =====
+
+impl<B> BodyPayload<B> {
     /// Wrap a `tower_h2::Body` into a `Stream` hyper can understand.
     pub fn new(body: B) -> Self {
-        BodyStream {
+        BodyPayload {
             body,
         }
     }
 }
 
-impl<B> hyper::body::Payload for BodyStream<B>
+impl<B> hyper::body::Payload for BodyPayload<B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as IntoBuf>::Buf: Send,
@@ -179,16 +219,23 @@ where
 
 // ===== impl HyperServerSvc =====
 
-impl<S> HyperServerSvc<S> {
-    pub fn new(svc: S, ctx: Arc<ServerCtx>) -> Self {
+impl<S, E> HyperServerSvc<S, E> {
+    pub fn new(
+        service: S,
+        srv_ctx: Arc<ServerCtx>,
+        upgrade_drain_signal: drain::Watch,
+        upgrade_executor: E,
+    ) -> Self {
         HyperServerSvc {
-            service: RefCell::new(svc),
-            srv_ctx: ctx,
+            service,
+            srv_ctx,
+            upgrade_drain_signal,
+            upgrade_executor,
         }
     }
 }
 
-impl<S, B> hyper::service::Service for HyperServerSvc<S>
+impl<S, E, B> hyper::service::Service for HyperServerSvc<S, E>
 where
     S: Service<
         Request=http::Request<HttpBody>,
@@ -197,32 +244,53 @@ where
     S::Error: fmt::Debug,
     B: tower_h2::Body + Default + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
+    E: Executor<BoxSendFuture> + Clone + Send + Sync + 'static,
 {
     type ReqBody = hyper::Body;
-    type ResBody = BodyStream<B>;
+    type ResBody = BodyPayload<B>;
     type Error = h2::Error;
     type Future = Either<
         HyperServerSvcFuture<S::Future>,
         future::FutureResult<http::Response<Self::ResBody>, Self::Error>,
     >;
 
-    fn call(&mut self, req: http::Request<Self::ReqBody>) -> Self::Future {
-        if let &hyper::Method::CONNECT = req.method() {
+    fn call(&mut self, mut req: http::Request<Self::ReqBody>) -> Self::Future {
+        //TODO: we can remove this also, should we?
+        if let &http::Method::CONNECT = req.method() {
             debug!("HTTP/1.1 CONNECT not supported");
-            let res = hyper::Response::builder()
-                .status(hyper::StatusCode::BAD_GATEWAY)
-                .body(BodyStream::new(Default::default()))
+            let res = http::Response::builder()
+                .status(http::StatusCode::BAD_GATEWAY)
+                .body(BodyPayload::new(Default::default()))
                 .expect("building response with empty body should not error!");
             return Either::B(future::ok(res));
         }
-        let mut req = req;
         req.extensions_mut().insert(self.srv_ctx.clone());
 
-        h1::strip_connection_headers(req.headers_mut());
+        let upgrade = if h1::wants_upgrade(&req) {
+            trace!("server request wants HTTP/1.1 upgrade");
+            // Upgrade requests include several "connection" headers that
+            // cannot be removed.
 
-        let req = req.map(|b| HttpBody::Http1(b));
+            // Setup HTTP Upgrade machinery.
+            let halves = Http11Upgrade::new(
+                self.upgrade_drain_signal.clone(),
+                ErasedExecutor::erase(self.upgrade_executor.clone()),
+            );
+            req.extensions_mut().insert(halves.client);
+
+            Some(halves.server)
+        } else {
+            h1::strip_connection_headers(req.headers_mut());
+            None
+        };
+
+
+        let req = req.map(move |b| HttpBody::Http1 {
+            body: Some(b),
+            upgrade,
+        });
         let f = HyperServerSvcFuture {
-            inner: self.service.borrow_mut().call(req),
+            inner: self.service.call(req),
         };
         Either::A(f)
     }
@@ -233,7 +301,7 @@ where
     F: Future<Item=http::Response<B>>,
     F::Error: fmt::Debug,
 {
-    type Item = hyper::Response<BodyStream<B>>;
+    type Item = http::Response<BodyPayload<B>>;
     type Error = h2::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -242,8 +310,12 @@ where
             h2::Error::from(io::Error::from(io::ErrorKind::Other))
         }));
 
-        h1::strip_connection_headers(res.headers_mut());
-        Ok(Async::Ready(res.map(BodyStream::new).into()))
+        if h1::is_upgrade(&res) {
+            trace!("client response is HTTP/1.1 upgrade");
+        } else {
+            h1::strip_connection_headers(res.headers_mut());
+        }
+        Ok(Async::Ready(res.map(BodyPayload::new)))
     }
 }
 

--- a/proxy/src/transparency/glue.rs
+++ b/proxy/src/transparency/glue.rs
@@ -24,7 +24,7 @@ use task::{BoxSendFuture, ErasedExecutor, Executor};
 pub enum HttpBody {
     Http1 {
         /// In HttpBody::drop, if this was an HTTP upgrade, the body is taken
-        /// to be sent on the oneshot::Sender.
+        /// to be inserted into the Http11Upgrade half.
         body: Option<hyper::Body>,
         upgrade: Option<Http11Upgrade>
     },
@@ -255,7 +255,6 @@ where
     >;
 
     fn call(&mut self, mut req: http::Request<Self::ReqBody>) -> Self::Future {
-        //TODO: we can remove this also, should we?
         if let &http::Method::CONNECT = req.method() {
             debug!("HTTP/1.1 CONNECT not supported");
             let res = http::Response::builder()

--- a/proxy/src/transparency/mod.rs
+++ b/proxy/src/transparency/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 mod glue;
 pub mod h1;
+mod upgrade;
 mod protocol;
 mod server;
 mod tcp;

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -79,10 +79,19 @@ impl Proxy {
         future::Either::A(connect.connect()
             .map_err(move |e| error!("tcp connect error to {}: {:?}", orig_dst, e))
             .and_then(move |tcp_out| {
-                Duplex::new(tcp_in, tcp_out)
-                    .map_err(|e| error!("tcp duplex error: {}", e))
+                duplex(tcp_in, tcp_out)
             }))
     }
+}
+
+pub(super) fn duplex<In, Out>(half_in: In, half_out: Out)
+    -> impl Future<Item=(), Error=()> + Send
+where
+    In: AsyncRead + AsyncWrite + Send + 'static,
+    Out: AsyncRead + AsyncWrite + Send + 'static,
+{
+    Duplex::new(half_in, half_out)
+        .map_err(|e| error!("tcp duplex error: {}", e))
 }
 
 /// A future piping data bi-directionally to In and Out.

--- a/proxy/src/transparency/upgrade.rs
+++ b/proxy/src/transparency/upgrade.rs
@@ -1,0 +1,155 @@
+//! HTTP/1.1 Upgrades
+use std::fmt;
+use std::mem;
+use std::sync::Arc;
+
+use futures::Future;
+use hyper::upgrade::OnUpgrade;
+use try_lock::TryLock;
+
+use drain;
+use super::tcp;
+use task::{ErasedExecutor, Executor};
+
+/// A type inserted into `http::Extensions` to bridge together HTTP Upgrades.
+///
+/// If the HTTP1 server service detects an upgrade request, this will be
+/// inserted into the `Request::extensions()`. If the HTTP1 client service
+/// also detects an upgrade, the two `OnUpgrade` futures will be joined
+/// together with the glue in this type.
+// Note: this relies on their only having been 2 Inner clones, so don't
+// implement `Clone` for this type.
+pub struct Http11Upgrade {
+    half: Half,
+    inner: Arc<Inner>,
+}
+
+/// A named "tuple" returned by `Http11Upgade::new()` of the two halves of
+/// an upgrade.
+#[derive(Debug)]
+pub struct Http11UpgradeHalves {
+    /// The "server" half.
+    pub server: Http11Upgrade,
+    /// The "client" half.
+    pub client: Http11Upgrade,
+    _inner: (),
+}
+
+struct Inner {
+    server: TryLock<Option<OnUpgrade>>,
+    client: TryLock<Option<OnUpgrade>>,
+    upgrade_drain_signal: Option<drain::Watch>,
+    upgrade_executor: ErasedExecutor,
+}
+
+#[derive(Debug)]
+enum Half {
+    Server,
+    Client,
+}
+
+
+// ===== impl Http11Upgrade =====
+
+impl Http11Upgrade {
+    /// Returns a pair of upgrade handles.
+    ///
+    /// Each handle is used to insert 1 half of the upgrade. When both handles
+    /// have inserted, the upgrade future will be spawned onto the executor.
+    pub fn new(
+        upgrade_drain_signal: drain::Watch,
+        upgrade_executor: ErasedExecutor,
+    ) -> Http11UpgradeHalves {
+        let inner = Arc::new(Inner {
+            server: TryLock::new(None),
+            client: TryLock::new(None),
+            upgrade_drain_signal: Some(upgrade_drain_signal),
+            upgrade_executor,
+        });
+
+        Http11UpgradeHalves {
+            server: Http11Upgrade {
+                half: Half::Server,
+                inner: inner.clone(),
+            },
+            client: Http11Upgrade {
+                half: Half::Client,
+                inner: inner,
+            },
+            _inner: (),
+        }
+    }
+
+    pub fn insert_half(self, upgrade: OnUpgrade) {
+        match self.half {
+            Half::Server => {
+                let mut lock = self
+                    .inner
+                    .server
+                    .try_lock()
+                    .expect("only Half::Server touches server TryLock");
+                debug_assert!(lock.is_none());
+                *lock = Some(upgrade);
+            },
+            Half::Client => {
+                let mut lock = self
+                    .inner
+                    .client
+                    .try_lock()
+                    .expect("only Half::Client touches client TryLock");
+                debug_assert!(lock.is_none());
+                *lock = Some(upgrade);
+            }
+        }
+    }
+}
+
+impl fmt::Debug for Http11Upgrade {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Http11Upgrade")
+            .field("half", &self.half)
+            .finish()
+    }
+}
+
+/// When both halves have dropped, check if both sides are inserted,
+/// and if so, spawn the upgrade task.
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // Since this is Inner::drop, no more synchronization is required.
+        // We can safely take the futures out of their locks.
+        let server = mem::replace(&mut self.server, TryLock::new(None)).into_inner();
+        let client = mem::replace(&mut self.client, TryLock::new(None)).into_inner();
+        if let (Some(server), Some(client)) = (server, client) {
+            trace!("HTTP/1.1 upgrade has both halves");
+
+            let server_upgrade = server.map_err(|e| {
+                debug!("server HTTP upgrade error: {}", e)
+            });
+
+            let client_upgrade = client.map_err(|e| {
+                debug!("client HTTP upgrade error: {}", e)
+            });
+
+            let both_upgrades = server_upgrade
+                .join(client_upgrade)
+                .and_then(|(server_conn, client_conn)| {
+                    trace!("HTTP upgrade successful");
+                    tcp::duplex(server_conn, client_conn)
+                });
+
+            // There's nothing to do when drain is signaled, we just have to hope
+            // the sockets finish soon. However, the drain signal still needs to
+            // 'watch' the TCP future so that the process doesn't close early.
+            let fut = self
+                .upgrade_drain_signal
+                .take()
+                .expect("only taken in drop")
+                .watch(both_upgrades, |_| ());
+
+            if let Err(_) = self.upgrade_executor.execute(fut) {
+                trace!("error spawning HTTP upgrade task");
+            }
+        }
+    }
+}

--- a/proxy/src/transparency/upgrade.rs
+++ b/proxy/src/transparency/upgrade.rs
@@ -39,6 +39,13 @@ struct Inner {
     server: TryLock<Option<OnUpgrade>>,
     client: TryLock<Option<OnUpgrade>>,
     upgrade_drain_signal: Option<drain::Watch>,
+    /// An ErasedExecutor is used because the containing type, Http11Upgrade,
+    /// is inserted into `http::Extensions`, which is a type map.
+    ///
+    /// If this were instead a generic `E: Executor`, it'd be very easy
+    /// to specify the wrong when trying to remove the `Http11Upgrade` from
+    /// the type map, since with different generics, they'd generate
+    /// different `TypeId`s.
     upgrade_executor: ErasedExecutor,
 }
 

--- a/proxy/tests/support/mod.rs
+++ b/proxy/tests/support/mod.rs
@@ -111,6 +111,20 @@ macro_rules! assert_eventually {
     };
 }
 
+#[macro_export]
+macro_rules! assert_contains {
+    ($haystack:expr, $needle:expr) => {
+        assert!($haystack.contains($needle), "haystack:\n{:8?}\ndid not contain:\n{:8?}", $haystack, $needle)
+    }
+}
+
+#[macro_export]
+macro_rules! assert_eventually_contains {
+    ($scrape:expr, $contains:expr) => {
+        assert_eventually!($scrape.contains($contains), "metrics scrape:\n{:8?}\ndid not contain:\n{:8?}", $scrape, $contains)
+    }
+}
+
 pub mod client;
 pub mod controller;
 pub mod proxy;

--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -3,12 +3,6 @@
 mod support;
 use self::support::*;
 
-macro_rules! assert_contains {
-    ($scrape:expr, $contains:expr) => {
-        assert_eventually!($scrape.contains($contains), "metrics scrape:\n{:8}\ndid not contain:\n{:8}", $scrape, $contains)
-    }
-}
-
 #[test]
 fn outbound_http1() {
     let _ = env_logger::try_init();
@@ -329,33 +323,56 @@ fn tcp_connections_close_if_client_closes() {
 }
 
 #[test]
-fn http11_upgrade_not_supported() {
+fn http11_upgrades() {
     let _ = env_logger::try_init();
 
-    // our h1 proxy will strip the Connection header
-    // and headers it mentions
-    let msg1 = "\
+    // To simplify things for this test, we just use the test TCP
+    // client and server to do an HTTP upgrade.
+    //
+    // This is upgrading to 'chatproto', a made up plaintext protocol
+    // to simplify testing.
+
+    let upgrade_req = "\
         GET /chat HTTP/1.1\r\n\
         Host: foo.bar\r\n\
-        Connection: Upgrade\r\n\
-        Upgrade: websocket\r\n\
+        Connection: upgrade\r\n\
+        Upgrade: chatproto\r\n\
         \r\n\
         ";
-
-    // but let's pretend the server tries to upgrade
-    // anyways
-    let msg2 = "\
+    let upgrade_res = "\
         HTTP/1.1 101 Switching Protocols\r\n\
-        Upgrade: websocket\r\n\
-        Connection: Upgrade\r\n\
+        Upgrade: chatproto\r\n\
+        Connection: upgrade\r\n\
         \r\n\
         ";
+    let upgrade_needle = "\r\nupgrade: chatproto\r\n";
+    let chatproto_req = "[chatproto-c]{send}: hi all\n";
+    let chatproto_res = "[chatproto-s]{recv}: welcome!\n";
+
 
     let srv = server::tcp()
-        .accept(move |read| {
-            let head = s(&read);
-            assert!(!head.contains("Upgrade: websocket"));
-            msg2
+        .accept_fut(move |sock| {
+            // Read upgrade_req...
+            tokio_io::io::read(sock, vec![0; 512])
+                .and_then(move |(sock, vec, n)| {
+                    let head = s(&vec[..n]);
+                    assert_contains!(head, upgrade_needle);
+
+                    // Write upgrade_res back...
+                    tokio_io::io::write_all(sock, upgrade_res)
+                })
+                .and_then(move |(sock, _)| {
+                    // Read the message in 'chatproto' format
+                    tokio_io::io::read(sock, vec![0; 512])
+                })
+                .and_then(move |(sock, vec, n)| {
+                    assert_eq!(s(&vec[..n]), chatproto_req);
+
+                    // Some processing... and then write back in chatproto...
+                    tokio_io::io::write_all(sock, chatproto_res)
+                })
+                .map(|_| ())
+                .map_err(|e| panic!("tcp server error: {}", e))
         })
         .run();
     let proxy = proxy::new()
@@ -366,10 +383,60 @@ fn http11_upgrade_not_supported() {
 
     let tcp_client = client.connect();
 
-    tcp_client.write(msg1);
+    tcp_client.write(upgrade_req);
 
-    let expected = "HTTP/1.1 500 ";
-    assert_eq!(s(&tcp_client.read()[..expected.len()]), expected);
+    let resp = tcp_client.read();
+    let resp_str = s(&resp);
+    assert!(
+        resp_str.starts_with("HTTP/1.1 101 Switching Protocols\r\n"),
+        "response not an upgrade: {:?}",
+        resp_str
+    );
+    assert_contains!(resp_str, upgrade_needle);
+
+    // We've upgraded from HTTP to chatproto! Say hi!
+    tcp_client.write(chatproto_req);
+    // Did anyone respond?
+    let chat_resp = tcp_client.read();
+    assert_eq!(s(&chat_resp), chatproto_res);
+}
+
+#[test]
+fn http11_upgrade_h2_stripped() {
+    let _ = env_logger::try_init();
+
+    // If an `h2` upgrade over HTTP/1.1 were to go by the proxy,
+    // and it succeeded, there would an h2 connection, but it would
+    // be opaque-to-the-proxy, acting as just a TCP proxy.
+    //
+    // A user wouldn't be able to see any usual HTTP telemetry about
+    // requests going over that connection. Instead of that confusion,
+    // the proxy strips h2 upgrade headers.
+    //
+    // Eventually, the proxy will support h2 upgrades directly.
+
+    let srv = server::http1()
+        .route_fn("/", |req| {
+            assert!(!req.headers().contains_key("connection"));
+            assert!(!req.headers().contains_key("upgrade"));
+            assert!(!req.headers().contains_key("http2-settings"));
+            Response::default()
+        })
+        .run();
+    let proxy = proxy::new()
+        .inbound(srv)
+        .run();
+
+    let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
+
+    let res = client.request(client.request_builder("/")
+        .header("upgrade", "h2c")
+        .header("http2-settings", "")
+        .header("connection", "upgrade, http2-settings"));
+
+    // If the assertion is trigger in the above test route, the proxy will
+    // just send back a 500.
+    assert_eq!(res.status(), http::StatusCode::OK);
 }
 
 #[test]
@@ -755,7 +822,7 @@ fn retry_reconnect_errors() {
 
     // wait until metrics has seen our connection, this can be flaky depending on
     // all the other threads currently running...
-    assert_contains!(
+    assert_eventually_contains!(
         metrics.get("/metrics"),
         "tcp_open_total{direction=\"inbound\",peer=\"src\"} 1"
     );


### PR DESCRIPTION
Any HTTP/1.1 requests seen by the proxy will automatically set up
to prepare such that if the proxied responses agree to an upgrade,
the two connections will converted into a standard TCP proxy duplex.

## Implementation

This adds a new type, `transparency::Http11Upgrade`, which is a sort of rendezvous type for triggering HTTP/1.1 upgrades. In the h1 server service, if a request looks like an upgrade (`h1::wants_upgrade`), the request body is decorated with this new `Http11Upgrade` type. It is actually a pair, and so the second half is put into the request extensions, so that the h1 client service may look for it right before serialization. If it finds the half in the extensions, it decorates the *response* body with that half (if it looks like a response upgrade (`h1::is_upgrade`)).

The `HttpBody` type now has a `Drop` impl, which will look to see if its been decorated with an `Http11Upgrade` half. If so, it will check for hyper's new `Body::on_upgrade()` future, and insert that into the half. 

When both `Http11Upgrade` halves are dropped, its internal `Drop` will look to if both halves have supplied an upgrade. If so, the two `OnUpgrade` futures from hyper are joined on, and when they succeed, a `transparency::tcp::duplex()` future is created. This chain is spawned into the default executor.

The `drain::Watch` signal is carried along, to ensure upgraded connections still count towards active connections when the proxy wants to shutdown.

Closes #195 