### PR TITLE
Don't panic on stats that aren't included in StatAllResourceTypes

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -223,15 +223,15 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 		os.Exit(0)
 	}
 
-	lastDisplayedStat := true // don't print a newline after the final stat
 	switch reqResourceType {
 	case k8s.All:
+		firstDisplayedStat := true // don't print a newline before the first stat
 		for _, resourceType := range k8s.StatAllResourceTypes {
 			if stats, ok := statTables[resourceType]; ok {
-				if !lastDisplayedStat {
+				if !firstDisplayedStat {
 					fmt.Fprint(w, "\n")
 				}
-				lastDisplayedStat = false
+				firstDisplayedStat = false
 				printStatTable(stats, resourceType, w, maxNameLength, maxNamespaceLength, options)
 			}
 		}

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -224,18 +224,20 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 	}
 
 	lastDisplayedStat := true // don't print a newline after the final stat
-
-	for _, resourceType := range k8s.StatAllResourceTypes {
-		if stats, ok := statTables[resourceType]; ok {
-			if !lastDisplayedStat {
-				fmt.Fprint(w, "\n")
-			}
-			lastDisplayedStat = false
-			if reqResourceType == k8s.All {
+	switch reqResourceType {
+	case k8s.All:
+		for _, resourceType := range k8s.StatAllResourceTypes {
+			if stats, ok := statTables[resourceType]; ok {
+				if !lastDisplayedStat {
+					fmt.Fprint(w, "\n")
+				}
+				lastDisplayedStat = false
 				printStatTable(stats, resourceType, w, maxNameLength, maxNamespaceLength, options)
-			} else {
-				printStatTable(stats, "", w, maxNameLength, maxNamespaceLength, options)
 			}
+		}
+	default:
+		if stats, ok := statTables[reqResourceType]; ok {
+			printStatTable(stats, "", w, maxNameLength, maxNamespaceLength, options)
 		}
 	}
 }

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -31,7 +31,7 @@ emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms     
 		}
 
 		if output != expectedOutput {
-			t.Fatalf("Wrong output:\n expected: \n%v\n, got: \n%v", expectedOutput, output)
+			t.Fatalf("Wrong output:\n expected: \n%s\n, got: \n%s", expectedOutput, output)
 		}
 	})
 }

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/runconduit/conduit/controller/api/public"
+)
+
+func TestStat(t *testing.T) {
+	t.Run("Returns namespace stats", func(t *testing.T) {
+		mockClient := &public.MockConduitApiClient{}
+
+		response := public.GenStatSummaryResponse("emoji", "namespaces", "emojivoto", 1, 2, 0)
+
+		mockClient.StatSummaryResponseToReturn = &response
+
+		expectedOutput := `NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   SECURED
+emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms      100%
+`
+
+		options := newStatOptions()
+		args := []string{"ns"}
+		req, err := buildStatSummaryRequest(args, options)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		output, err := requestStatsFromAPI(mockClient, req, options)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if output != expectedOutput {
+			t.Fatalf("Wrong output:\n expected: \n%v\n, got: \n%v", expectedOutput, output)
+		}
+	})
+}

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -43,44 +43,6 @@ func genPromSample(resName string, resType string, resNs string, classification 
 	}
 }
 
