### PR TITLE
proxy: Remove TLS client config from Process context

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -31,6 +31,7 @@ use watch_service::{WatchService, Rebind};
 pub struct Bind<C, B> {
     ctx: C,
     sensors: telemetry::Sensors,
+    tls_client_config: tls::ClientConfigWatch,
     _p: PhantomData<fn() -> B>,
 }
 
@@ -179,10 +180,11 @@ impl Error for BufferSpawnError {
 }
 
 impl<B> Bind<(), B> {
-    pub fn new() -> Self {
+    pub fn new(tls_client_config: tls::ClientConfigWatch) -> Self {
         Self {
             ctx: (),
             sensors: telemetry::Sensors::null(),
+            tls_client_config,
             _p: PhantomData,
         }
     }
@@ -198,6 +200,7 @@ impl<B> Bind<(), B> {
         Bind {
             ctx,
             sensors: self.sensors,
+            tls_client_config: self.tls_client_config,
             _p: PhantomData,
         }
     }
@@ -208,6 +211,7 @@ impl<C: Clone, B> Clone for Bind<C, B> {
         Self {
             ctx: self.ctx.clone(),
             sensors: self.sensors.clone(),
+            tls_client_config: self.tls_client_config.clone(),
             _p: PhantomData,
         }
     }
@@ -307,10 +311,7 @@ where
             endpoint: ep.clone(),
             protocol: protocol.clone(),
         };
-        // TODO: the watch should be an explicit field of `Bind`, rather
-        // than passed in the context.
-        let tls_client_config = self.ctx.tls_client_config_watch().clone();
-        WatchService::new(tls_client_config, rebind)
+        WatchService::new(self.tls_client_config.clone(), rebind)
     }
 
     pub fn bind_service(&self, ep: &Endpoint, protocol: &Protocol) -> BoundService<B> {

--- a/proxy/src/ctx/mod.rs
+++ b/proxy/src/ctx/mod.rs
@@ -10,7 +10,6 @@
 use config;
 use std::time::SystemTime;
 use std::sync::Arc;
-use transport::tls;
 
 pub mod http;
 pub mod transport;
@@ -22,8 +21,6 @@ pub struct Process {
     pub scheduled_namespace: String,
 
     pub start_time: SystemTime,
-
-    tls_client_config: tls::ClientConfigWatch,
 }
 
 /// Indicates the orientation of traffic, relative to a sidecar proxy.
@@ -46,17 +43,15 @@ impl Process {
         Arc::new(Self {
             scheduled_namespace: ns.into(),
             start_time: SystemTime::now(),
-            tls_client_config: tls::ClientConfig::no_tls(),
         })
     }
 
     /// Construct a new `Process` from environment variables.
-    pub fn new(config: &config::Config, tls_client_config: tls::ClientConfigWatch) -> Arc<Self> {
+    pub fn new(config: &config::Config) -> Arc<Self> {
         let start_time = SystemTime::now();
         Arc::new(Self {
             scheduled_namespace: config.namespaces.pod.clone(),
             start_time,
-            tls_client_config,
         })
     }
 }
@@ -79,12 +74,6 @@ impl Proxy {
 
     pub fn is_outbound(&self) -> bool {
         !self.is_inbound()
-    }
-
-    pub fn tls_client_config_watch(&self) -> &tls::ClientConfigWatch {
-        match self {
-            Proxy::Inbound(process) | Proxy::Outbound(process) => &process.tls_client_config
-        }
     }
 }
 

--- a/proxy/src/inbound.rs
+++ b/proxy/src/inbound.rs
@@ -113,7 +113,7 @@ mod tests {
     use tls;
 
     fn new_inbound(default: Option<net::SocketAddr>, ctx: &Arc<ctx::Proxy>) -> Inbound<()> {
-        let bind = Bind::new().with_ctx(ctx.clone());
+        let bind = Bind::new(tls::ClientConfig::no_tls()).with_ctx(ctx.clone());
         Inbound::new(default, bind)
     }
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -189,7 +189,7 @@ where
         let (tls_client_config, tls_server_config, tls_cfg_bg) =
             tls::watch_for_config_changes(self.config.tls_settings.as_ref());
 
-        let process_ctx = ctx::Process::new(&self.config, tls_client_config.clone());
+        let process_ctx = ctx::Process::new(&self.config);
 
         let Main {
             config,
@@ -249,7 +249,7 @@ where
 
         let (drain_tx, drain_rx) = drain::channel();
 
-        let bind = Bind::new().with_sensors(sensors.clone());
+        let bind = Bind::new(tls_client_config).with_sensors(sensors.clone());
 
         // Setup the public listener. This will listen on a publicly accessible
         // address and listen for inbound connections that should be forwarded


### PR DESCRIPTION
As the TLS client config watch stored in `ctx::Process` is used only in
`Bind`, it's not necessary for it to be part of the process context.
Instead, it can be explicitly passed into `Bind`.

The resultant code is simpler, and resolves a potential cyclic 
dependency caused when adding `Sensors` to the watch (see 
https://github.com/runconduit/conduit/pull/1141#issuecomment-400082357).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>