### PR TITLE
Proxy: Allow non-Conduit-bound TLS and non-TLS through.

### DIFF
--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -30,6 +30,18 @@ pub fn connect(addr: &SocketAddr,
     }
 }
 
+/// A server socket that is in the process of conditionally upgrading to TLS.
+enum ConditionallyUpgradeServerToTls {
+    Plaintext(Option<ConditionallyUpgradeServerToTlsInner>),
+    UpgradeToTls(tls::UpgradeServerToTls),
+}
+
+struct ConditionallyUpgradeServerToTlsInner {
+    socket: TcpStream,
+    tls: tls::ConnectionConfig<tls::ServerConfig>,
+    peek_buf: BytesMut,
+}
+
 /// A socket that is in the process of connecting.
 pub enum Connecting {
     Plaintext {
@@ -154,19 +166,10 @@ impl BoundPort {
                         Conditional::None(r) => Conditional::None(*r),
                     };
                     let conn = match tls {
-                        Conditional::Some(config) => {
-                            // TODO: use `config.identity` to differentiate
-                            // between TLS that the proxy should terminate vs.
-                            // TLS that should be passed through.
-                            let f = tls::Connection::accept(socket, config.config)
-                                .map(move |tls| Connection::tls(tls));
-                            Either::A(f)
-                        },
-                        Conditional::None(why_no_tls) => {
-                            let f = future::ok(socket)
-                                .map(move |plain| Connection::plain(plain, why_no_tls));
-                            Either::B(f)
-                        },
+                        Conditional::Some(tls) =>
+                            Either::A(ConditionallyUpgradeServerToTls::new(socket, tls)),
+                        Conditional::None(why_no_tls) =>
+                            Either::B(future::ok(Connection::plain(socket, why_no_tls))),
                     };
                     conn.map(move |conn| (conn, remote_addr))
                 })
@@ -183,6 +186,61 @@ impl BoundPort {
                 .fold(initial, f)
         )
         .map(|_| ())
+    }
+}
+
+// ===== impl ConditionallyUpgradeServerToTls =====
+
+impl ConditionallyUpgradeServerToTls {
+    fn new(socket: TcpStream, tls: tls::ConnectionConfig<tls::ServerConfig>) -> Self {
+        ConditionallyUpgradeServerToTls::Plaintext(Some(ConditionallyUpgradeServerToTlsInner {
+            socket,
+            tls,
+            peek_buf: BytesMut::with_capacity(8192),
+        }))
+    }
+}
+
+impl Future for ConditionallyUpgradeServerToTls {
+    type Item = Connection;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            *self = match self {
+                ConditionallyUpgradeServerToTls::Plaintext(ref mut inner) => {
+                    let r = {
+                        let inner = inner.as_mut().unwrap();
+                        try_ready!(inner.socket.read_buf(&mut inner.peek_buf));
+                        tls::conditional_accept::match_client_hello(
+                            inner.peek_buf.as_ref(), &inner.tls.identity)
+                    };
+                    match r {
+                        tls::conditional_accept::Match::Matched => {
+                            trace!("upgrading accepted connection to TLS");
+                            let inner = inner.take().expect("Polled after ready");
+                            let upgrade_to_tls = tls::Connection::accept(
+                                inner.socket, inner.peek_buf.freeze(), inner.tls.config);
+                            ConditionallyUpgradeServerToTls::UpgradeToTls(upgrade_to_tls)
+                        },
+                        tls::conditional_accept::Match::NotMatched => {
+                            trace!("passing through accepted connection without TLS");
+                            let inner = inner.take().expect("Polled after ready");
+                            let conn = Connection::plain_with_peek_buf(
+                                inner.socket, inner.peek_buf, tls::ReasonForNoTls::NotProxyTls);
+                            return Ok(Async::Ready(conn));
+                        },
+                        tls::conditional_accept::Match::Incomplete => {
+                            return Ok(Async::NotReady);
+                        },
+                    }
+                },
+                ConditionallyUpgradeServerToTls::UpgradeToTls(upgrading) => {
+                    let tls_stream = try_ready!(upgrading.poll());
+                    return Ok(Async::Ready(Connection::tls(BoxedIo::new(tls_stream))));
+                }
+            }
+        }
     }
 }
 
