### PR TITLE
Fix unbound variable issue in docker-build script

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -206,12 +206,13 @@ In development you can run:
 bin/go-run cli check
 ```
 
-### Building CLI for development
+### Building the CLI for development
 
-When Conduit's CLI is built using `bin/docker-build` it always creates binaries for all three platforms.
-For local development and fast edit-build-test cycle you might want to avoid that. For those situations
-you can use the fast-build option, that will skip the docker build altogether and will build CLI
-locally using `go build`.
+When Conduit's CLI is built using `bin/docker-build` it always creates binaries
+for all three platforms. For local development and a faster edit-build-test
+cycle you might want to avoid that. For those situations you can use the
+`bin/fast-build` script, which builds the CLI using the local Go toolchain
+outside of Docker.
 
 ```bash
 bin/fast-build

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -12,9 +12,8 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $bindir/docker-build-controller
 $bindir/docker-build-web
 $bindir/docker-build-proxy-init
-if [ $CONDUIT_SKIP_CLI_CONTAINER -ne 1 ]; then
+if [ -z "${CONDUIT_SKIP_CLI_CONTAINER:-}" ]; then
     $bindir/docker-build-cli-bin
 fi
 $bindir/docker-build-grafana
-
 $bindir/docker-build-proxy

--- a/bin/fast-build
+++ b/bin/fast-build
@@ -9,7 +9,7 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
-CONDUIT_SKIP_CLI_CONTAINER=1 bin/docker-build
+CONDUIT_SKIP_CLI_CONTAINER=1 $bindir/docker-build
 current_platform=$(uname)
 host_platform="windows"
 if [ "${current_platform}" = 'Darwin' ]; then
@@ -18,7 +18,10 @@ elif [ "${current_platform}" = 'Linux' ]; then
     host_platform="linux"
 fi
 
-./bin/dep ensure -vendor-only -v
-target="$rootdir/target/cli/${host_platform}/conduit"
-CGO_ENABLED=0 go build -installsuffix cgo -o $target -ldflags "-s -w -X github.com/runconduit/conduit/pkg/version.Version=$($bindir/root-tag)" ./cli
-echo "$target"
+(
+    cd $rootdir
+    $bindir/dep ensure -vendor-only -v
+    target="target/cli/${host_platform}/conduit"
+    CGO_ENABLED=0 go build -installsuffix cgo -o $target -ldflags "-s -w -X github.com/runconduit/conduit/pkg/version.Version=$($bindir/root-tag)" ./cli
+    echo "$target"
+)


### PR DESCRIPTION
This is a follow-up to #884. When running the `bin/docker-build` script independent of the `bin/fast-build` script, I see:

```
bin/docker-build: line 15: CONDUIT_SKIP_CLI_CONTAINER: unbound variable
```

Am updating with a fix. As part of this change I'm also address the remainder of the comments on #884.