### PR TITLE
Web UI: Better format empty errors

### DIFF
--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -453,7 +453,9 @@ func checkContainerErrors(containerStatuses []apiv1.ContainerStatus, containerNa
 	errors := []*pb.PodErrors_PodError{}
 	for _, st := range containerStatuses {
 		if st.Name == containerName && st.State.Waiting != nil {
-			errors = append(errors, toPodError(st.Name, st.Image, st.State.Waiting.Message))
+			if st.State.Waiting.Message != "" {
+				errors = append(errors, toPodError(st.Name, st.Image, st.State.Waiting.Message))
+			}
 
 			if st.LastTerminationState.Waiting != nil {
 				errors = append(errors, toPodError(st.Name, st.Image, st.LastTerminationState.Waiting.Message))

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -55,6 +55,11 @@ export default class ErrorModal extends React.Component {
             .mapValues(v => {
               return _.map(v, err => {
                 let errMsg = _.get(err, ["container", "message"]);
+
+                if (!errMsg) {
+                  return null;
+                }
+
                 if (_.size(errMsg) > maxErrorLength) {
                   shouldTruncate = true;
                   err.container.truncatedMessage = _.take(errMsg, maxErrorLength).join("") + "...";
@@ -63,6 +68,7 @@ export default class ErrorModal extends React.Component {
                 return err.container;
               });
             })
+            .compact()
             .value()
         };
       }).value();
@@ -74,6 +80,10 @@ export default class ErrorModal extends React.Component {
   }
 
   renderContainerErrors = (pod, errorsByContainer) => {
+    if (_.isEmpty(errorsByContainer)) {
+      return "No messages to display";
+    }
+
     return _.map(errorsByContainer, (errors, container) => (
       <div key={`error-${container}`}>
         <div className="clearfix">


### PR DESCRIPTION
When connecting to the community cluster, I noticed there were a lot of namespaces that appeared to have errors, but when I inspected them they didn't. Also the blank error boxes were kind of ugly.

This PR 
- tries to better determine when we need to send a container state of `Waiting` as an error
- better displays empty error messages

Before:

![screen shot 2018-06-25 at 3 05 08 pm](https://user-images.githubusercontent.com/549258/41878650-be8c6e04-788a-11e8-8868-49bef901bb70.png)
![screen shot 2018-06-25 at 2 57 35 pm](https://user-images.githubusercontent.com/549258/41878661-cbfcbd3c-788a-11e8-8426-773829aaf800.png)

After:
![screen shot 2018-06-25 at 3 09 24 pm](https://user-images.githubusercontent.com/549258/41878656-c5768c72-788a-11e8-9a05-2d6f2f7fab2b.png)
![screen shot 2018-06-25 at 3 13 45 pm](https://user-images.githubusercontent.com/549258/41878660-c8ebe96a-788a-11e8-81d7-83d61536c404.png)


