### PR TITLE
Add controller admin servers and readiness probes

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -148,12 +148,21 @@ spec:
         - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9995
+          initialDelaySeconds: 10
         name: public-api
         ports:
         - containerPort: 8085
           name: http
         - containerPort: 9995
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9995
         resources: {}
       - args:
         - destination
@@ -162,12 +171,21 @@ spec:
         - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9999
+          initialDelaySeconds: 10
         name: destination
         ports:
         - containerPort: 8089
           name: grpc
         - containerPort: 9999
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9999
         resources: {}
       - args:
         - proxy-api
@@ -176,12 +194,21 @@ spec:
         - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9996
+          initialDelaySeconds: 10
         name: proxy-api
         ports:
         - containerPort: 8086
           name: grpc
         - containerPort: 9996
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9996
         resources: {}
       - args:
         - tap
@@ -189,12 +216,21 @@ spec:
         - -logtostderr=true
         image: gcr.io/runconduit/controller:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9998
+          initialDelaySeconds: 10
         name: tap
         ports:
         - containerPort: 8088
           name: grpc
         - containerPort: 9998
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9998
         resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG
@@ -306,12 +342,21 @@ spec:
         - -log-level=info
         image: gcr.io/runconduit/web:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9994
+          initialDelaySeconds: 10
         name: web
         ports:
         - containerPort: 8084
           name: http
         - containerPort: 9994
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9994
         resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -160,6 +160,7 @@ spec:
         - containerPort: 9995
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9995
@@ -183,6 +184,7 @@ spec:
         - containerPort: 9999
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9999
@@ -206,6 +208,7 @@ spec:
         - containerPort: 9996
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9996
@@ -228,6 +231,7 @@ spec:
         - containerPort: 9998
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9998
@@ -354,6 +358,7 @@ spec:
         - containerPort: 9994
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9994
@@ -711,7 +716,7 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 30
         resources: {}

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -161,6 +161,7 @@ spec:
         - containerPort: 9995
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9995
@@ -184,6 +185,7 @@ spec:
         - containerPort: 9999
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9999
@@ -207,6 +209,7 @@ spec:
         - containerPort: 9996
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9996
@@ -229,6 +232,7 @@ spec:
         - containerPort: 9998
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9998
@@ -356,6 +360,7 @@ spec:
         - containerPort: 9994
           name: admin-http
         readinessProbe:
+          failureThreshold: 7
           httpGet:
             path: /ready
             port: 9994
@@ -715,7 +720,7 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 30
         resources: {}

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -149,12 +149,21 @@ spec:
         - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9995
+          initialDelaySeconds: 10
         name: public-api
         ports:
         - containerPort: 8085
           name: http
         - containerPort: 9995
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9995
         resources: {}
       - args:
         - destination
@@ -163,12 +172,21 @@ spec:
         - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9999
+          initialDelaySeconds: 10
         name: destination
         ports:
         - containerPort: 8089
           name: grpc
         - containerPort: 9999
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9999
         resources: {}
       - args:
         - proxy-api
@@ -177,12 +195,21 @@ spec:
         - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9996
+          initialDelaySeconds: 10
         name: proxy-api
         ports:
         - containerPort: 123
           name: grpc
         - containerPort: 9996
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9996
         resources: {}
       - args:
         - tap
@@ -190,12 +217,21 @@ spec:
         - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9998
+          initialDelaySeconds: 10
         name: tap
         ports:
         - containerPort: 8088
           name: grpc
         - containerPort: 9998
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9998
         resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG
@@ -308,12 +344,21 @@ spec:
         - -log-level=ControllerLogLevel
         image: WebImage
         imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9994
+          initialDelaySeconds: 10
         name: web
         ports:
         - containerPort: 8084
           name: http
         - containerPort: 9994
           name: admin-http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9994
         resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -161,6 +161,7 @@ spec:
           httpGet:
             path: /ready
             port: 9995
+          failureThreshold: 7
       - name: destination
         ports:
         - name: grpc
