### PR TITLE
proxy: Fix false positives in polling-based fs watches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,6 +36,9 @@ regex = "1.0.0"
 # networking
 tokio = "0.1.7"
 tokio-signal = "0.2"
+# We have to depend on `tokio-timer` rather than using the re-exports in the
+# `tokio crate`, as `tokio` doesn't expose the `Clock` trait.
+tokio-timer = "0.2.4"
 tokio-connect         = { git = "https://github.com/carllerche/tokio-connect" }
 tower-balance         = { git = "https://github.com/tower-rs/tower" }
 tower-buffer          = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -36,9 +36,7 @@ regex = "1.0.0"
 # networking
 tokio = "0.1.7"
 tokio-signal = "0.2"
-# We have to depend on `tokio-timer` rather than using the re-exports in the
-# `tokio crate`, as `tokio` doesn't expose the `Clock` trait.
-tokio-timer = "0.2.4"
+tokio-timer = "0.2.4"   # for tokio_timer::clock
 tokio-connect         = { git = "https://github.com/carllerche/tokio-connect" }
 tower-balance         = { git = "https://github.com/tower-rs/tower" }
 tower-buffer          = { git = "https://github.com/tower-rs/tower" }

--- a/proxy/src/fs_watch.rs
+++ b/proxy/src/fs_watch.rs
@@ -134,7 +134,7 @@ impl PathAndHash {
                     let prev_hash = self.curr_hash.borrow();
                     let prev_hash_bytes = prev_hash.as_ref().map(Digest::as_ref);
                     let curr_hash_bytes = curr_hash.as_ref().map(Digest::as_ref);
-                    prev_hash_bytes == curr_hash_bytes
+                    prev_hash_bytes != curr_hash_bytes
                 };
                 if changed {
                     trace!("{:?} changed", &self.path);

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -35,6 +35,7 @@ extern crate ring;
 extern crate tempdir;
 extern crate tokio;
 extern crate tokio_connect;
+extern crate tokio_timer;
 extern crate tower_balance;
 extern crate tower_buffer;
 extern crate tower_discover;


### PR DESCRIPTION
There are currently two issues which can lead to false positives (changes being
reported when files have not actually changed) in the polling-based filesystem
watch implementation. 

The first issue is that when checking each watched file for changes, the loop
iterating over each path currently short-circuits as soon as it detects a 
change. This means that if two or more files have changed, the first time we
poll the fs, we will see the first change, then if we poll again, we will see
the next change, and so on. 

This branch fixes that issue by always hashing all the watched files, even if a
change has already been detected. This way, if all the files change between one
poll and the next, we no longer generate additional change events until a file
actually changes again.

The other issue is that the old implementation would treat any instance of a 
"file not found" error as indicating that the file had been deleted, and 
generate a change event. This leads to changes repeatedly being detected as
long as a file does not exist, rather than a single time when the file's 
existence state actually changes.

This branch fixes that issue as well, by only generating change events on
"file not found" errors if the file existed the last time it was polled. 
Otherwise, if a file did not previously exist, we no longer generate a new 
event.

I've verified both of these fixes through manual testing, as well as a new
test for the second issue. The new test fails on master but passes on this
branch.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>