### PR TITLE
Truncate very long error messages, small tweaks to error messages

### DIFF
--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -95,7 +95,6 @@ td .status-dot {
 }
 
 .conduit-pod-error {
-  margin-top: calc(2 * var(--base-width));
   margin-bottom: calc(3 * var(--base-width));
 
   & p {
@@ -104,6 +103,7 @@ td .status-dot {
 
   & .error-text {
     padding: var(--base-width);
+    margin-top: calc(2 * var(--base-width));
     border-radius: calc(0.5 * var(--base-width));
     font-size: 12px;
     color: white;

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Icon, Modal, Switch } from 'antd';
 
+// max characters we displaly for error messages before truncating them
+const maxErrorLength = 500;
+
 export default class ErrorModal extends React.Component {
   static propTypes = {
     errors: PropTypes.shape({}).isRequired,
@@ -12,7 +15,6 @@ export default class ErrorModal extends React.Component {
 
   state = {
     visible: false,
-    maxErrorLength: 500,
     truncateErrors: true
   }
 
@@ -53,9 +55,9 @@ export default class ErrorModal extends React.Component {
             .mapValues(v => {
               return _.map(v, err => {
                 let errMsg = _.get(err, ["container", "message"]);
-                if (_.size(errMsg) > this.state.maxErrorLength) {
+                if (_.size(errMsg) > maxErrorLength) {
                   shouldTruncate = true;
-                  err.container.truncatedMessage = _.take(errMsg, this.state.maxErrorLength).join("") + "...";
+                  err.container.truncatedMessage = _.take(errMsg, maxErrorLength).join("") + "...";
                 }
 
                 return err.container;


### PR DESCRIPTION
- If error messages are very long, truncate them and display a toggle to show the full message
- Tweak the headings - remove `Pod`, `Container` and `Image` - instead show them as titles
- Also move over from using Ant's `Modal.method` to the plain `Modal` component, which is a little simpler to hook into our other renders.

Before:
![screen shot 2018-06-18 at 3 47 43 pm](https://user-images.githubusercontent.com/549258/41566181-3da9208c-730f-11e8-8f6d-5d0023f233fe.png)


After:

![screen shot 2018-06-18 at 3 50 53 pm](https://user-images.githubusercontent.com/549258/41566248-967b3a6a-730f-11e8-839a-ce48f720aebf.png)


![screen shot 2018-06-18 at 3 30 59 pm](https://user-images.githubusercontent.com/549258/41566163-2aa88f5e-730f-11e8-9737-8e0241069580.png)