### PR TITLE
 proxy: Rebind endpoints on TLS client config changes 

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -310,6 +310,12 @@ where
     }
 }
 
+impl<C, B> BindProtocol<C, B> {
+    pub fn ctx(&self) -> &C {
+        &self.bind.ctx
+    }
+}
+
 
 // ===== impl NormalizeUri =====
 

--- a/proxy/src/conditional.rs
+++ b/proxy/src/conditional.rs
@@ -65,4 +65,11 @@ where
             Conditional::None(r) => Conditional::None(*r),
         }
     }
+
+    pub fn is_some(&self) -> bool {
+        match self {
+            Conditional::Some(_) => true,
+            Conditional::None(_) => false,
+        }
+    }
 }

--- a/proxy/src/outbound.rs
+++ b/proxy/src/outbound.rs
@@ -173,8 +173,17 @@ where
         let resolve = {
             let proto = self.bind.clone().with_protocol(protocol.clone());
             match *dest {
-                Destination::Name(ref authority) =>
-                    Discovery::Name(self.discovery.resolve(authority, proto)),
+                Destination::Name(ref authority) => {
+                    let tls_client_cfg = proto.ctx()
+                        .tls_client_config_watch()
+                        .clone();
+                    let resolve = self.discovery.resolve(
+                        authority,
+                        proto,
+                        tls_client_cfg,
+                    );
+                    Discovery::Name(resolve)
+                },
                 Destination::Addr(addr) => Discovery::Addr(Some((addr, proto))),
             }
         };


### PR DESCRIPTION
This branch changes the proxy's service discovery module to watch the TLS
client configuration changes, and rebind the client stacks of any endpoints 
with which it is able to communicate with over TLS (i.e. those with 
`TlsIdentity` metadata) when the client config changes. The rebinding is done
at the level of individual endpoints in the load balancer, rather than for the
entire service stack for the destination.

The way this is implemented is as follows: A new variant, 
`Update::RebindIfTls`, was added to the `Update` enum. The `update_rx` in
`Resolution`, which was previously just a `mpsc::UnboundedReceiver` that 
receives updates from the destination service client, is now a stream that
`select`s over the `UnboundedReceiver` and the stream of changes to the 
client config watch. 

When the client config changes, the `Resolution` sees an `Update::RebindIfTls`
event, causing it to enter into a state where it will provide the load balancer
with `Change::Insert` events for all previously bound endpoints with 
`TlsIdentity` metadata before polling `update_rx` again. The load balancer will
rebind the endpoints when it recieves duplicate `Change::Insert`s. 

In order to know which previously inserted endpoints will need to be rebound,
`Resolution` now has to track some additional state between polls, so I've 
added a new `RebindState` struct to encapsulate that. 

While I was somewhat disappointed that these changes made the already rather
complicated service discovery code more complex, this seemed like the only
possible way to get this behaviour at the level of individual endpoints in the
LB rather than the level of entire service stacks. Since adding this behaviour
at that level allows us to gracefully finish any in-progress connections to the
old endpoints, and means we don't have to rebind non-TLS endpoints, I felt like
this was worth it, and I tried to add as little additional complexity to the
discovery module as possible.

I'm working on writing tests for these changes as well. However, my current test
implementation depends on the code added in PR #1155, which hasn't merged yet, so
I decided to write the tests in a separate branch to prevent #1155 from blocking
this code. I'll open a separate PR for the tests when they're finished.

Closes #1161

Signed-off-by: Eliza Weisman <eliza@buoyant.io>