### PR TITLE
dest service: close open streams on shutdown

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	<-stop
 
-	log.Infof("shutting down gRPC server on %s\n", *addr)
-	done <- struct{}{}
+	log.Infof("shutting down gRPC server on %s", *addr)
+	close(done)
 	server.GracefulStop()
 }

--- a/controller/destination/endpoints_watcher.go
+++ b/controller/destination/endpoints_watcher.go
@@ -411,7 +411,7 @@ func (sp *servicePort) unsubscribeAll() {
 	defer sp.mutex.Unlock()
 
 	for _, listener := range sp.listeners {
-		close(listener.ServerClose())
+		listener.Stop()
 	}
 }
 

--- a/controller/destination/endpoints_watcher.go
+++ b/controller/destination/endpoints_watcher.go
@@ -61,9 +61,17 @@ func newEndpointsWatcher(k8sAPI *k8s.API) *endpointsWatcher {
 	return watcher
 }
 
-// TODO: this method should close all open streams
-// https://github.com/runconduit/conduit/issues/644
-func (e *endpointsWatcher) stop() {}
+// Close all open streams on shutdown
+func (e *endpointsWatcher) stop() {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	for _, portMap := range e.servicePorts {
+		for _, servicePort := range portMap {
+			servicePort.unsubscribeAll()
+		}
+	}
+}
 
 // Subscribe to a service and service port.
 // The provided listener will be updated each time the address set for the
@@ -394,6 +402,17 @@ func (sp *servicePort) unsubscribe(listener updateListener) (bool, int) {
 		}
 	}
 	return false, len(sp.listeners)
+}
+
+func (sp *servicePort) unsubscribeAll() {
+	log.Debugf("Unsubscribing %s:%d", sp.service, sp.port)
+
+	sp.mutex.Lock()
+	defer sp.mutex.Unlock()
+
+	for _, listener := range sp.listeners {
+		close(listener.ServerClose())
+	}
 }
 
 /// helpers ///

