### PR TITLE
Proxy: Make the control plane completely optional.

### DIFF
--- a/proxy/src/control/destination/background.rs
+++ b/proxy/src/control/destination/background.rs
@@ -77,11 +77,11 @@ pub(super) fn task(
     request_rx: mpsc::UnboundedReceiver<ResolveRequest>,
     dns_resolver: dns::Resolver,
     namespaces: Namespaces,
-    host_and_port: HostAndPort,
+    host_and_port: Option<HostAndPort>,
 ) -> impl Future<Item = (), Error = ()>
 {
     // Build up the Controller Client Stack
-    let mut client = {
+    let mut client = host_and_port.map(|host_and_port| {
         let scheme = http::uri::Scheme::from_shared(Bytes::from_static(b"http")).unwrap();
         let authority = http::uri::Authority::from(&host_and_port);
         let connect = Timeout::new(
@@ -101,7 +101,7 @@ pub(super) fn task(
         let backoff = Backoff::new(log_errors, Duration::from_secs(5));
         // TODO: Use AddOrigin in tower-http
         AddOrigin::new(scheme, authority, backoff)
-    };
+    });
 
     let mut disco = Background::new(
         request_rx,
@@ -138,7 +138,7 @@ where
         }
     }
 
-   fn poll_rpc(&mut self, client: &mut T) {
+   fn poll_rpc(&mut self, client: &mut Option<T>) {
         // This loop is make sure any streams that were found disconnected
         // in `poll_destinations` while the `rpc` service is ready should
         // be reconnected now, otherwise the task would just sleep...
@@ -153,27 +153,29 @@ where
         }
     }
 
-    fn poll_resolve_requests(&mut self, client: &mut T) {
+    fn poll_resolve_requests(&mut self, client: &mut Option<T>) {
         loop {
-            // if rpc service isn't ready, not much we can do...
-            match client.poll_ready() {
-                Ok(Async::Ready(())) => {
-                    self.rpc_ready = true;
-                },
-                Ok(Async::NotReady) => {
-                    self.rpc_ready = false;
-                    break;
-                },
-                Err(err) => {
-                    warn!("Destination.Get poll_ready error: {:?}", err);
-                    self.rpc_ready = false;
-                    break;
-                },
-            }
+            if let Some(client) = client {
+                // if rpc service isn't ready, not much we can do...
+                match client.poll_ready() {
+                    Ok(Async::Ready(())) => {
+                        self.rpc_ready = true;
+                    },
+                    Ok(Async::NotReady) => {
+                        self.rpc_ready = false;
+                        break;
+                    },
+                    Err(err) => {
+                        warn!("Destination.Get poll_ready error: {:?}", err);
+                        self.rpc_ready = false;
+                        break;
+                    },
+                }
 
-            // handle any pending reconnects first
-            if self.poll_reconnect(client) {
-                continue;
+                // handle any pending reconnects first
+                if self.poll_reconnect(client) {
+                    continue;
+                }
             }
 
             // check for any new watches
@@ -197,12 +199,15 @@ where
                             set.responders.push(resolve.responder);
                         },
                         Entry::Vacant(vac) => {
-                            let query = Self::query_destination_service_if_relevant(
-                                &self.namespaces.pod,
-                                client,
-                                vac.key(),
-                                "connect",
-                            );
+                            let pod_namespace = &self.namespaces.pod;
+                            let query = client.as_mut().and_then(|client| {
+                                Self::query_destination_service_if_relevant(
+                                    pod_namespace,
+                                    client,
+                                    vac.key(),
+                                    "connect",
+                                )
+                            });
                             let mut set = DestinationSet {
                                 addrs: Exists::Unknown,
                                 query,
@@ -211,7 +216,8 @@ where
                             };
                             // If the authority is one for which the Destination service is never
                             // relevant (e.g. an absolute name that doesn't end in ".svc.$zone." in
-                            // Kubernetes), then immediately start polling DNS.
+                            // Kubernetes), or if we don't have a `client`, then immediately start
+                            // polling DNS.
                             if set.query.is_none() {
                                 set.reset_dns_query(
                                     &self.dns_resolver,

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -142,7 +142,7 @@ pub trait Bind {
 pub fn new(
     dns_resolver: dns::Resolver,
     namespaces: Namespaces,
-    host_and_port: HostAndPort,
+    host_and_port: Option<HostAndPort>,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };


### PR DESCRIPTION
Previously, the proxy required `CONDUIT_PROXY_CONTROL_URL` to be set,
bit it still worked fine even if it could not contact any server at
that address, modulo its inability to do Kubernetes service discovery.
However, the proxy would keep trying to connect over and over again,
so such a degenerate configuration didn't work so well. In particular,
the logs were very noisy.

With this change, `CONDUIT_PROXY_CONTROL_URL` is now optional. See the
doc comments in config.rs for the difference in semantics when it is
set vs. when it is unset.

Fixes the remaining part of #486.

Signed-off-by: Brian Smith <brian@briansmith.org>