### PR TITLE
proxy: Fall back to plaintext communication when a TLS handshake fails

### DIFF
--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -290,9 +290,6 @@ impl Future for Connecting {
                                     -> falling back to plaintext",
                                 self.addr, e,
                             );
-                            // XXX: We can't get the old connection back
-                            // from the failed upgrade future, so we have
-                            // to try reconnecting.
                             let connect = TcpStream::connect(&self.addr);
                             // TODO: emit a `HandshakeFailed` telemetry event.
                             let reason = tls::ReasonForNoTls::HandshakeFailed;

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -79,7 +79,7 @@ pub struct Connection {
     peek_buf: BytesMut,
 
     /// Whether or not the connection is secured with TLS.
-    tls_status: TlsStatus,
+    pub tls_status: TlsStatus,
 }
 
 /// A trait describing that a type can peek bytes.

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -264,8 +264,8 @@ impl Future for Connecting {
         loop {
             self.state = match &mut self.state {
                 ConnectingState::Plaintext { connect, tls } => {
-                    trace!("Connecting: state=plaintext; tls={:?};",tls);
                     let plaintext_stream = try_ready!(connect.poll());
+                    trace!("Connecting: state=plaintext; tls={:?};",tls);
                     set_nodelay_or_warn(&plaintext_stream);
                     match tls.take().expect("Polled after ready") {
                         Conditional::Some(config) => {
@@ -288,7 +288,7 @@ impl Future for Connecting {
                             return Ok(Async::Ready(conn));
                         },
                         Err(e) => {
-                            warn!(
+                            debug!(
                                 "TLS handshake with {:?} failed: {}\
                                     -> falling back to plaintext",
                                 self.addr, e,

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -381,6 +381,8 @@ impl fmt::Display for ctx::transport::TlsStatus {
         match *self {
             Conditional::Some(()) => f.pad(",tls=\"true\""),
             Conditional::None(tls::ReasonForNoTls::NoConfig) => f.pad(",tls=\"no_config\""),
+            Conditional::None(tls::ReasonForNoTls::HandshakeFailed) =>
+                f.pad("tls=\"handshake_failed\""),
             Conditional::None(tls::ReasonForNoTls::Disabled) |
             Conditional::None(tls::ReasonForNoTls::InternalTraffic) |
             Conditional::None(tls::ReasonForNoTls::NoIdentity(_)) |

--- a/proxy/src/telemetry/sensor/mod.rs
+++ b/proxy/src/telemetry/sensor/mod.rs
@@ -69,7 +69,7 @@ impl Sensors {
 
     pub fn connect<C>(&self, connect: C, ctx: &Arc<ctx::transport::Client>) -> Connect<C>
     where
-        C: tokio_connect::Connect,
+        C: tokio_connect::Connect<Connected = ::connection::Connection>,
     {
         Connect::new(connect, &self.0, ctx)
     }

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -105,8 +105,6 @@ pub enum ReasonForNoTls {
     NotProxyTls,
 
     /// We fell back to plaintext because the TLS handshake failed.
-    // TODO: Perhaps this should store some more detailed information on
-    // why the handshake failed...
     HandshakeFailed,
 }
 

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -103,6 +103,11 @@ pub enum ReasonForNoTls {
     /// The connection isn't TLS or it is TLS but not intended to be handled
     /// by the proxy.
     NotProxyTls,
+
+    /// We fell back to plaintext because the TLS handshake failed.
+    // TODO: Perhaps this should store some more detailed information on
+    // why the handshake failed...
+    HandshakeFailed,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/proxy/src/transport/tls/mod.rs
+++ b/proxy/src/transport/tls/mod.rs
@@ -33,4 +33,5 @@ pub use self::{
     },
     dns_name::{DnsName, InvalidDnsName},
     identity::Identity,
+    rustls::TLSError as Error,
 };


### PR DESCRIPTION
This branch modifies the proxy's logic for opening a connection so
that when an attempted TLS handshake fails, the proxy will retry that
connection without TLS.

This is implemented by changing the `UpgradeToTls` case in the `Future`
implementation for `Connecting`, so that rather than simply wrapping
a poll to the TLS upgrade future with `try_ready!` (and thus failing
the future if the upgrade future fails), we reset the state of the
future to the `Plaintext` state and continue looping. The `tls_status`
field of the future is changed to `ReasonForNoTls::HandshakeFailed`,
and the `Plaintext` state is changed so that if its `tls_status` is
`HandshakeFailed`, it will no longer attempt to upgrade to TLS when the
laintext connection is successfully established. This also ensures that
any subsequent telemetry events generated by that connection are labeled
with `tls="handshake_failed"`.

Closes #1084 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>