@@ -211,7 +269,7 @@ impl Future for Connecting {
                 },
                 Connecting::UpgradeToTls(upgrading) => {
                     let tls_stream = try_ready!(upgrading.poll());
-                    return Ok(Async::Ready(Connection::tls(tls_stream)));
+                    return Ok(Async::Ready(Connection::tls(BoxedIo::new(tls_stream))));
                 },
             };
         }
@@ -222,16 +280,22 @@ impl Future for Connecting {
 
 impl Connection {
     fn plain(io: TcpStream, why_no_tls: tls::ReasonForNoTls) -> Self {
+        Self::plain_with_peek_buf(io, BytesMut::new(), why_no_tls)
+    }
+
+    fn plain_with_peek_buf(io: TcpStream, peek_buf: BytesMut, why_no_tls: tls::ReasonForNoTls)
+        -> Self
+    {
         Connection {
             io: BoxedIo::new(io),
-            peek_buf: BytesMut::new(),
+            peek_buf,
             tls_status: Conditional::None(why_no_tls),
         }
     }
 
-    fn tls<S: tls::Session + std::fmt::Debug + 'static>(tls: tls::Connection<S>) -> Self {
+    fn tls(io: BoxedIo) -> Self {
         Connection {
-            io: BoxedIo::new(tls),
+            io: io,
             peek_buf: BytesMut::new(),
             tls_status: Conditional::Some(()),
         }

--- a/proxy/src/telemetry/metrics/labels.rs
+++ b/proxy/src/telemetry/metrics/labels.rs
@@ -383,7 +383,8 @@ impl fmt::Display for ctx::transport::TlsStatus {
             Conditional::None(tls::ReasonForNoTls::NoConfig) => f.pad(",tls=\"no_config\""),
             Conditional::None(tls::ReasonForNoTls::Disabled) |
             Conditional::None(tls::ReasonForNoTls::InternalTraffic) |
-            Conditional::None(tls::ReasonForNoTls::NoIdentity(_)) => Ok(()),
+            Conditional::None(tls::ReasonForNoTls::NoIdentity(_)) |
+            Conditional::None(tls::ReasonForNoTls::NotProxyTls) => Ok(()),
         }
     }
 }

--- a/proxy/src/transport/prefixed.rs
+++ b/proxy/src/transport/prefixed.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO: Actually use this.
-
 use std::{cmp, fmt::Debug, io, net::SocketAddr};
 
 use super::io::internal::Io;

--- a/proxy/src/transport/tls/conditional_accept.rs
+++ b/proxy/src/transport/tls/conditional_accept.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO: Use this.
-
 use super::{Identity, untrusted};
 
 #[derive(Debug, Eq, PartialEq)]

--- a/proxy/src/transport/tls/config.rs
+++ b/proxy/src/transport/tls/config.rs
@@ -96,6 +96,10 @@ pub enum ReasonForNoTls {
 
     /// The connection is between the proxy and the service
     InternalTraffic,
+
+    /// The connection isn't TLS or it is TLS but not intended to be handled
+    /// by the proxy.
+    NotProxyTls,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/proxy/src/transport/tls/mod.rs
+++ b/proxy/src/transport/tls/mod.rs
@@ -4,7 +4,7 @@ extern crate tokio_rustls;
 extern crate untrusted;
 extern crate webpki;
 
-mod conditional_accept;
+pub mod conditional_accept;
 mod config;
 mod cert_resolver;
 mod connection;
@@ -25,7 +25,12 @@ pub use self::{
         ServerConfigWatch,
         watch_for_config_changes,
     },
-    connection::{Connection, Session, UpgradeClientToTls},
+    connection::{
+        Connection,
+        Session,
+        UpgradeClientToTls,
+        UpgradeServerToTls
+    },
     dns_name::{DnsName, InvalidDnsName},
     identity::Identity,
 };


### PR DESCRIPTION
On the server (accept) side of TLS, if the traffic isn't targetting the
proxy (as determined by the TLS ClientHello SNI), or if the traffic
isn't TLS, then pass it through.

Signed-off-by: Brian Smith <brian@briansmith.org>

conditoinally accept