### PR TITLE
Fix dashboard integration test

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -141,7 +141,7 @@ func TestDashboard(t *testing.T) {
 	}
 	defer outputStream.Stop()
 
-	outputLines, err := outputStream.ReadUntil(5, 1*time.Minute)
+	outputLines, err := outputStream.ReadUntil(4, 1*time.Minute)
 	if err != nil {
 		t.Fatalf("Error running command:\n%s", err)
 	}

--- a/test/tap/testdata/tap_application.yaml
+++ b/test/tap/testdata/tap_application.yaml
@@ -171,9 +171,9 @@ spec:
     spec:
       containers:
       - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.0
+        image: buoyantio/slow_cooker:1.1.1
         command:
-        - "/bin/bash"
+        - "/bin/sh"
         args:
         - "-c"
         - |

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // TestHelper provides helpers for running the conduit integration tests.
@@ -32,6 +34,7 @@ func NewTestHelper() *TestHelper {
 	conduit := flag.String("conduit", "", "path to the conduit binary to test")
 	namespace := flag.String("conduit-namespace", "conduit", "the namespace where conduit is installed")
 	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
+	verbose := flag.Bool("verbose", false, "turn on debug logging")
 	flag.Parse()
 
 	if !*runTests {
@@ -49,6 +52,12 @@ func NewTestHelper() *TestHelper {
 	_, err := os.Stat(*conduit)
 	if err != nil {
 		exit(1, "-conduit binary does not exist")
+	}
+
+	if *verbose {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.PanicLevel)
 	}
 
 	testHelper := &TestHelper{


### PR DESCRIPTION
I made a change in 8f23056 that changed the output of `conduit dashboard` to stop printing a redundant URL. Unfortunately I didn't update the dashboard integration test to account for the change.

As part of this branch I'm also updating our tests to set their log level to panic by default, and adding a flag to set the log level to debug instead, for... debugging. This mimics the way that the CLI already behaves.

And I'm upgrading the version of slow_cooker used in our tests to 1.1.1.