-func genStatSummaryResponse(resName, resType, resNs string, meshedPods uint64, runningPods uint64, failedPods uint64) pb.StatSummaryResponse {
-	return pb.StatSummaryResponse{
-		Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
-			Ok: &pb.StatSummaryResponse_Ok{
-				StatTables: []*pb.StatTable{
-					&pb.StatTable{
-						Table: &pb.StatTable_PodGroup_{
-							PodGroup: &pb.StatTable_PodGroup{
-								Rows: []*pb.StatTable_PodGroup_Row{
-									&pb.StatTable_PodGroup_Row{
-										Resource: &pb.Resource{
-											Namespace: resNs,
-											Type:      resType,
-											Name:      resName,
-										},
-										Stats: &pb.BasicStats{
-											SuccessCount:    123,
-											FailureCount:    0,
-											LatencyMsP50:    123,
-											LatencyMsP95:    123,
-											LatencyMsP99:    123,
-											TlsRequestCount: 123,
-										},
-										TimeWindow:      "1m",
-										MeshedPodCount:  meshedPods,
-										RunningPodCount: runningPods,
-										FailedPodCount:  failedPods,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 func genEmptyResponse() pb.StatSummaryResponse {
 	return pb.StatSummaryResponse{
 		Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
@@ -229,7 +191,7 @@ status:
 					},
 					TimeWindow: "1m",
 				},
-				expectedResponse: genStatSummaryResponse("emoji", "deployments", "emojivoto", 1, 2, 0),
+				expectedResponse: GenStatSummaryResponse("emoji", "deployments", "emojivoto", 1, 2, 0),
 			},
 		}
 
@@ -271,7 +233,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (le, namespace, pod))`,
 					`sum(increase(response_total{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod, classification, tls)`,
 				},
-				expectedResponse: genStatSummaryResponse("emojivoto-1", "pods", "emojivoto", 1, 1, 0),
+				expectedResponse: GenStatSummaryResponse("emojivoto-1", "pods", "emojivoto", 1, 1, 0),
 			},
 		}
 
@@ -763,7 +725,7 @@ status:
 						},
 						TimeWindow: "1m",
 					},
-					expectedResponse: genStatSummaryResponse("emoji", "deployments", "emojivoto", 1, 2, 1),
+					expectedResponse: GenStatSummaryResponse("emoji", "deployments", "emojivoto", 1, 2, 1),
 				},
 			}
 

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -125,3 +125,41 @@ func (m *MockProm) LabelValues(ctx context.Context, label string) (model.LabelVa
 func (m *MockProm) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
 	return nil, nil
 }
+
+func GenStatSummaryResponse(resName, resType, resNs string, meshedPods uint64, runningPods uint64, failedPods uint64) pb.StatSummaryResponse {
+	return pb.StatSummaryResponse{
+		Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
+			Ok: &pb.StatSummaryResponse_Ok{
+				StatTables: []*pb.StatTable{
+					&pb.StatTable{
+						Table: &pb.StatTable_PodGroup_{
+							PodGroup: &pb.StatTable_PodGroup{
+								Rows: []*pb.StatTable_PodGroup_Row{
+									&pb.StatTable_PodGroup_Row{
+										Resource: &pb.Resource{
+											Namespace: resNs,
+											Type:      resType,
+											Name:      resName,
+										},
+										Stats: &pb.BasicStats{
+											SuccessCount:    123,
+											FailureCount:    0,
+											LatencyMsP50:    123,
+											LatencyMsP95:    123,
+											LatencyMsP99:    123,
+											TlsRequestCount: 123,
+										},
+										TimeWindow:      "1m",
+										MeshedPodCount:  meshedPods,
+										RunningPodCount: runningPods,
+										FailedPodCount:  failedPods,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -82,11 +82,7 @@ func TestCliStatForConduitNamespace(t *testing.T) {
 				return err
 			}
 
-			if err := validateRowStats(TestHelper.GetConduitNamespace(), "4/4", rowStats); err != nil {
-				return err
-			}
-
-			return nil
+			return validateRowStats(TestHelper.GetConduitNamespace(), "4/4", rowStats)
 		})
 		if err != nil {
 			t.Fatal(err.Error())


### PR DESCRIPTION
*Problem*
When we run `conduit stat ...`, the `writeStatsToBuffer` function would go through `StatAllResourceTypes` and print all the resources that were there. `namespaces` is not in `StatAllResourceTypes` however, so no stats are written to the buffer. This causes the buffer length to be 0, which causes a panic when we try to do `out := string(buffer.Bytes()[padding:])`

This bug was introduced by https://github.com/runconduit/conduit/pull/1088/files

*Solution*
Fix `writeStatsToBuffer` to not depend on what resources are in `StatAllResourceTypes`.
Also add a `stat` test that would fail on current master. We do already have an integration test for stat, but no unit tests.

Fixes #1151