### PR TITLE
proxy: Clarify Outbound::recognize

### DIFF
--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -86,17 +86,17 @@ impl<B> Outbound<B> {
 
     /// Determines the destination for a request.
     ///
-    /// Typically, a request's authority is used to produce a `Destination`. If the it
-    /// addresses a DNS name, a `Destinatino::Name` is returned; and, otherwise, if it
-    /// addresses a fixed IP address, a `Destination::Addr` is returned. A port is
+    /// Typically, a request's authority is used to produce a `Destination`. If the
+    /// authority addresses a DNS name, a `Destination::Name` is returned; and, otherwise,
+    /// it addresses a fixed IP address and a `Destination::Addr` is returned. The port is
     /// inferred if not specified in the authority.
     ///
-    /// Otherwise, the `SO_ORIGINAL_DST` socket option is checked. If it's available, it
-    /// is used to return a `Destination;:Addr`. This option is typically set by
-    /// `iptables(8)` in containerized environments like Kubernetes (as configured by the
-    /// `proxy-init` program).
+    /// If no authority is available, the `SO_ORIGINAL_DST` socket option is checked. If
+    /// it's available, it is used to return a `Destination::Addr`. This socket option is
+    /// typically set by `iptables(8)` in containerized environments like Kubernetes (as
+    /// configured by the `proxy-init` program).
     ///
-    /// If none of this informatino is available, no `Destination` is returned.
+    /// If none of this information is available, no `Destination` is returned.
     fn destination(req: &http::Request<B>) -> Option<Destination> {
         match Self::host_port(req) {
             Some(HostAndPort { host: Host::DnsName(host), port }) => {

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -85,11 +85,11 @@ impl<B> Outbound<B> {
     ///
     /// A Destination is determined for each request as follows:
     ///
-    /// 1. If the request includes a logical authority, it is routed by the hostname and
-    ///    port. If an explicit port is not provided, a default is assumed.
+    /// 1. If the request's authority contains a logical hostname, it is routed by the
+    ///    hostname and port. If an explicit port is not provided, a default is assumed.
     ///
-    /// 2. If the request authority contains a concrete IP address, it is routed directly
-    ///    to that IP address.
+    /// 2. If the request's authority contains a concrete IP address, it is routed
+    ///    directly to that IP address.
     ///
     /// 3. If no authority is present on the request, the client's original destination,
     ///    as determined by the SO_ORIGINAL_DST socket option, is used as the request's

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -60,8 +60,7 @@ impl<B> Outbound<B> {
     /// TODO: Use scheme-appropriate default port.
     fn normalize(authority: &http::uri::Authority) -> Option<HostAndPort> {
         const DEFAULT_PORT: Option<u16> = Some(80);
-        HostAndPort::normalize(authority, DEFAULT_PORT)
-            .inspect_err(|e| error!("invalid authority=\"{}\": {:?}", authority, e))
+        HostAndPort::normalize(authority, DEFAULT_PORT).ok()
     }
 
     /// Determines the logical host:port of the request.

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -242,6 +242,7 @@ where
         }
     }
 }
+
 #[derive(Copy, Clone, Debug)]
 pub enum BindError {
     External { addr: SocketAddr },


### PR DESCRIPTION
The comments in Outbound::recognize had become somewhat stale as the
logic changed. Furthermore, this implementation may be easier to
understand if broken into smaller pieces.

This change reorganizes the Outbound:recognize method into helper
methods--`destination`, `host_port`, and `normalize`--each with
accompanying docstrings that more accurately reflect the current
implementation.

This also has the side-effect benefit of eliminating a string clone on
every request.