### PR TITLE
Simplify & clarify "No TLS" server configuration

### DIFF
--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -274,11 +274,9 @@ where
                 config.outbound_router_capacity,
                 config.outbound_router_max_idle_age,
             );
-            // No TLS yet.
-            let (no_tls, _) = tls::ServerConfig::no_tls();
             serve(
                 outbound_listener,
-                no_tls,
+                tls::ServerConfig::no_tls(), // No TLS between service & proxy.
                 router,
                 config.public_connect_timeout,
                 config.outbound_ports_disable_protocol_detection,
@@ -501,12 +499,10 @@ where
         h2_builder,
         log.clone().executor(),
     );
-    let (no_tls, _) = tls::ServerConfig::no_tls();
-
     let fut = {
         let log = log.clone();
         bound_port.listen_and_fold(
-            no_tls,
+            tls::ServerConfig::no_tls(), // TODO: serve over TLS.
             server,
             move |server, (session, remote)| {
                 let log = log.clone().with_remote(remote);

--- a/proxy/src/telemetry/control.rs
+++ b/proxy/src/telemetry/control.rs
@@ -98,13 +98,11 @@ impl Control {
         use hyper;
 
         let log = ::logging::admin().server("metrics", bound_port.local_addr());
-        let (no_tls, _) = ::tls::ServerConfig::no_tls();
-
         let service = self.metrics_service.clone();
         let fut = {
             let log = log.clone();
             bound_port.listen_and_fold(
-                no_tls, // TODO: Serve over TLS.
+                ::tls::ServerConfig::no_tls(), // TODO: Serve over TLS.
                 hyper::server::conn::Http::new(),
                 move |hyper, (conn, remote)| {
                     let service = service.clone();

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -327,13 +327,9 @@ impl ServerConfig {
         ServerConfig(Arc::new(config))
     }
 
-    pub fn no_tls()
-        -> (ServerConfigWatch, Box<Future<Item = (), Error = ()> + Send>)
-    {
-            let (watch, _) = Watch::new(None);
-            let no_future = future::ok(());
-
-            (watch, Box::new(no_future))
+    pub fn no_tls() -> ServerConfigWatch {
+        let (watch, _) = Watch::new(None);
+        watch
     }
 }
 


### PR DESCRIPTION
The same pattern will be used for the "No TLS" client configuration.

Signed-off-by: Brian Smith <brian@briansmith.org>