### PR TITLE
Re-add sidebar links to individual resource pages 

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -8,13 +8,21 @@
   background-repeat: no-repeat;
   background-size: 100% 50vh;
 
+  & .ant-menu-submenu {
+    & .ant-menu-submenu-title, & .anticon{
+      /* override ant transition animation */
+      transition: none;
+    }
+  }
+
   & .sidebar-menu {
     background: none;
   }
 
-  & .sidebar-menu-item {
+  & .sidebar-menu-item, & .sidebar-title {
     font-size: 16px;
     font-weight: var(--font-weight-bold);
+    color: white;
 
     & a {
       color: white;

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -180,24 +180,15 @@ class Sidebar extends React.Component {
                 : null
             }
 
-            <Menu.Item className="sidebar-menu-item" key="/authorities">
-              <ConduitLink to="/authorities">
-                <Icon type="cloud-o" />
-                <span>Authorities</span>
-              </ConduitLink>
-            </Menu.Item>
+            <Menu.SubMenu
+              className="sidebar-menu-item"
+              key="byresource"
+              title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "Resources"}</span>}>
+              <Menu.Item><ConduitLink to="/deployments">Deployments</ConduitLink></Menu.Item>
+              <Menu.Item><ConduitLink to="/replicationcontrollers">Replication Controllers</ConduitLink></Menu.Item>
+              <Menu.Item><ConduitLink to="/pods">Pods</ConduitLink></Menu.Item>
+            </Menu.SubMenu>
 
-            {
-              process.env.NODE_ENV !== "development" ? null :
-              <Menu.SubMenu
-                className="sidebar-menu-item"
-                key="byresource"
-                title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "asdf"}</span>}>
-                <Menu.Item><ConduitLink to="/deployments">Deployments</ConduitLink></Menu.Item>
-                <Menu.Item><ConduitLink to="/replicationcontrollers">Replication Controllers</ConduitLink></Menu.Item>
-                <Menu.Item><ConduitLink to="/pods">Pods</ConduitLink></Menu.Item>
-              </Menu.SubMenu>
-            }
 
             <Menu.Item className="sidebar-menu-item" key="/docs">
               <Link to="https://conduit.io/docs/" target="_blank">

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -180,6 +180,22 @@ class Sidebar extends React.Component {
                 : null
             }
 
+            <Menu.Item className="sidebar-menu-item" key="/authorities">
+              <ConduitLink to="/authorities">
+                <Icon type="cloud-o" />
+                <span>Authorities</span>
+              </ConduitLink>
+            </Menu.Item>
+
+            <Menu.SubMenu
+              className="sidebar-menu-item"
+              key="byresource"
+              title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "asdf"}</span>}>
+              <Menu.Item><ConduitLink to="/deployments">Deployments</ConduitLink></Menu.Item>
+              <Menu.Item><ConduitLink to="/replicationcontrollers">Replication Controllers</ConduitLink></Menu.Item>
+              <Menu.Item><ConduitLink to="/pods">Pods</ConduitLink></Menu.Item>
+            </Menu.SubMenu>
+
             <Menu.Item className="sidebar-menu-item" key="/docs">
               <Link to="https://conduit.io/docs/" target="_blank">
                 <Icon type="solution" />

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -189,7 +189,6 @@ class Sidebar extends React.Component {
               <Menu.Item><ConduitLink to="/pods">Pods</ConduitLink></Menu.Item>
             </Menu.SubMenu>
 
-
             <Menu.Item className="sidebar-menu-item" key="/docs">
               <Link to="https://conduit.io/docs/" target="_blank">
                 <Icon type="solution" />

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -187,14 +187,17 @@ class Sidebar extends React.Component {
               </ConduitLink>
             </Menu.Item>
 
-            <Menu.SubMenu
-              className="sidebar-menu-item"
-              key="byresource"
-              title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "asdf"}</span>}>
-              <Menu.Item><ConduitLink to="/deployments">Deployments</ConduitLink></Menu.Item>
-              <Menu.Item><ConduitLink to="/replicationcontrollers">Replication Controllers</ConduitLink></Menu.Item>
-              <Menu.Item><ConduitLink to="/pods">Pods</ConduitLink></Menu.Item>
-            </Menu.SubMenu>
+            {
+              process.env.NODE_ENV !== "development" ? null :
+              <Menu.SubMenu
+                className="sidebar-menu-item"
+                key="byresource"
+                title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "asdf"}</span>}>
+                <Menu.Item><ConduitLink to="/deployments">Deployments</ConduitLink></Menu.Item>
+                <Menu.Item><ConduitLink to="/replicationcontrollers">Replication Controllers</ConduitLink></Menu.Item>
+                <Menu.Item><ConduitLink to="/pods">Pods</ConduitLink></Menu.Item>
+              </Menu.SubMenu>
+            }
 
             <Menu.Item className="sidebar-menu-item" key="/docs">
               <Link to="https://conduit.io/docs/" target="_blank">


### PR DESCRIPTION
Add Sidebar links to Pods, Deployments, and Replication Controllers when `NODE_ENV=development`

In #1016 we removed the sidebar links to individual resource pages in favour of a namespace page that lists all resources. These resource pages require no additional code so they're still in our UI (accessible under `/pods`, `/deployments` etc), just not easily findable. I find them useful to check when in development mode, or when debugging something, so I'd like to re-add links.

I've gated them behind `NODE_ENV=development`, but I would also be happy to just add them back into the Sidebar.

![screen shot 2018-06-22 at 1 15 57 pm](https://user-images.githubusercontent.com/549258/41797517-2e7c4eb4-761f-11e8-8654-dee39f5af7a0.png)
