### PR TITLE
Add probes and log termination policy for distributor

### DIFF
--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -921,7 +921,20 @@ spec:
         - -logtostderr=true
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9997
+          initialDelaySeconds: 10
         name: ca-distributor
+        ports:
+        - containerPort: 9997
+          name: admin-http
+        readinessProbe:
+          failureThreshold: 7
+          httpGet:
+            path: /ready
+            port: 9997
         resources: {}
       - env:
         - name: CONDUIT_PROXY_LOG
@@ -953,6 +966,7 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -972,6 +986,7 @@ spec:
             add:
             - NET_ADMIN
           privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
       serviceAccount: conduit-ca
 status: {}
 ---

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -677,6 +677,9 @@ spec:
       serviceAccount: conduit-ca
       containers:
       - name: ca-distributor
+        ports:
+        - name: admin-http
+          containerPort: 9997
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
@@ -684,4 +687,14 @@ spec:
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"
         - "-logtostderr=true"
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9997
+          initialDelaySeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9997
+          failureThreshold: 7
 `

--- a/controller/ca/controller_test.go
+++ b/controller/ca/controller_test.go
@@ -173,9 +173,7 @@ func new(fixtures ...string) (*CertificateController, chan bool, chan struct{}, 
 		return err
 	}
 
-	if err := controller.k8sAPI.Sync(); err != nil {
-		return nil, nil, nil, fmt.Errorf("k8sAPI.Sync() returned an error: %s", err)
-	}
+	controller.k8sAPI.Sync(nil)
 
 	stopCh := make(chan struct{})
 	go controller.Run(stopCh)


### PR DESCRIPTION
I should have rebase #675 before merging it to master, to pick up the changes from #1117 and #1168. This branch fixes the compilation errors and tests that broke as a result, and it adds liveliness and readiness probes for the new ca-distributor control plane component.