### PR TITLE
Add --registry flag support for inject command

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -150,7 +150,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec, controlPlaneDNSNameOverride st
 
 	initContainer := v1.Container{
 		Name:                     "conduit-init",
-		Image:                    fmt.Sprintf("%s:%s", options.initImage, options.conduitVersion),
+		Image:                    options.taggedProxyInitImage(),
 		ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		Args: initArgs,
@@ -168,7 +168,7 @@ func injectPodTemplateSpec(t *v1.PodTemplateSpec, controlPlaneDNSNameOverride st
 
 	sidecar := v1.Container{
 		Name:                     "conduit-proxy",
-		Image:                    fmt.Sprintf("%s:%s", options.proxyImage, options.conduitVersion),
+		Image:                    options.taggedProxyImage(),
 		ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &v1.SecurityContext{

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"text/template"
 
 	"github.com/runconduit/conduit/cli/install"
@@ -36,7 +35,6 @@ type installConfig struct {
 }
 
 type installOptions struct {
-	dockerRegistry     string
 	controllerReplicas uint
 	webReplicas        uint
 	prometheusReplicas uint
@@ -46,7 +44,6 @@ type installOptions struct {
 
 func newInstallOptions() *installOptions {
 	return &installOptions{
-		dockerRegistry:     "gcr.io/runconduit",
 		controllerReplicas: 1,
 		webReplicas:        1,
 		prometheusReplicas: 1,
@@ -72,7 +69,6 @@ func newCmdInstall() *cobra.Command {
 	}
 
 	addProxyConfigFlags(cmd, options.proxyConfigOptions)
-	cmd.PersistentFlags().StringVar(&options.dockerRegistry, "registry", options.dockerRegistry, "Docker registry to pull images from")
 	cmd.PersistentFlags().UintVar(&options.controllerReplicas, "controller-replicas", options.controllerReplicas, "Replicas of the controller to deploy")
 	cmd.PersistentFlags().UintVar(&options.webReplicas, "web-replicas", options.webReplicas, "Replicas of the web server to deploy")
 	cmd.PersistentFlags().UintVar(&options.prometheusReplicas, "prometheus-replicas", options.prometheusReplicas, "Replicas of prometheus to deploy")
@@ -131,18 +127,7 @@ func render(config installConfig, w io.Writer, options *installOptions) error {
 	return InjectYAML(buf, w, injectOptions)
 }
 
-var alphaNumDash = regexp.MustCompile("^[a-zA-Z0-9-]+$")
-var alphaNumDashDotSlash = regexp.MustCompile("^[\\./a-zA-Z0-9-]+$")
-
 func validate(options *installOptions) error {
-	// These regexs are not as strict as they could be, but are a quick and dirty
-	// sanity check against illegal characters.
-	if !alphaNumDash.MatchString(controlPlaneNamespace) {
-		return fmt.Errorf("%s is not a valid namespace", controlPlaneNamespace)
-	}
-	if !alphaNumDashDotSlash.MatchString(options.dockerRegistry) {
-		return fmt.Errorf("%s is not a valid Docker registry", options.dockerRegistry)
-	}
 	if _, err := log.ParseLevel(options.controllerLogLevel); err != nil {
 		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug")
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/runconduit/conduit/controller/api/public"
@@ -18,17 +19,31 @@ var apiAddr string // An empty value means "use the Kubernetes configuration"
 var kubeconfigPath string
 var verbose bool
 
+var (
+	// These regexs are not as strict as they could be, but are a quick and dirty
+	// sanity check against illegal characters.
+	alphaNumDash         = regexp.MustCompile("^[a-zA-Z0-9-]+$")
+	alphaNumDashDot      = regexp.MustCompile("^[\\.a-zA-Z0-9-]+$")
+	alphaNumDashDotSlash = regexp.MustCompile("^[\\./a-zA-Z0-9-]+$")
+)
+
 var RootCmd = &cobra.Command{
 	Use:   "conduit",
 	Short: "conduit manages the Conduit service mesh",
 	Long:  `conduit manages the Conduit service mesh.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// enable / disable logging
 		if verbose {
 			log.SetLevel(log.DebugLevel)
 		} else {
 			log.SetLevel(log.PanicLevel)
 		}
+
+		if !alphaNumDash.MatchString(controlPlaneNamespace) {
+			return fmt.Errorf("%s is not a valid namespace", controlPlaneNamespace)
+		}
+
+		return nil
 	},
 }
 
@@ -64,6 +79,7 @@ type proxyConfigOptions struct {
 	conduitVersion   string
 	proxyImage       string
 	initImage        string
+	dockerRegistry   string
 	imagePullPolicy  string
 	proxyUID         int64
 	proxyLogLevel    string
@@ -74,11 +90,17 @@ type proxyConfigOptions struct {
 	tls              string
 }
 
+const (
+	optionalTLS           = "optional"
+	defaultDockerRegistry = "gcr.io/runconduit"
+)
+
 func newProxyConfigOptions() *proxyConfigOptions {
 	return &proxyConfigOptions{
 		conduitVersion:   version.Version,
-		proxyImage:       "gcr.io/runconduit/proxy",
-		initImage:        "gcr.io/runconduit/proxy-init",
+		proxyImage:       defaultDockerRegistry + "/proxy",
+		initImage:        defaultDockerRegistry + "/proxy-init",
+		dockerRegistry:   defaultDockerRegistry,
 		imagePullPolicy:  "IfNotPresent",
 		proxyUID:         2102,
 		proxyLogLevel:    "warn,conduit_proxy=info",
@@ -90,13 +112,12 @@ func newProxyConfigOptions() *proxyConfigOptions {
 	}
 }
 
-const optionalTLS = "optional"
-
-var alphaNumDashDot = regexp.MustCompile("^[\\.a-zA-Z0-9-]+$")
-
 func (options *proxyConfigOptions) validate() error {
 	if !alphaNumDashDot.MatchString(options.conduitVersion) {
 		return fmt.Errorf("%s is not a valid version", options.conduitVersion)
+	}
+	if !alphaNumDashDotSlash.MatchString(options.dockerRegistry) {
+		return fmt.Errorf("%s is not a valid Docker registry", options.dockerRegistry)
 	}
 	if options.imagePullPolicy != "Always" && options.imagePullPolicy != "IfNotPresent" && options.imagePullPolicy != "Never" {
 		return fmt.Errorf("--image-pull-policy must be one of: Always, IfNotPresent, Never")
@@ -114,10 +135,21 @@ func (options *proxyConfigOptions) enableTLS() bool {
 	return options.tls == optionalTLS
 }
 
+func (options *proxyConfigOptions) taggedProxyImage() string {
+	image := strings.Replace(options.proxyImage, defaultDockerRegistry, options.dockerRegistry, 1)
+	return fmt.Sprintf("%s:%s", image, options.conduitVersion)
+}
+
+func (options *proxyConfigOptions) taggedProxyInitImage() string {
+	image := strings.Replace(options.initImage, defaultDockerRegistry, options.dockerRegistry, 1)
+	return fmt.Sprintf("%s:%s", image, options.conduitVersion)
+}
+
 func addProxyConfigFlags(cmd *cobra.Command, options *proxyConfigOptions) {
 	cmd.PersistentFlags().StringVarP(&options.conduitVersion, "conduit-version", "v", options.conduitVersion, "Tag to be used for Conduit images")
 	cmd.PersistentFlags().StringVar(&options.initImage, "init-image", options.initImage, "Conduit init container image name")
 	cmd.PersistentFlags().StringVar(&options.proxyImage, "proxy-image", options.proxyImage, "Conduit proxy container image name")
+	cmd.PersistentFlags().StringVar(&options.dockerRegistry, "registry", options.dockerRegistry, "Docker registry to pull images from")
 	cmd.PersistentFlags().StringVar(&options.imagePullPolicy, "image-pull-policy", options.imagePullPolicy, "Docker image pull policy")
 	cmd.PersistentFlags().Int64Var(&options.proxyUID, "proxy-uid", options.proxyUID, "Run the proxy under this user ID")
 	cmd.PersistentFlags().StringVar(&options.proxyLogLevel, "proxy-log-level", options.proxyLogLevel, "Log level for the proxy")


### PR DESCRIPTION
Previously the `--registry` flag was only supported for overriding the control plane used by the install command, but not the data plane images used by both install and inject. This branch moves the `--registry` flag to proxy config options so that it's available to both, and honors the registry flag for the data plane images. I've also done some more flag validation cleanup as part of this branch.

Fixes #1100.