### PR TITLE
Don't allow api stat requests for named resources in --all-namespaces 

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -319,6 +320,10 @@ func buildStatSummaryRequest(resource []string, options *statOptions) (*pb.StatS
 	target, err := util.BuildResource(targetNamespace, resource...)
 	if err != nil {
 		return nil, err
+	}
+
+	if target.Name != "" && targetNamespace == "" {
+		return nil, errors.New("stats for a resource cannot be retrieved by name across all namespaces")
 	}
 
 	var toRes, fromRes pb.Resource

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -34,4 +34,16 @@ emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms     
 			t.Fatalf("Wrong output:\n expected: \n%s\n, got: \n%s", expectedOutput, output)
 		}
 	})
+
+	t.Run("Returns an error for named resource queries with the --all-namespaces flag", func(t *testing.T) {
+		options := newStatOptions()
+		options.allNamespaces = true
+		args := []string{"po", "web"}
+		expectedError := "stats for a resource cannot be retrieved by name across all namespaces"
+
+		_, err := buildStatSummaryRequest(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
 }

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -72,6 +72,7 @@ func TestCliStatForConduitNamespace(t *testing.T) {
 
 	t.Run("test conduit stat namespace", func(t *testing.T) {
 		err := TestHelper.RetryFor(20*time.Second, func() error {
+			fmt.Println("HEREEEEE")
 			out, err := TestHelper.ConduitRun("stat", "ns", TestHelper.GetConduitNamespace())
 			if err != nil {
 				t.Fatalf("Unexpected stat error: %v", err)
@@ -83,6 +84,22 @@ func TestCliStatForConduitNamespace(t *testing.T) {
 			}
 
 			return validateRowStats(TestHelper.GetConduitNamespace(), "4/4", rowStats)
+		})
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+	})
+
+	t.Run("test named deploy query", func(t *testing.T) {
+		err := TestHelper.RetryFor(10*time.Second, func() error {
+			fmt.Println("HEREEEEE")
+			out, err := TestHelper.ConduitRun("stat", "deploy/web", "--all-namespaces")
+			if err == nil {
+				t.Fatalf("Unexpected stat error: %v", err)
+			}
+
+			fmt.Println(out)
+			return nil
 		})
 		if err != nil {
 			t.Fatal(err.Error())

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -88,21 +88,6 @@ func TestCliStatForConduitNamespace(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 	})
-
-	t.Run("test named deploy query", func(t *testing.T) {
-		err := TestHelper.RetryFor(10*time.Second, func() error {
-			_, err := TestHelper.ConduitRun("stat", "deploy/web", "--all-namespaces")
-
-			if err == nil {
-				t.Fatalf("Unexpected stat error: %v", err)
-			}
-
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-	})
 }
 
 // check that expectedRowCount rows have been returned

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -72,7 +72,6 @@ func TestCliStatForConduitNamespace(t *testing.T) {
 
 	t.Run("test conduit stat namespace", func(t *testing.T) {
 		err := TestHelper.RetryFor(20*time.Second, func() error {
-			fmt.Println("HEREEEEE")
 			out, err := TestHelper.ConduitRun("stat", "ns", TestHelper.GetConduitNamespace())
 			if err != nil {
 				t.Fatalf("Unexpected stat error: %v", err)
@@ -92,13 +91,12 @@ func TestCliStatForConduitNamespace(t *testing.T) {
 
 	t.Run("test named deploy query", func(t *testing.T) {
 		err := TestHelper.RetryFor(10*time.Second, func() error {
-			fmt.Println("HEREEEEE")
-			out, err := TestHelper.ConduitRun("stat", "deploy/web", "--all-namespaces")
+			_, err := TestHelper.ConduitRun("stat", "deploy/web", "--all-namespaces")
+
 			if err == nil {
 				t.Fatalf("Unexpected stat error: %v", err)
 			}
 
-			fmt.Println(out)
 			return nil
 		})
 		if err != nil {

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -85,7 +85,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     }
 
     let baseUrl = '/api/tps-reports?resource_type=' + type;
-    return !namespace ? baseUrl : baseUrl + '&namespace=' + namespace;
+    return !namespace ? baseUrl + '&all_namespaces=true' : baseUrl + '&namespace=' + namespace;
   };
 
   // maintain a list of a component's requests,

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -131,6 +131,9 @@ export const processSingleResourceRollup = rawMetrics => {
   if (_.size(result) > 1) {
     console.error("Multi metric returned; expected single metric.");
   }
+  if (_.isEmpty(result)) {
+    return [];
+  }
   return _.values(result)[0];
 };
 

--- a/web/app/test/ApiHelpersTest.jsx
+++ b/web/app/test/ApiHelpersTest.jsx
@@ -285,13 +285,13 @@ describe('ApiHelpers', () => {
     it('returns the correct rollup url for deployment overviews', () => {
       api = ApiHelpers('/go/my/own/way');
       let deploymentUrl = api.urlsForResource("deployment");
-      expect(deploymentUrl).to.equal('/api/tps-reports?resource_type=deployment');
+      expect(deploymentUrl).to.equal('/api/tps-reports?resource_type=deployment&all_namespaces=true');
     });
 
     it('returns the correct rollup url for pod overviews', () => {
       api = ApiHelpers('/go/my/own/way');
       let deploymentUrls = api.urlsForResource("pod");
-      expect(deploymentUrls).to.equal('/api/tps-reports?resource_type=pod');
+      expect(deploymentUrls).to.equal('/api/tps-reports?resource_type=pod&all_namespaces=true');
     });
 
     it('scopes the query to the provided namespace', () => {

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -70,6 +70,10 @@ func (h *handler) handleApiPods(w http.ResponseWriter, req *http.Request, p http
 }
 
 func (h *handler) handleApiStat(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	allNs := false
+	if req.FormValue("all_namespaces") == "true" {
+		allNs = true
+	}
 	requestParams := util.StatSummaryRequestParams{
 		TimeWindow:    req.FormValue("window"),
 		ResourceName:  req.FormValue("resource_name"),
@@ -81,6 +85,7 @@ func (h *handler) handleApiStat(w http.ResponseWriter, req *http.Request, p http
 		FromName:      req.FormValue("from_name"),
 		FromType:      req.FormValue("from_type"),
 		FromNamespace: req.FormValue("from_namespace"),
+		AllNamespaces: allNs,
 	}
 
 	// default to returning deployment stats


### PR DESCRIPTION
This follows `kubectl`, which also does not allow requesting named resources over all namespaces:

```
$ kubectl get po/foo --all-namespaces
error: a resource cannot be retrieved by name across all namespaces
```

This PR also updates the Web API's behaviour to be in line with the CLI's. Both will now default to the `default` namespace if no namespace is specified.

Fixes #1159