### PR TITLE
Keep accepting new connections after TLS handshake error.

### DIFF
--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -135,10 +135,16 @@ impl BoundPort {
                         None => Either::B(future::ok((Connection::new(Box::new(socket)), remote_addr))),
                     }
                 })
-                .or_else(|err| {
-                    debug!("error handshaking: {}", err);
-                    future::err(err)
+                .then(|r| {
+                    future::ok(match r {
+                        Ok(r) => Some(r),
+                        Err(err) => {
+                            debug!("error handshaking: {}", err);
+                            None
+                        }
+                    })
                 })
+                .filter_map(|x| x)
                 .fold(initial, f)
         )
         .map(|_| ())


### PR DESCRIPTION
When a TLS handshake error occurs, the proxy just stops accepting
requests. It seems my expectations of how `Stream` handles errors
were wrong.

The test for this will be added in a separate PR after the
infrastructure needed for TLS testing is added. (This is a chicken
and egg problem.)

Signed-off-by: Brian Smith <brian@briansmith.org>