### PR TITLE
Proxy: More carefully keep track of the reason TLS isn't used.

### DIFF
--- a/proxy/benches/record.rs
+++ b/proxy/benches/record.rs
@@ -49,7 +49,9 @@ where
     ctx::transport::Client::new(
         &proxy,
         &addr(),
-        destination::Metadata::new(metrics::DstLabels::new(labels), None),
+        destination::Metadata::new(
+            metrics::DstLabels::new(labels),
+            Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery)),
         TLS_DISABLED,
     )
 }

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -221,8 +221,7 @@ where
                     None => Conditional::None(tls::ReasonForNoTls::NoConfig),
                 }
             },
-            Conditional::None(why_no_identity) =>
-                Conditional::None(tls::ReasonForNoTls::NoIdentity(why_no_identity)),
+            Conditional::None(why_no_identity) => Conditional::None(why_no_identity.into()),
         };
 
         let client_ctx = ctx::transport::Client::new(

--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -18,6 +18,7 @@ use transparency::{self, HttpBody, h1};
 use transport;
 use tls;
 use ctx::transport::TlsStatus;
+use conditional::Conditional;
 
 /// Binds a `Service` from a `SocketAddr`.
 ///
@@ -208,8 +209,21 @@ where
         debug!("bind_stack endpoint={:?}, protocol={:?}", ep, protocol);
         let addr = ep.address();
 
-        let tls = tls::current_connection_config(ep.tls_identity(),
-                                                 &self.ctx.tls_client_config_watch());
+        // Like `tls::current_connection_config()` with optional identity.
+        let tls = match ep.tls_identity() {
+            Conditional::Some(identity) => {
+                match *self.ctx.tls_client_config_watch().borrow() {
+                    Some(ref config) =>
+                        Conditional::Some(tls::ConnectionConfig {
+                            identity: identity.clone(),
+                            config: config.clone()
+                        }),
+                    None => Conditional::None(tls::ReasonForNoTls::NoConfig),
+                }
+            },
+            Conditional::None(why_no_identity) =>
+                Conditional::None(tls::ReasonForNoTls::NoIdentity(why_no_identity)),
+        };
 
         let client_ctx = ctx::transport::Client::new(
             &self.ctx,

--- a/proxy/src/conditional.rs
+++ b/proxy/src/conditional.rs
@@ -53,3 +53,16 @@ where
         }
     }
 }
+
+impl<C, R> Conditional<C, R>
+where
+    C: Clone + std::fmt::Debug,
+    R: Copy + Clone + std::fmt::Debug,
+{
+    pub fn as_ref<'a>(&'a self) -> Conditional<&'a C, R> {
+        match self {
+            Conditional::Some(c) => Conditional::Some(&c),
+            Conditional::None(r) => Conditional::None(*r),
+        }
+    }
+}

--- a/proxy/src/control/destination/endpoint.rs
+++ b/proxy/src/control/destination/endpoint.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use telemetry::metrics::DstLabels;
 use super::Metadata;
 use tls;
+use conditional::Conditional;
 
 /// An individual traffic target.
 ///
@@ -35,7 +36,7 @@ impl Endpoint {
         self.metadata.dst_labels()
     }
 
-    pub fn tls_identity(&self) -> Option<&tls::Identity> {
+    pub fn tls_identity(&self) -> Conditional<&tls::Identity, tls::ReasonForNoIdentity> {
         self.metadata.tls_identity()
     }
 }

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -5,6 +5,7 @@ use ctx;
 use telemetry::metrics::DstLabels;
 use std::sync::atomic::Ordering;
 use transport::tls;
+use conditional::Conditional;
 
 
 /// A `RequestId` can be mapped to a `u64`. No `RequestId`s will map to the
@@ -76,7 +77,7 @@ impl Request {
         Arc::new(r)
     }
 
