### PR TITLE
Enable get for nodes/proxy for Prometheus RBAC

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -57,8 +57,8 @@ metadata:
   name: conduit-prometheus
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "pods"]
-  verbs: ["list", "watch"]
+  resources: ["nodes", "nodes/proxy", "pods"]
+  verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -57,8 +57,8 @@ metadata:
   name: conduit-prometheus
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "pods"]
-  verbs: ["list", "watch"]
+  resources: ["nodes", "nodes/proxy", "pods"]
+  verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -60,8 +60,8 @@ metadata:
   name: conduit-prometheus
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "pods"]
-  verbs: ["list", "watch"]
+  resources: ["nodes", "nodes/proxy", "pods"]
+  verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
The `kubernetes-nodes-cadvisor` Prometheus queries node-level data via
the Kubernetes API server. In some configurations of Kubernetes, namely
minikube and at least one baremetal kubespray cluster, this API call
requires the `get` verb on the `nodes/proxy` resource.

Enable `get` for `nodes/proxy` for the `conduit-prometheus` service
account.

Fixes #912

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

### Kubernetes Grafana dashboard working on baremetal kubespray cluster

<img width="1172" alt="screen shot 2018-06-15 at 4 42 30 pm" src="https://user-images.githubusercontent.com/236915/41493441-222777c8-70bc-11e8-8444-c24dd3375d62.png">
