### PR TITLE
update documentation in TEST.md to reflect changes in testing setup/running tests:

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -63,9 +63,13 @@ Javascript dependencies are managed via [yarn](https://yarnpkg.com/) and
 [webpack](https://webpack.js.org/). To fetch dependencies and run tests, run:
 
 ```bash
+bin/web test
+
+# or alternatively:
+
 cd web/app
-yarn && yarn webpack
-yarn karma start --single-run
+yarn && NODE_ENV=test yarn webpack
+NODE_ENV=test yarn karma start --single-run
 ```
 
 # Integration tests


### PR DESCRIPTION
- the current test setup requires a NODE_ENV variable to be set for the tests to run, that is not yet documented. Following the TEST.md documentation will cause the tests to fail.
- The env_var is set either through a test script that was added or manually setting.
- This PR addresses the documentation fix and links the test script and updates instructions to include the node_env variable setting.

Signed-off-by: Franziska von der Goltz <franziska@vdgoltz.eu>