### PR TITLE
Remove `tls::current_connection_config`.

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -234,7 +234,6 @@ where
         debug!("bind_inner_stack endpoint={:?}, protocol={:?}", ep, protocol);
         let addr = ep.address();
 
-        // Like `tls::current_connection_config()`.
         let tls = ep.tls_identity().and_then(|identity| {
             tls_client_config.as_ref().map(|config| {
                 tls::ConnectionConfig {

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -362,20 +362,6 @@ impl ServerConfig {
     }
 }
 
-pub fn current_connection_config<C>(
-    watch: &ConditionalConnectionConfig<Watch<Conditional<C, ReasonForNoTls>>>)
-    -> ConditionalConnectionConfig<C> where C: Clone
-{
-    watch.as_ref().and_then(|c| {
-        c.config.borrow().as_ref().map(|config| {
-            ConnectionConfig {
-                identity: c.identity.clone(),
-                config: config.clone()
-            }
-        })
-    })
-}
-
 fn load_file_contents(path: &PathBuf) -> Result<Vec<u8>, Error> {
     fn load_file(path: &PathBuf) -> Result<Vec<u8>, io::Error> {
         let mut result = Vec::new();

--- a/proxy/src/transport/tls/mod.rs
+++ b/proxy/src/transport/tls/mod.rs
@@ -22,7 +22,6 @@ pub use self::{
         ReasonForNoIdentity,
         ServerConfig,
         ServerConfigWatch,
-        current_connection_config,
         watch_for_config_changes,
     },
     connection::{Connection, Session, UpgradeClientToTls},


### PR DESCRIPTION
It turned out not to be a useful abstraction as it's now only used
once.

Signed-off-by: Brian Smith <brian@briansmith.org>