### PR TITLE
test: Use proxy instead of lb for external test traffic

### DIFF
--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -42,9 +42,9 @@ func TestEgressHttp(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			expectedURL := fmt.Sprintf("%s://%s/%s", protocolToUse, dnsName, strings.ToLower(methodToUse))
 
-			svcURL, err := TestHelper.GetURLForService(prefixedNs, serviceName)
+			svcURL, err := TestHelper.ProxyURLFor(prefixedNs, serviceName, "http")
 			if err != nil {
-				t.Fatalf("Failed to get service URL: %v", err)
+				t.Fatalf("Failed to get proxy URL: %s", err)
 			}
 
 			output, err := TestHelper.HTTPGetURL(svcURL)

--- a/test/egress/testdata/proxy.yaml
+++ b/test/egress/testdata/proxy.yaml
@@ -33,7 +33,6 @@ kind: Service
 metadata:
   name: egress-test-https-post-svc
 spec:
-  type: LoadBalancer
   selector:
     app: egress-test-https-post
   ports:
@@ -74,7 +73,6 @@ kind: Service
 metadata:
   name: egress-test-http-post-svc
 spec:
-  type: LoadBalancer
   selector:
     app: egress-test-http-post
   ports:
@@ -116,7 +114,6 @@ kind: Service
 metadata:
   name: egress-test-https-get-svc
 spec:
-  type: LoadBalancer
   selector:
     app: egress-test-https-get
   ports:
@@ -157,7 +154,6 @@ kind: Service
 metadata:
   name: egress-test-http-get-svc
 spec:
-  type: LoadBalancer
   selector:
     app: egress-test-http-get
   ports:
@@ -199,7 +195,6 @@ kind: Service
 metadata:
   name: egress-test-not-www-get-svc
 spec:
-  type: LoadBalancer
   selector:
     app: egress-test-not-www-get
   ports:

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -31,7 +31,7 @@ var (
 		"web",
 	}
 
-	conduitDeploys = map[string]int{
+	conduitDeployReplicas = map[string]int{
 		"controller": 1,
 		"grafana":    1,
 		"prometheus": 1,
@@ -83,24 +83,15 @@ func TestInstall(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Tests Pods
-	err = TestHelper.RetryFor(1*time.Minute, func() error {
-		for deploy, replicas := range conduitDeploys {
+	// Tests Pods and Deployments
+	// The Grafana readiness check can take 1+ min; hence the high timeout here
+	err = TestHelper.RetryFor(2*time.Minute, func() error {
+		for deploy, replicas := range conduitDeployReplicas {
 			if err := TestHelper.CheckPods(TestHelper.GetConduitNamespace(), deploy, replicas); err != nil {
 				return fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err)
 			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Tests Deployments
-	err = TestHelper.RetryFor(1*time.Minute, func() error {
-		for deploy, replicas := range conduitDeploys {
 			if err := TestHelper.CheckDeployment(TestHelper.GetConduitNamespace(), deploy, replicas); err != nil {
-				return fmt.Errorf("Error validating Deployment [%s]:\n%s", deploy, err)
+				return fmt.Errorf("Error validating deploy [%s]:\n%s", deploy, err)
 			}
 		}
 		return nil

--- a/test/testdata/smoke_test.yaml
+++ b/test/testdata/smoke_test.yaml
@@ -60,7 +60,6 @@ metadata:
 spec:
   selector:
     app: smoke-test-gateway
-  type: LoadBalancer
   ports:
   - name: http
     port: 8080

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -171,29 +170,6 @@ func (h *TestHelper) CheckVersion(serverVersion string) error {
 	return nil
 }
 
-// BlockUntilTrue retries a given function every second until the function
-// returns true or a timeout is reached. If the timeout is reached, it returns
-// an error.
-func (h *TestHelper) BlockUntilTrue(timeout time.Duration, fn func() bool) error {
-	if fn() {
-		return nil
-	}
-
-	timeoutAfter := time.After(timeout)
-	retryAfter := time.Tick(time.Second)
-
-	for {
-		select {
-		case <-timeoutAfter:
-			return errors.New("timed out waiting for condition")
-		case <-retryAfter:
-			if fn() {
-				return nil
-			}
-		}
-	}
-}
-
 // RetryFor retries a given function every second until the function returns
 // without an error, or a timeout is reached. If the timeout is reached, it
 // returns the last error received from the function.
@@ -221,11 +197,11 @@ func (h *TestHelper) RetryFor(timeout time.Duration, fn func() error) error {
 
 // HTTPGetURL sends a GET request to the given URL. It returns the response body
 // in the event of a successful 200 response. In the event of a non-200
-// response, it returns an error. It retries requests for up to 10 seconds,
+// response, it returns an error. It retries requests for up to 30 seconds,
 // giving pods time to start.
 func (h *TestHelper) HTTPGetURL(url string) (string, error) {
 	var body string
-	err := h.RetryFor(10*time.Second, func() error {
+	err := h.RetryFor(30*time.Second, func() error {
 		resp, err := h.httpClient.Get(url)
 		if err != nil {
 			return err

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -221,58 +221,29 @@ func (h *TestHelper) RetryFor(timeout time.Duration, fn func() error) error {
 
 // HTTPGetURL sends a GET request to the given URL. It returns the response body
 // in the event of a successful 200 response. In the event of a non-200
-// response, it returns an error.
+// response, it returns an error. It retries requests for up to 10 seconds,
+// giving pods time to start.
 func (h *TestHelper) HTTPGetURL(url string) (string, error) {
-	resp, err := h.httpClient.Get(url)
-	if err != nil {
-		// retry once on timeout error; workaround for GKE loadbalancers
-		if strings.Contains(err.Error(), "Client.Timeout") {
-			resp, err = h.httpClient.Get(url)
-		}
-	}
-	if err != nil {
-		return "", err
-	}
-
-	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("Error reading response body: %v", err)
-	}
-	body := string(bytes)
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GET request to [%s] returned status [%d]\n%s", url, resp.StatusCode, body)
-	}
-
-	return body, nil
-}
-
-// GetURLForService returns the external URL for a service in a namespace.
-func (h *TestHelper) GetURLForService(namespace string, serviceName string) (string, error) {
-	var url string
-	err := h.RetryFor(3*time.Minute, func() error {
-		// first try fetching the url from kubectl
-		cmd := exec.Command("kubectl", "-n", namespace, "get", "svc", serviceName, "-o",
-			"jsonpath={.status.loadBalancer.ingress[0].*}:{.spec.ports[0].port}")
-		out, err := cmd.Output()
+	var body string
+	err := h.RetryFor(10*time.Second, func() error {
+		resp, err := h.httpClient.Get(url)
 		if err != nil {
-			return fmt.Errorf("kubectl get svc error: %s\n%s", out, err)
-		}
-		addr := strings.TrimSpace(string(out))
-		if !strings.HasPrefix(addr, ":") {
-			url = "http://" + addr
-			return nil
+			return err
 		}
 
-		// fallback to minikube
-		cmd = exec.Command("minikube", "-n", namespace, "service", serviceName, "--url")
-		out, err = cmd.Output()
+		defer resp.Body.Close()
+		bytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("minikube service error: %s\n%s", out, err)
+			return fmt.Errorf("Error reading response body: %v", err)
 		}
-		url = strings.TrimSpace(string(out))
+		body = string(bytes)
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("GET request to [%s] returned status [%d]\n%s", url, resp.StatusCode, body)
+		}
+
 		return nil
 	})
-	return url, err
+
+	return body, err
 }


### PR DESCRIPTION
This branch switches our integration test harness to use kubeproxy to connect to services in the test cluster, rather than waiting for external load balancers to be provisioned. This speeds the tests up substantially. It will also make the tests more reliable, so that we can start running them in CI (#1064), and in other environments that don't provision load balancers, like Docker for Mac.

As part of this change I'm also tweaking the install test, which wasn't up-to-date with the list of conduit services and deploys, and was occasionally timing out due to the prometheus container not being ready within the test timeout.

Fixes #621.
Fixes #652.