### PR TITLE
Display proxy container errors in the Web UI

### DIFF
--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -85,3 +85,28 @@ td .status-dot {
     background-color: #E0E0E0;
   }
 }
+
+
+/* error indicator and modal */
+.conduit-error-icon {
+  cursor: pointer;
+  margin-left: 5px;
+  color: var(--siennared);
+}
+
+.conduit-pod-error {
+  margin-top: calc(2 * var(--base-width));
+  margin-bottom: calc(3 * var(--base-width));
+
+  & p {
+    line-height: 8px;
+  }
+
+  & .error-text {
+    padding: var(--base-width);
+    border-radius: calc(0.5 * var(--base-width));
+    font-size: 12px;
+    color: white;
+    background-color: #696969;
+  }
+}

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -1,0 +1,60 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Icon, Modal } from 'antd';
+
+const ContainerError = (container, errors) => {
+  return (
+    <div key={`error-${container}`}>
+      <p>Container: {_.get(errors, [0, "container", "container"])}</p>
+      <p>Image: {_.get(errors, [0, "container", "image"])}</p>
+      <div className="error-text">
+        {
+        _.map(errors, (er, i) => (
+          <code key={`error-msg-${i}`}>
+            {_.get(er, ["container", "message"])}
+          </code>
+        ))
+      }
+      </div>
+    </div>
+  );
+};
+
+export default class ErrorModal extends React.Component {
+  static propTypes = {
+    errors: PropTypes.shape({}).isRequired,
+    resourceName: PropTypes.string.isRequired,
+    resourceType: PropTypes.string.isRequired
+  }
+
+  showModal = () => {
+    Modal.error({
+      title: `Errors in ${this.props.resourceType} ${this.props.resourceName}`,
+      width: 800,
+      maskClosable: true,
+      content: this.renderPodErrors(this.props.errors),
+      onOk() {},
+    });
+  }
+
+  renderPodErrors = podErrors => {
+    let sortedPods = _.sortBy(_.keys(podErrors));
+    return _.map(sortedPods, pod => {
+      let errorsByContainer = _.groupBy(podErrors[pod].errors, "container.container");
+
+      return (
+        <div className="conduit-pod-error" key={pod}>
+          <h3>Pod: {pod}</h3>
+          {_.map(errorsByContainer, (errors, container) => ContainerError(container, errors))}
+        </div>
+      );
+    });
+  }
+
+  render() {
+    return (
+      <Icon type="warning" className="conduit-error-icon" onClick={this.showModal} />
+    );
+  }
+}

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import BaseTable from './BaseTable.jsx';
+import ErrorModal from './ErrorModal.jsx';
 import GrafanaLink from './GrafanaLink.jsx';
 import { processedMetricsPropType } from './util/MetricUtils.js';
 import PropTypes from 'prop-types';
@@ -60,12 +61,13 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       defaultSortOrder: 'ascend',
       sorter: (a, b) => (a.name || "").localeCompare(b.name),
       render: row => {
+        let nameContents;
         if (resource.toLowerCase() === "namespace") {
-          return <ConduitLink to={"/namespaces/" + row.name}>{row.name}</ConduitLink>;
+          nameContents = <ConduitLink to={"/namespaces/" + row.name}>{row.name}</ConduitLink>;
         } else if (!row.added) {
-          return row.name;
+          nameContents = row.name;
         } else {
-          return (
+          nameContents = (
             <GrafanaLink
               name={row.name}
               namespace={row.namespace}
@@ -73,6 +75,12 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
               ConduitLink={ConduitLink} />
           );
         }
+        return (
+          <React.Fragment>
+            {nameContents}
+            { _.isEmpty(row.errors) ? null : <ErrorModal errors={row.errors} resourceName={row.name} resourceType={resource} /> }
+          </React.Fragment>
+        );
       }
     },
     {

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -117,7 +117,8 @@ const processStatTable = table => {
       successRate: getSuccessRate(row),
       latency: getLatency(row),
       tlsRequestPercent: getTlsRequestPercentage(row),
-      added: row.meshedPodCount === row.runningPodCount
+      added: row.meshedPodCount === row.runningPodCount,
+      errors: row.errorsByPod
     };
   })
     .compact()

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -26,7 +26,8 @@ describe('MetricUtils', () => {
             P95: 2,
             P99: 7
           },
-          added: true
+          added: true,
+          errors: {}
         }
       ];
       expect(result).to.have.length(1);

--- a/web/app/test/fixtures/deployRollup.json
+++ b/web/app/test/fixtures/deployRollup.json
@@ -21,7 +21,8 @@
               },
               "timeWindow": "1m",
               "runningPodCount": "1",
-              "failedPodCount": null
+              "failedPodCount": null,
+              "errorsByPod": {}
             }
           ]
         }


### PR DESCRIPTION
This PR adds a warning icon to any resource row that has pod errors in its underlying pods.
Clicking the warning icon brings up a modal that shows errors by pods.

Note that on the namespaces page, if a pod is erroring, it will cause a warning icon on the Pods table, as well as the Deployments table for the deployment that pod is part of. If this is too aggressive, I can change it such that the errors only display on one of the tables.

TODO: Detect large error messages and truncate them; errors could get very long.

![screen shot 2018-06-14 at 5 52 05 pm](https://user-images.githubusercontent.com/549258/41445129-34ca56f4-6ffc-11e8-8a76-4ecd82ea2ac0.png)

![screen shot 2018-06-14 at 5 51 50 pm](https://user-images.githubusercontent.com/549258/41445131-3d4ed62e-6ffc-11e8-8970-70cd9cbd800b.png)

![screen shot 2018-06-14 at 5 28 31 pm](https://user-images.githubusercontent.com/549258/41445121-2e1e19b2-6ffc-11e8-85d5-a87e865672db.png)

Follow up to #1117 
