### PR TITLE
Proxy: use `Conditional` inside TLS configuration watches.

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -226,7 +226,12 @@ where
     ///
     /// When the TLS client configuration is invalidated, this function will
     /// be called again to bind a new stack.
-    fn bind_inner_stack(&self, ep: &Endpoint, protocol: &Protocol)-> StackInner<B> {
+    fn bind_inner_stack(
+        &self,
+        ep: &Endpoint,
+        protocol: &Protocol,
+        tls_client_config: &Option<tls::ClientConfig>,
+    )-> StackInner<B> {
         debug!("bind_inner_stack endpoint={:?}, protocol={:?}", ep, protocol);
         let addr = ep.address();
 
@@ -235,7 +240,7 @@ where
             Conditional::Some(identity) => {
                 // TODO: the watch should be an explicit field of `Bind`, rather
                 // than passed in the context.
-                match *self.ctx.tls_client_config_watch().borrow() {
+                match tls_client_config.as_ref() {
                     Some(ref config) =>
                         Conditional::Some(tls::ConnectionConfig {
                             identity: identity.clone(),
@@ -584,13 +589,11 @@ where
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Service = StackInner<B>;
-    fn rebind(&mut self, _cfg: &Option<tls::ClientConfig>) -> Self::Service {
+    fn rebind(&mut self, cfg: &Option<tls::ClientConfig>) -> Self::Service {
         debug!(
             "rebinding endpoint stack for {:?}:{:?} on TLS config change",
             self.endpoint, self.protocol,
         );
-        // We don't actually pass in the config, as `self.bind` also already
-        // owns a config watch of its own.
-        self.bind.bind_inner_stack(&self.endpoint, &self.protocol)
+        self.bind.bind_inner_stack(&self.endpoint, &self.protocol, cfg)
     }
 }

--- a/proxy/src/conditional.rs
+++ b/proxy/src/conditional.rs
@@ -22,7 +22,7 @@ where
 impl<C, R> std::fmt::Debug for Conditional<C, R>
 where
     C: Clone + std::fmt::Debug,
-    R: Clone + std::fmt::Debug
+    R: Clone + std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
@@ -72,10 +72,33 @@ where
     C: Clone,
     R: Copy + Clone,
 {
+    pub fn and_then<CR, RR, F>(self, f: F) -> Conditional<CR, RR>
+    where
+        CR: Clone,
+        R: Into<RR>,
+        RR: Clone,
+        F: FnOnce(C) -> Conditional<CR, RR>,
+    {
+        match self {
+            Conditional::Some(c) => f(c),
+            Conditional::None(r) => Conditional::None(r.into()),
+        }
+    }
+
     pub fn as_ref<'a>(&'a self) -> Conditional<&'a C, R> {
         match self {
             Conditional::Some(c) => Conditional::Some(&c),
             Conditional::None(r) => Conditional::None(*r),
         }
+    }
+
+    pub fn map<CR, RR, F>(self, f: F) -> Conditional<CR, RR>
+    where
+        CR: Clone,
+        R: Into<RR>,
+        RR: Clone,
+        F: FnOnce(C) -> CR,
+    {
+        self.and_then(|c| Conditional::Some(f(c)))
     }
 }

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -42,10 +42,7 @@ impl TlsStatus {
     pub fn from<C>(c: &Conditional<C, tls::ReasonForNoTls>) -> Self
     where C: Clone + std::fmt::Debug
     {
-        match c {
-            Conditional::Some(_) => Conditional::Some(()),
-            Conditional::None(r) => Conditional::None(*r),
-        }
+        c.map(|_| ())
     }
 }
 

--- a/proxy/src/ctx/transport.rs
+++ b/proxy/src/ctx/transport.rs
@@ -42,7 +42,7 @@ impl TlsStatus {
     pub fn from<C>(c: &Conditional<C, tls::ReasonForNoTls>) -> Self
     where C: Clone + std::fmt::Debug
     {
-        c.map(|_| ())
+        c.as_ref().map(|_| ())
     }
 }
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -264,13 +264,12 @@ where
                 config.inbound_router_capacity,
                 config.inbound_router_max_idle_age,
             );
-            let tls_settings = match &config.tls_settings {
-                Conditional::Some(settings) => Conditional::Some(tls::ConnectionConfig {
+            let tls_settings = config.tls_settings.as_ref().map(|settings| {
+                tls::ConnectionConfig {
                     identity: settings.service_identity.clone(),
                     config: tls_server_config
-                }),
-                Conditional::None(r) => Conditional::None(*r),
-            };
+                }
+            });
             serve(
                 inbound_listener,
                 tls_settings,


### PR DESCRIPTION
Simplify the code and make it easier to report finer-grained
reasoning about what part(s) of the TLS configuration are
missing.

Signed-off-by: Brian Smith <brian@briansmith.org>