### PR TITLE
Switch to multi-value --tls flag, add to inject command

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/runconduit/conduit/pkg/k8s"
@@ -64,8 +63,8 @@ with 'conduit inject'. e.g. curl http://url.to/yml | conduit inject -
 				return fmt.Errorf("please specify a kubernetes resource file")
 			}
 
-			if _, err := time.ParseDuration(options.proxyBindTimeout); err != nil {
-				return fmt.Errorf("Invalid duration '%s' for --proxy-bind-timeout flag", options.proxyBindTimeout)
+			if err := options.validate(); err != nil {
+				return err
 			}
 
 			var in io.Reader


### PR DESCRIPTION
The install command was previously configured with a binary `--enable-tls` flag in #1055. In conversation with @briansmith we realized that we needed the TLS flag to support multiple different modes, and to be available to the inject command as well.

In this branch I'm removing the `--enable-tls` flag in favor of a `--tls` flag that's available to both install and inject. To enable TLS, set `--tls=optional`. As part of this change I've also standardized validation of proxy flags, which differed between inject and install.