--- a/controller/destination/k8s_resolver_test.go
+++ b/controller/destination/k8s_resolver_test.go
@@ -116,17 +116,17 @@ func TestLocalKubernetesServiceIdFromDNSName(t *testing.T) {
 		resolver := &k8sResolver{k8sDNSZoneLabels: zone}
 
 		resolvableServiceNames := map[string]string{
-			"name1.ns.svc.this.is.the.zone":  "ns/name1",
-			"name2.ns.svc.this.is.the.zone.": "ns/name2",
-			"name3.ns.svc.cluster.local":     "ns/name3",
-			"name4.ns.svc.cluster.local.":    "ns/name4",
+			"name1.ns.svc.this.is.the.zone":  "name1.ns",
+			"name2.ns.svc.this.is.the.zone.": "name2.ns",
+			"name3.ns.svc.cluster.local":     "name3.ns",
+			"name4.ns.svc.cluster.local.":    "name4.ns",
 		}
 		assertIsResolved(t, resolver, resolvableServiceNames)
 	})
 
 	t.Run("Resolves names of services only if three labels in it", func(t *testing.T) {
 		resolver := &k8sResolver{k8sDNSZoneLabels: someKubernetesDNSZone}
-		validServiceNames := map[string]string{"name.ns.svc": "ns/name"}
+		validServiceNames := map[string]string{"name.ns.svc": "name.ns"}
 		assertIsResolved(t, resolver, validServiceNames)
 
 		invalidServiceNames := []string{"", "something.name.ns.svc.cluster.local", "a.svc", "svc", "a.b.c.svc", "a.b.c.d.svc"}

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -14,9 +14,10 @@ type podsByIpFn func(string) ([]*coreV1.Pod, error)
 type updateListener interface {
 	Update(add []common.TcpAddress, remove []common.TcpAddress)
 	ClientClose() <-chan struct{}
-	ServerClose() chan struct{}
+	ServerClose() <-chan struct{}
 	NoEndpoints(exists bool)
 	SetServiceId(id *serviceId)
+	Stop()
 }
 
 // implements the updateListener interface
@@ -46,8 +47,12 @@ func (l *endpointListener) ClientClose() <-chan struct{} {
 	return l.stream.Context().Done()
 }
 
-func (l *endpointListener) ServerClose() chan struct{} {
+func (l *endpointListener) ServerClose() <-chan struct{} {
 	return l.stopCh
+}
+
+func (l *endpointListener) Stop() {
+	close(l.stopCh)
 }
 
 func (l *endpointListener) SetServiceId(id *serviceId) {

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -92,7 +92,7 @@ func TestEndpointListener(t *testing.T) {
 
 		completed := make(chan bool)
 		go func() {
-			<-listener.Done()
+			<-listener.ClientClose()
 			completed <- true
 		}()
 

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -117,7 +117,7 @@ func (s *server) podsByIp(ip string) ([]*v1.Pod, error) {
 }
 
 func (s *server) streamResolutionUsingCorrectResolverFor(host string, port int, stream pb.Destination_GetServer) error {
-	listener := &endpointListener{stream: stream, podsByIp: s.podsByIp, enableTLS: s.enableTLS}
+	listener := newEndpointListener(stream, s.podsByIp, s.enableTLS)
 
 	for _, resolver := range s.resolvers {
 		resolverCanResolve, err := resolver.canResolve(host, port)

--- a/controller/destination/test_helper.go
+++ b/controller/destination/test_helper.go
@@ -25,8 +25,12 @@ func (c *collectUpdateListener) ClientClose() <-chan struct{} {
 	return c.context.Done()
 }
 
-func (c *collectUpdateListener) ServerClose() chan struct{} {
+func (c *collectUpdateListener) ServerClose() <-chan struct{} {
 	return c.stopCh
+}
+
+func (c *collectUpdateListener) Stop() {
+	close(c.stopCh)
 }
 
 func (c *collectUpdateListener) NoEndpoints(exists bool) {

--- a/controller/destination/test_helper.go
+++ b/controller/destination/test_helper.go
@@ -13,6 +13,7 @@ type collectUpdateListener struct {
 	noEndpointsCalled bool
 	noEndpointsExists bool
 	context           context.Context
+	stopCh            chan struct{}
 }
 
 func (c *collectUpdateListener) Update(add []common.TcpAddress, remove []common.TcpAddress) {
@@ -20,8 +21,12 @@ func (c *collectUpdateListener) Update(add []common.TcpAddress, remove []common.
 	c.removed = append(c.removed, remove...)
 }
 
-func (c *collectUpdateListener) Done() <-chan struct{} {
+func (c *collectUpdateListener) ClientClose() <-chan struct{} {
 	return c.context.Done()
+}
+
+func (c *collectUpdateListener) ServerClose() chan struct{} {
+	return c.stopCh
 }
 
 func (c *collectUpdateListener) NoEndpoints(exists bool) {

--- a/pkg/k8s/proxy.go
+++ b/pkg/k8s/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/kubectl/proxy"
 	// Load all the auth plugins for the cloud providers.
@@ -83,7 +84,7 @@ func proxyListen(server *proxy.Server, proxyPort int) (net.Listener, error) {
 }
 
 func proxyServe(server *proxy.Server, listener net.Listener) error {
-	fmt.Printf("Starting to serve on %s\n", listener.Addr().String())
+	log.Infof("Starting to serve on %s", listener.Addr().String())
 
 	// blocks until process is killed
 	err := server.ServeOnListener(listener)


### PR DESCRIPTION
The destination service previously did not close open streams on shutdown. This caused the gRPC server's `GracefulStop` method to hang indefinitely. In this branch I'm modifying the server to close all open streams before calling `GracefulStop`. As part of this change I'm also cleaning up some issues I noticed with the destination service logs.

Fixes #644.