### PR TITLE
WIP: proxy: Use TLS client config version to determine when to rebind endpoints

### DIFF
--- a/proxy/src/conditional.rs
+++ b/proxy/src/conditional.rs
@@ -77,4 +77,11 @@ where
         }
     }
 
+    pub fn is_some(&self) -> bool {
+        match self {
+            Conditional::Some(_) => true,
+            Conditional::None(_) => false,
+        }
+    }
+
 }

--- a/proxy/src/conditional.rs
+++ b/proxy/src/conditional.rs
@@ -65,4 +65,16 @@ where
             Conditional::None(r) => Conditional::None(*r),
         }
     }
+
+    pub fn map<D, F>(self, f: F) -> Conditional<D, R>
+    where
+        F: FnOnce(C) -> D,
+        D: Clone + std::fmt::Debug,
+    {
+        match self {
+            Conditional::Some(c) => Conditional::Some(f(c)),
+            Conditional::None(r) => Conditional::None(r),
+        }
+    }
+
 }

--- a/proxy/src/control/destination/mod.rs
+++ b/proxy/src/control/destination/mod.rs
@@ -96,9 +96,14 @@ pub struct Metadata {
     dst_labels: Option<DstLabels>,
 
     /// How to verify TLS for the endpoint.
-    tls_identity: Conditional<tls::Identity, tls::ReasonForNoIdentity>,
+    tls: Conditional<TlsMetadata, tls::ReasonForNoIdentity>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TlsMetadata {
+    identity: tls::Identity,
+    client_cfg_version: usize,
+}
 
 #[derive(Debug, Clone)]
 enum Update {
@@ -145,6 +150,7 @@ pub fn new(
     namespaces: Namespaces,
     host_and_port: Option<HostAndPort>,
     controller_tls: tls::ConditionalConnectionConfig<tls::ClientConfigWatch>,
+    client_tls: tls::ClientConfigWatch,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };
@@ -154,6 +160,7 @@ pub fn new(
         namespaces,
         host_and_port,
         controller_tls,
+        client_tls,
     );
     (disco, bg)
 }
@@ -243,18 +250,24 @@ impl Metadata {
         Metadata {
             dst_labels: None,
             // If we have no metadata on an endpoint, assume it does not support TLS.
-            tls_identity:
+            tls:
                 Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery),
         }
     }
 
     pub fn new(
         dst_labels: Option<DstLabels>,
-        tls_identity: Conditional<tls::Identity, tls::ReasonForNoIdentity>
+        tls_identity: Conditional<tls::Identity, tls::ReasonForNoIdentity>,
+        tls_config_version: usize,
     ) -> Self {
+        let tls = tls_identity
+            .map(|identity| TlsMetadata {
+                identity,
+                client_cfg_version: tls_config_version,
+            });
         Metadata {
             dst_labels,
-            tls_identity,
+            tls
         }
     }
 
@@ -264,6 +277,17 @@ impl Metadata {
     }
 
     pub fn tls_identity(&self) -> Conditional<&tls::Identity, tls::ReasonForNoIdentity> {
-        self.tls_identity.as_ref()
+        self.tls.as_ref().map(|tls| &tls.identity)
+    }
+
+    pub fn with_tls_config_version(self, client_cfg_version: usize) -> Self {
+        Self {
+            dst_labels: self.dst_labels,
+            tls: self.tls
+                .map(|old| TlsMetadata {
+                    identity: old.identity,
+                    client_cfg_version,
+                })
+        }
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -240,6 +240,7 @@ where
             config.namespaces.clone(),
             control_host_and_port,
             controller_tls,
+            tls_client_config.clone(),
         );
 
         let (drain_tx, drain_rx) = drain::channel();


### PR DESCRIPTION
Here's my rough branch on this approach to config reloading. I'm unsure if this is better or worse than #1169; it's possible I'm overlooking some way of implementing this that's less messy...