@@ -183,6 +184,7 @@ spec:
           httpGet:
             path: /ready
             port: 9999
+          failureThreshold: 7
       - name: proxy-api
         ports:
         - name: grpc
@@ -205,6 +207,7 @@ spec:
           httpGet:
             path: /ready
             port: 9996
+          failureThreshold: 7
       - name: tap
         ports:
         - name: grpc
@@ -226,6 +229,7 @@ spec:
           httpGet:
             path: /ready
             port: 9998
+          failureThreshold: 7
 
 ### Web ###
 ---
@@ -294,6 +298,7 @@ spec:
           httpGet:
             path: /ready
             port: 9994
+          failureThreshold: 7
 
 ### Prometheus ###
 ---
@@ -547,7 +552,7 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 30
           timeoutSeconds: 30
           failureThreshold: 10
           periodSeconds: 10

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -152,6 +152,15 @@ spec:
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9995
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9995
       - name: destination
         ports:
         - name: grpc
@@ -165,6 +174,15 @@ spec:
         - "-enable-tls={{.EnableTLS}}"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9999
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9999
       - name: proxy-api
         ports:
         - name: grpc
@@ -178,6 +196,15 @@ spec:
         - "-addr=:{{.ProxyAPIPort}}"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9996
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9996
       - name: tap
         ports:
         - name: grpc
@@ -190,6 +217,15 @@ spec:
         - "tap"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9998
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9998
 
 ### Web ###
 ---
@@ -249,6 +285,15 @@ spec:
         - "-uuid={{.UUID}}"
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9994
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9994
 
 ### Prometheus ###
 ---

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -161,9 +161,9 @@ spec:
 				[]string{},
 			)
 
-			err = k8sAPI.Sync()
+			err = k8sAPI.Sync(nil)
 			if err != nil {
-				t.Fatalf("k8sAPI.Sync() returned an error: %s", err)
+				t.Fatalf("k8sAPI.Sync returned an error: %s", err)
 			}
 
 			rsp, err := fakeGrpcServer.ListPods(context.TODO(), &pb.Empty{})

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -161,10 +161,7 @@ spec:
 				[]string{},
 			)
 
