### PR TITLE
Revert usage of parallel in docker-build

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -9,24 +9,11 @@ fi
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-containers=$(cat <<-END
-controller
-web
-proxy-init
-grafana
-proxy
-END
-)
-
+$bindir/docker-build-controller
+$bindir/docker-build-web
+$bindir/docker-build-proxy-init
 if [ -z "${CONDUIT_SKIP_CLI_CONTAINER:-}" ]; then
-  containers=$(printf "$containers\ncli-bin")
+    $bindir/docker-build-cli-bin
 fi
-
-if which parallel >/dev/null; then
-  cmd="parallel $bindir/docker-build-{}"
-else
-  printf "Install parallel to speed the build up (brew install parallel)\n" >&2
-  cmd="xargs -I{} /bin/sh -c $bindir/docker-build-{}"
-fi
-
-echo "$containers" | $cmd
+$bindir/docker-build-grafana
+$bindir/docker-build-proxy


### PR DESCRIPTION
PR #978 introduced usage of parallel in docker-build. Unfortunately this
breaks if the system has non-GNU parallel.

Remove usage of parallel until we can do at least one of the following:
- detect version of parallel installed
- make usage of parallel optional and off by default
- confirm this speeds up builds for a majority of use cases

Signed-off-by: Andrew Seigner <siggy@buoyant.io>