### PR TITLE
proxy: Implement a WatchService

### DIFF
--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -89,8 +89,10 @@ mod transparency;
 mod transport;
 pub mod timeout;
 mod tower_fn; // TODO: move to tower-fn
+mod watch_service; // TODO: move to tower
 
 use bind::Bind;
+use conditional::Conditional;
 use connection::BoundPort;
 use inbound::Inbound;
 use map_err::MapErr;
@@ -98,7 +100,7 @@ use task::MainRuntime;
 use transparency::{HttpBody, Server};
 pub use transport::{AddrInfo, GetOriginalDst, SoOriginalDst, tls};
 use outbound::Outbound;
-use conditional::Conditional;
+pub use watch_service::WatchService;
 
 /// Runs a sidecar proxy.
 ///

--- a/proxy/src/watch_service.rs
+++ b/proxy/src/watch_service.rs
@@ -1,0 +1,51 @@
+use futures::{Async, Poll, Stream};
+use futures_watch::Watch;
+use tower_service::Service;
+
+pub trait Rebind<T> {
+    type Service: Service;
+    fn rebind(&mut self, t: &T) -> Self::Service;
+}
+
+/// A Service that updates itself as a Watch updates.
+#[derive(Debug)]
+pub struct WatchService<T, R: Rebind<T>> {
+    watch: Watch<T>,
+    rebind: R,
+    inner: R::Service,
+}
+
+impl<T, R: Rebind<T>> WatchService<T, R> {
+    pub fn new(watch: Watch<T>, mut rebind: R) -> WatchService<T, R> {
+        let inner = rebind.rebind(&*watch.borrow());
+        WatchService { watch, rebind, inner }
+    }
+}
+
+impl<T, R: Rebind<T>> Service for WatchService<T, R> {
+    type Request = <R::Service as Service>::Request;
+    type Response = <R::Service as Service>::Response;
+    type Error = <R::Service as Service>::Error;
+    type Future = <R::Service as Service>::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        // Check to see if the watch has been updated and, if so, rebind the service.
+        if let Async::Ready(Some(())) = self.watch.poll().expect("watch poll") {
+            self.inner = self.rebind.rebind(&*self.watch.borrow());
+        }
+
+        Ok(Async::Ready(()))
+    }
+
+    fn call(&mut self, req: Self::Request) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+impl<T, S> Rebind<T> for FnMut(&T) -> S where S: Service
+{
+    type Service = S;
+    fn rebind(&mut self, t: &T) -> S {
+        (self)(t)
+    }
+}

--- a/proxy/src/watch_service.rs
+++ b/proxy/src/watch_service.rs
@@ -34,7 +34,7 @@ impl<T, R: Rebind<T>> Service for WatchService<T, R> {
             self.inner = self.rebind.rebind(&*self.watch.borrow());
         }
 
-        Ok(Async::Ready(()))
+        self.inner.poll_ready()
     }
 
     fn call(&mut self, req: Self::Request) -> Self::Future {

--- a/proxy/src/watch_service.rs
+++ b/proxy/src/watch_service.rs
@@ -30,7 +30,9 @@ impl<T, R: Rebind<T>> Service for WatchService<T, R> {
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         // Check to see if the watch has been updated and, if so, rebind the service.
-        if let Async::Ready(Some(())) = self.watch.poll().expect("watch poll") {
+        //
+        // `watch.poll()` can't actually fail; so errors are not considered.
+        if let Ok(Async::Ready(Some(()))) = self.watch.poll() {
             self.inner = self.rebind.rebind(&*self.watch.borrow());
         }
 


### PR DESCRIPTION
This introduces a generic middleware, WatchService, which can be used
to rebind an inner service when a configuration object changes.

This needs tests, etc, but I'm sharing this to unblock TLS work.