-			err = k8sAPI.Sync(nil)
-			if err != nil {
-				t.Fatalf("k8sAPI.Sync returned an error: %s", err)
-			}
+			k8sAPI.Sync(nil)
 
 			rsp, err := fakeGrpcServer.ListPods(context.TODO(), &pb.Empty{})
 			if err != exp.err {

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -69,10 +69,7 @@ func testStatSummary(t *testing.T, expectations []statSumExpected) {
 			[]string{},
 		)
 
-		err = k8sAPI.Sync(nil)
-		if err != nil {
-			t.Fatalf("k8sAPI.Sync returned an error: %s", err)
-		}
+		k8sAPI.Sync(nil)
 
 		rsp, err := fakeGrpcServer.StatSummary(context.TODO(), &exp.req)
 		if err != exp.err {

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -69,9 +69,9 @@ func testStatSummary(t *testing.T, expectations []statSumExpected) {
 			[]string{},
 		)
 
-		err = k8sAPI.Sync()
+		err = k8sAPI.Sync(nil)
 		if err != nil {
-			t.Fatalf("k8sAPI.Sync() returned an error: %s", err)
+			t.Fatalf("k8sAPI.Sync returned an error: %s", err)
 		}
 
 		rsp, err := fakeGrpcServer.StatSummary(context.TODO(), &exp.req)

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -54,12 +54,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	go func() {
-		err := k8sAPI.Sync(ready)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-	}()
+	go k8sAPI.Sync(ready)
 
 	go func() {
 		log.Infof("starting gRPC server on %s", *addr)

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/runconduit/conduit/controller/api/proxy"
 	"github.com/runconduit/conduit/controller/destination"
-	"github.com/runconduit/conduit/pkg/prometheus"
+	"github.com/runconduit/conduit/pkg/admin"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -49,7 +49,7 @@ func main() {
 		server.Serve(lis)
 	}()
 
-	go prometheus.NewMetricsServer(*metricsAddr)
+	go admin.StartServer(*metricsAddr, nil)
 
 	<-stop
 

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -77,12 +77,7 @@ func main() {
 
 	ready := make(chan struct{})
 
-	go func() {
-		err := k8sAPI.Sync(ready)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-	}()
+	go k8sAPI.Sync(ready)
 
 	go func() {
 		log.Infof("starting HTTP server on %+v", *addr)

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/runconduit/conduit/controller/api/public"
 	"github.com/runconduit/conduit/controller/k8s"
 	"github.com/runconduit/conduit/controller/tap"
-	"github.com/runconduit/conduit/pkg/prometheus"
+	"github.com/runconduit/conduit/pkg/admin"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -75,8 +75,10 @@ func main() {
 		strings.Split(*ignoredNamespaces, ","),
 	)
 
+	ready := make(chan struct{})
+
 	go func() {
-		err := k8sAPI.Sync()
+		err := k8sAPI.Sync(ready)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
@@ -87,7 +89,7 @@ func main() {
 		server.ListenAndServe()
 	}()
 
-	go prometheus.NewMetricsServer(*metricsAddr)
+	go admin.StartServer(*metricsAddr, ready)
 
 	<-stop
 

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -54,12 +54,7 @@ func main() {
 
 	ready := make(chan struct{})
 
-	go func() {
-		err := k8sAPI.Sync(ready)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-	}()
+	go k8sAPI.Sync(ready)
 
 	go func() {
 		log.Println("starting gRPC server on", *addr)

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/runconduit/conduit/controller/k8s"
 	"github.com/runconduit/conduit/controller/tap"
-	"github.com/runconduit/conduit/pkg/prometheus"
+	"github.com/runconduit/conduit/pkg/admin"
 	"github.com/runconduit/conduit/pkg/version"
 	log "github.com/sirupsen/logrus"
 )
@@ -52,8 +52,10 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	ready := make(chan struct{})
+
 	go func() {
-		err := k8sAPI.Sync()
+		err := k8sAPI.Sync(ready)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
@@ -64,7 +66,7 @@ func main() {
 		server.Serve(lis)
 	}()
 
-	go prometheus.NewMetricsServer(*metricsAddr)
+	go admin.StartServer(*metricsAddr, ready)
 
 	<-stop
 

--- a/controller/destination/endpoints_watcher_test.go
+++ b/controller/destination/endpoints_watcher_test.go
@@ -111,9 +111,9 @@ spec:
 
 			watcher := newEndpointsWatcher(k8sAPI)
 
-			err = k8sAPI.Sync()
+			err = k8sAPI.Sync(nil)
 			if err != nil {
-				t.Fatalf("k8sAPI.Sync() returned an error: %s", err)
+				t.Fatalf("k8sAPI.Sync returned an error: %s", err)
 			}
 
 			listener, cancelFn := newCollectUpdateListener()

--- a/controller/destination/endpoints_watcher_test.go
+++ b/controller/destination/endpoints_watcher_test.go
@@ -111,10 +111,7 @@ spec:
 
 			watcher := newEndpointsWatcher(k8sAPI)
 
-			err = k8sAPI.Sync(nil)
-			if err != nil {
-				t.Fatalf("k8sAPI.Sync returned an error: %s", err)
-			}
+			k8sAPI.Sync(nil)
 
 			listener, cancelFn := newCollectUpdateListener()
 			defer cancelFn()

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -96,7 +96,7 @@ func NewAPI(k8sClient kubernetes.Interface, resources ...ApiResource) *API {
 // Sync waits for all informers to be synced.
 // For servers, call this asynchronously.
 // For testing, call this synchronously.
-func (api *API) Sync() error {
+func (api *API) Sync(readyCh chan<- struct{}) error {
 	api.sharedInformers.Start(nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -107,6 +107,10 @@ func (api *API) Sync() error {
 		return errors.New("timed out waiting for caches to sync")
 	}
 	log.Infof("caches synced")
+
+	if readyCh != nil {
+		close(readyCh)
+	}
 
 	return nil
 }

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -96,7 +95,7 @@ func NewAPI(k8sClient kubernetes.Interface, resources ...ApiResource) *API {
 // Sync waits for all informers to be synced.
 // For servers, call this asynchronously.
 // For testing, call this synchronously.
-func (api *API) Sync(readyCh chan<- struct{}) error {
+func (api *API) Sync(readyCh chan<- struct{}) {
 	api.sharedInformers.Start(nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -104,15 +103,13 @@ func (api *API) Sync(readyCh chan<- struct{}) error {
 
 	log.Infof("waiting for caches to sync")
 	if !cache.WaitForCacheSync(ctx.Done(), api.syncChecks...) {
-		return errors.New("timed out waiting for caches to sync")
+		log.Fatal("failed to sync caches")
 	}
 	log.Infof("caches synced")
 
 	if readyCh != nil {
 		close(readyCh)
 	}
-
-	return nil
 }
 
 func (api *API) NS() coreinformers.NamespaceInformer {

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -35,10 +35,7 @@ func newAPI(resourceConfigs []string, extraConfigs ...string) (*API, []runtime.O
 		return nil, nil, fmt.Errorf("NewFakeAPI returned an error: %s", err)
 	}
 
-	err = api.Sync(nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("api.Sync returned an error: %s", err)
-	}
+	api.Sync(nil)
 
 	return api, k8sResults, nil
 }

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -35,9 +35,9 @@ func newAPI(resourceConfigs []string, extraConfigs ...string) (*API, []runtime.O
 		return nil, nil, fmt.Errorf("NewFakeAPI returned an error: %s", err)
 	}
 
-	err = api.Sync()
+	err = api.Sync(nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("api.Sync() returned an error: %s", err)
+		return nil, nil, fmt.Errorf("api.Sync returned an error: %s", err)
 	}
 
 	return api, k8sResults, nil

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -620,7 +620,7 @@ func main() {
 		k8s.Deploy,
 		k8s.Pod,
 	)
-	err = k8sAPI.Sync()
+	err = k8sAPI.Sync(nil)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -620,10 +620,7 @@ func main() {
 		k8s.Deploy,
 		k8s.Pod,
 	)
-	err = k8sAPI.Sync(nil)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
+	k8sAPI.Sync(nil)
 
 	proxyCount := endPort - startPort + 1
 	simulatedPods := getDeploymentByPod(k8sAPI, proxyCount)

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -170,10 +170,7 @@ status:
 			go func() { server.Serve(listener) }()
 			defer server.GracefulStop()
 
-			err = k8sAPI.Sync(nil)
-			if err != nil {
-				t.Fatalf("k8sAPI.Sync returned an error: %s", err)
-			}
+			k8sAPI.Sync(nil)
 
 			client, conn, err := NewClient(listener.Addr().String())
 			if err != nil {

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -170,9 +170,9 @@ status:
 			go func() { server.Serve(listener) }()
 			defer server.GracefulStop()
 
-			err = k8sAPI.Sync()
+			err = k8sAPI.Sync(nil)
 			if err != nil {
-				t.Fatalf("k8sAPI.Sync() returned an error: %s", err)
+				t.Fatalf("k8sAPI.Sync returned an error: %s", err)
 			}
 
 			client, conn, err := NewClient(listener.Addr().String())

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -23,12 +23,12 @@ func StartServer(addr string, readyCh <-chan struct{}) {
 		ready:       readyCh == nil,
 	}
 
-	go func() {
-		if readyCh != nil {
+	if readyCh != nil {
+		go func() {
 			<-readyCh
 			h.setReady(true)
-		}
-	}()
+		}()
+	}
 
 	s := &http.Server{
 		Addr:         addr,

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -1,0 +1,78 @@
+package admin
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+)
+
+type handler struct {
+	promHandler http.Handler
+	ready       bool
+	sync.RWMutex
+}
+
+func StartServer(addr string, readyCh <-chan struct{}) {
+	log.Infof("starting admin server on %s", addr)
+
+	h := &handler{
+		promHandler: promhttp.Handler(),
+		ready:       readyCh == nil,
+	}
+
+	go func() {
+		if readyCh != nil {
+			<-readyCh
+			h.setReady(true)
+		}
+	}()
+
+	s := &http.Server{
+		Addr:         addr,
+		Handler:      h,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	log.Fatal(s.ListenAndServe())
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	switch req.URL.Path {
+	case "/metrics":
+		h.promHandler.ServeHTTP(w, req)
+	case "/ping":
+		h.servePing(w, req)
+	case "/ready":
+		h.serveReady(w, req)
+	default:
+		http.NotFound(w, req)
+	}
+}
+
+func (h *handler) servePing(w http.ResponseWriter, req *http.Request) {
+	w.Write([]byte("pong\n"))
+}
+
+func (h *handler) serveReady(w http.ResponseWriter, req *http.Request) {
+	if h.getReady() {
+		w.Write([]byte("ok\n"))
+	} else {
+		http.Error(w, "unready", http.StatusServiceUnavailable)
+	}
+}
+
+func (h *handler) getReady() bool {
+	h.RLock()
+	defer h.RUnlock()
+	return h.ready
+}
+
+func (h *handler) setReady(ready bool) {
+	h.Lock()
+	defer h.Unlock()
+	h.ready = ready
+}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -6,7 +6,6 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 
@@ -71,10 +70,4 @@ func WithTelemetry(handler http.Handler) http.HandlerFunc {
 	return promhttp.InstrumentHandlerDuration(duration,
 		promhttp.InstrumentHandlerResponseSize(responseSize,
 			promhttp.InstrumentHandlerCounter(counter, handler)))
-}
-
-func NewMetricsServer(metricsAddr string) {
-	log.Infof("serving scrapable metrics on %s", metricsAddr)
-	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(metricsAddr, nil)
 }

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -84,8 +84,7 @@ func TestInstall(t *testing.T) {
 	}
 
 	// Tests Pods and Deployments
-	// The Grafana readiness check can take 1+ min; hence the high timeout here
-	err = TestHelper.RetryFor(2*time.Minute, func() error {
+	err = TestHelper.RetryFor(1*time.Minute, func() error {
 		for deploy, replicas := range conduitDeployReplicas {
 			if err := TestHelper.CheckPods(TestHelper.GetConduitNamespace(), deploy, replicas); err != nil {
 				return fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err)

--- a/web/main.go
+++ b/web/main.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"flag"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/runconduit/conduit/controller/api/public"
+	"github.com/runconduit/conduit/pkg/admin"
 	"github.com/runconduit/conduit/pkg/version"
 	"github.com/runconduit/conduit/web/srv"
 	log "github.com/sirupsen/logrus"
@@ -59,11 +58,7 @@ func main() {
 		server.ListenAndServe()
 	}()
 
-	go func() {
-		log.Infof("serving scrapable metrics on %+v", *metricsAddr)
-		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(*metricsAddr, nil)
-	}()
+	go admin.StartServer(*metricsAddr, nil)
 
 	<-stop
 


### PR DESCRIPTION
This branch introduces a new package, `pkg/admin`, which our go processes can use to run an admin server. The admin server has the following three endpoints:

* `/metrics` -- prometheus metrics
* `/ping` -- liveliness check
* `/ready` -- readiness check

The `/ping` endpoint is a no-op at this point, but we might want to make that more sophisticated as part of #1116.

For controller components that sync with Kubernetes, the `/ready` endpoint doesn't return ready until the caches are fully synced.

I've also updated our install configs to configure the checks accordingly.

Fixes #1013.