-    pub fn tls_identity(&self) -> Option<&tls::Identity> {
+    pub fn tls_identity(&self) -> Conditional<&tls::Identity, tls::ReasonForNoIdentity> {
         self.client.tls_identity()
     }
 

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -100,6 +100,8 @@ pub mod test_util {
     use ctx;
     use control::destination;
     use telemetry::metrics::DstLabels;
+    use tls;
+    use conditional::Conditional;
 
     fn addr() -> SocketAddr {
         ([1, 2, 3, 4], 5678).into()
@@ -125,7 +127,8 @@ pub mod test_util {
         L: IntoIterator<Item=(S, S)>,
         S: fmt::Display,
     {
-        let meta = destination::Metadata::new(DstLabels::new(labels), None);
+        let meta = destination::Metadata::new(DstLabels::new(labels),
+            Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery));
         ctx::transport::Client::new(&proxy, &addr(), meta, tls)
     }
 

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -126,7 +126,7 @@ impl Client {
         Arc::new(c)
     }
 
-    pub fn tls_identity(&self) -> Option<&tls::Identity> {
+    pub fn tls_identity(&self) -> Conditional<&tls::Identity, tls::ReasonForNoIdentity> {
         self.metadata.tls_identity()
     }
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -97,6 +97,7 @@ use task::MainRuntime;
 use transparency::{HttpBody, Server};
 pub use transport::{AddrInfo, GetOriginalDst, SoOriginalDst, tls};
 use outbound::Outbound;
+use conditional::Conditional;
 
 /// Runs a sidecar proxy.
 ///
@@ -183,7 +184,7 @@ where
         let (tls_client_config, tls_server_config, tls_cfg_bg) =
             tls::watch_for_config_changes(self.config.tls_settings.as_ref());
 
-        let process_ctx = ctx::Process::new(&self.config, tls_client_config);
+        let process_ctx = ctx::Process::new(&self.config, tls_client_config.clone());
 
         let Main {
             config,
@@ -225,6 +226,10 @@ where
             &taps,
         );
 
+        let controller_tls =
+                Conditional::None(tls::ReasonForNoTls::NoIdentity(
+                    tls::ReasonForNoIdentity::NotImplementedForController)); // TODO
+
         let (dns_resolver, dns_bg) = dns::Resolver::from_system_config_and_env(&config)
             .unwrap_or_else(|e| {
                 // TODO: Make DNS configuration infallible.
@@ -234,7 +239,8 @@ where
         let (resolver, resolver_bg) = control::destination::new(
             dns_resolver.clone(),
             config.namespaces.clone(),
-            control_host_and_port
+            control_host_and_port,
+            controller_tls,
         );
 
         let (drain_tx, drain_rx) = drain::channel();

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -227,8 +227,7 @@ where
         );
 
         let controller_tls =
-                Conditional::None(tls::ReasonForNoTls::NoIdentity(
-                    tls::ReasonForNoIdentity::NotImplementedForController)); // TODO
+            Conditional::None(tls::ReasonForNoIdentity::NotImplementedForController.into()); // TODO
 
         let (dns_resolver, dns_bg) = dns::Resolver::from_system_config_and_env(&config)
             .unwrap_or_else(|e| {

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -382,8 +382,7 @@ impl fmt::Display for ctx::transport::TlsStatus {
             Conditional::Some(()) => f.pad(",tls=\"true\""),
             Conditional::None(tls::ReasonForNoTls::NoConfig) => f.pad(",tls=\"no_config\""),
             Conditional::None(tls::ReasonForNoTls::Disabled) |
-            Conditional::None(tls::ReasonForNoTls::NotImplementedForNonHttp) |
-            Conditional::None(tls::ReasonForNoTls::NotImplementedForControlPlane) => Ok(()),
+            Conditional::None(tls::ReasonForNoTls::NoIdentity(_)) => Ok(()),
         }
     }
 }

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -60,7 +60,8 @@ impl Proxy {
             return future::Either::B(future::ok(()));
         };
 
-        let tls = Conditional::None(tls::ReasonForNoTls::NotImplementedForNonHttp); // TODO
+        let tls = Conditional::None(
+            tls::ReasonForNoTls::NoIdentity(tls::ReasonForNoIdentity::NotHttp)); // TODO
 
         let client_ctx = ClientCtx::new(
             &srv_ctx.proxy,

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -60,8 +60,7 @@ impl Proxy {
             return future::Either::B(future::ok(()));
         };
 
-        let tls = Conditional::None(
-            tls::ReasonForNoTls::NoIdentity(tls::ReasonForNoIdentity::NotHttp)); // TODO
+        let tls = Conditional::None(tls::ReasonForNoIdentity::NotHttp.into()); // TODO
 
         let client_ctx = ClientCtx::new(
             &srv_ctx.proxy,

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -115,6 +115,12 @@ pub enum ReasonForNoIdentity {
     NotImplementedForController,
 }
 
+impl From<ReasonForNoIdentity> for ReasonForNoTls {
+    fn from(r: ReasonForNoIdentity) -> Self {
+        ReasonForNoTls::NoIdentity(r)
+    }
+}
+
 pub type ConditionalConnectionConfig<C> = Conditional<ConnectionConfig<C>, ReasonForNoTls>;
 
 #[derive(Debug)]

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -91,13 +91,28 @@ pub enum ReasonForNoTls {
     /// TLS was enabled but the configuration isn't available (yet).
     NoConfig,
 
-    /// TLS isn't implemented for the connection between the proxy and the
-    /// control plane yet.
-    NotImplementedForControlPlane,
+    /// The endpoint's TLS identity is unknown. Without knowing its identity
+    /// we can't validate its certificate.
+    NoIdentity(ReasonForNoIdentity),
+}
 
-    /// TLS is only enabled for HTTP (HTTPS) right now.
-    NotImplementedForNonHttp,
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ReasonForNoIdentity {
+    /// The connection is a non-HTTP connection so we don't know anything
+    /// about the destination besides its address.
+    NotHttp,
 
+    /// The connection is for HTTP but the HTTP request doesn't have an
+    /// authority so we can't extract the identity from it.
+    NoAuthorityInHttpRequest,
+
+    /// The destination service didn't give us the identity, which is its way
+    /// of telling us that we shouldn't do TLS for this endpoint.
+    NotProvidedByServiceDiscovery,
+
+    /// We haven't implemented the mechanism to construct a TLS identity for
+    /// the controller yet.
+    NotImplementedForController,
 }
 
 pub type ConditionalConnectionConfig<C> = Conditional<ConnectionConfig<C>, ReasonForNoTls>;
@@ -318,21 +333,21 @@ impl ServerConfig {
     }
 }
 
-pub fn current_connection_config<C>(identity: Option<&Identity>, watch: &Watch<Option<C>>)
+pub fn current_connection_config<C>(watch: &ConditionalConnectionConfig<Watch<Option<C>>>)
     -> ConditionalConnectionConfig<C> where C: Clone + std::fmt::Debug
 {
-    match identity {
-        Some(identity) => {
-            match *watch.borrow() {
+    match watch {
+        Conditional::Some(c) => {
+            match *c.config.borrow() {
                 Some(ref config) =>
                     Conditional::Some(ConnectionConfig {
-                        identity: identity.clone(),
+                        identity: c.identity.clone(),
                         config: config.clone()
                     }),
                 None => Conditional::None(ReasonForNoTls::NoConfig),
             }
         },
-        None => Conditional::None(ReasonForNoTls::Disabled),
+        Conditional::None(r) => Conditional::None(*r),
     }
 }
 

--- a/proxy/src/transport/tls/mod.rs
+++ b/proxy/src/transport/tls/mod.rs
@@ -18,6 +18,7 @@ pub use self::{
         ConditionalConnectionConfig,
         ConnectionConfig,
         ReasonForNoTls,
+        ReasonForNoIdentity,
         ServerConfig,
         ServerConfigWatch,
         current_connection_config,


### PR DESCRIPTION
There is only one case where we dynamically don't know whether we'll
have an identity to construct a TLS connection configuration. Refactor
the code with that in mind, better documenting all the reasons why an
identity isn't available.

Signed-off-by: Brian Smith <brian@briansmith.org>