### PR TITLE
doc update to remove extra configurations for websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ control plane written in Go, and a native proxy data plane written in
 [Rust][rust] that boasts the performance of C without the heartbleed.
 
 Conduit is **alpha**. It is capable of proxying all TCP traffic, including
-websockets, and reporting top-line metrics (success rates, latencies, etc) for
-all HTTP, HTTP/2, and gRPC traffic.
-It currently does not work with HTTP tunneling -- see the `--skip-outbound-ports`
-flag for how to exclude that traffic.
+websockets and HTTP tunneling, and reporting top-line metrics (success rates,
+latencies, etc) for all HTTP, HTTP/2, and gRPC traffic.
 
 ## Get involved
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Conduit is an ultralight service mesh for Kubernetes. It features a minimalist
 control plane written in Go, and a native proxy data plane written in
 [Rust][rust] that boasts the performance of C without the heartbleed.
 
-Conduit is **alpha**. It is capable of proxying all TCP traffic, and reporting
-top-line metrics (success rates, latencies, etc) for all HTTP, HTTP/2, and gRPC traffic.
-It currently does not work with websockets or with HTTP tunneling--see the
-`--skip-outbound-ports` flag for how to exclude these types of traffic.
+Conduit is **alpha**. It is capable of proxying all TCP traffic, including
+websockets, and reporting top-line metrics (success rates, latencies, etc) for
+all HTTP, HTTP/2, and gRPC traffic.
+
+It currently does not work with HTTP tunneling -- see the `--skip-outbound-ports`
+flag for how to exclude that traffic.
 
 ## Get involved
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ control plane written in Go, and a native proxy data plane written in
 Conduit is **alpha**. It is capable of proxying all TCP traffic, including
 websockets, and reporting top-line metrics (success rates, latencies, etc) for
 all HTTP, HTTP/2, and gRPC traffic.
-
 It currently does not work with HTTP tunneling -- see the `--skip-outbound-ports`
 flag for how to exclude that traffic.
 

--- a/doc/adding-your-service.md
+++ b/doc/adding-your-service.md
@@ -43,18 +43,15 @@ part. To accomplish this, Conduit automatically detects the protocol used on
 each connection. In some cases, however, Conduit's protocol detection can't be
 fully automated and requires some configuration from you.
 
-### HTTP Tunneling and WebSockets
+### HTTP Tunneling
 
 Most HTTP traffic (including HTTP/2) will be handled automatically and
 transparently by Conduit without any configuration on your part. However,
-non-HTTPS WebSockets and HTTP tunneling/proxying (use of the HTTP `CONNECT`
-method) currently require manual configuration to disable the layer 7 features
-for those connections. For pods that accept incoming `CONNECT` requests and/or
-incoming WebSocket connections, use the `--skip-inbound-ports` flag when running
-`conduit inject`. For pods that make outgoing `CONNECT` requests and/or outgoing
-WebSocket connections, use the `--skip-outbound-ports` flag when running
-`conduit inject`. (Automatic transparent proxying of WebSockets will be
-implemented in a [future release](https://github.com/runconduit/conduit/issues/195).)
+HTTP tunneling/proxying (use of the HTTP `CONNECT` method) currently requires
+manual configuration to disable the layer 7 features. For pods that accept
+incoming `CONNECT` requests, use the `--skip-inbound-ports` flag when running
+`conduit inject`. For pods that make outgoing `CONNECT` requests, use the
+`--skip-outbound-ports` flag when running `conduit inject`.
 
 ### For example, to allow inbound traffic on ports 80 and 7777 to bypass the proxy, use the command:
 #### `conduit inject deployment.yml --skip-inbound-ports=80,7777 | kubectl apply -f -`

--- a/doc/adding-your-service.md
+++ b/doc/adding-your-service.md
@@ -43,19 +43,6 @@ part. To accomplish this, Conduit automatically detects the protocol used on
 each connection. In some cases, however, Conduit's protocol detection can't be
 fully automated and requires some configuration from you.
 
-### HTTP Tunneling
-
-Most HTTP traffic (including HTTP/2) will be handled automatically and
-transparently by Conduit without any configuration on your part. However,
-HTTP tunneling/proxying (use of the HTTP `CONNECT` method) currently requires
-manual configuration to disable the layer 7 features. For pods that accept
-incoming `CONNECT` requests, use the `--skip-inbound-ports` flag when running
-`conduit inject`. For pods that make outgoing `CONNECT` requests, use the
-`--skip-outbound-ports` flag when running `conduit inject`.
-
-### For example, to allow inbound traffic on ports 80 and 7777 to bypass the proxy, use the command:
-#### `conduit inject deployment.yml --skip-inbound-ports=80,7777 | kubectl apply -f -`
-
 ### MySQL and SMTP
 
 Most non-HTTP traffic will also be handled automatically and transparently by


### PR DESCRIPTION
- remove instructions from readme and docs to set extra configs for websockets.

- #1126 introduces automatic http upgrades and hence we do not need to set `--skip-inbound-ports` or `--skip-outbound-ports` when using conduit with websockets. 

Signed-off-by: Franziska von der Goltz <franziska@vdgoltz.eu>