### PR TITLE
Change the icon for Documentation in the sidebar

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -191,7 +191,7 @@ class Sidebar extends React.Component {
 
             <Menu.Item className="sidebar-menu-item" key="/docs">
               <Link to="https://conduit.io/docs/" target="_blank">
-                <Icon type="solution" />
+                <Icon type="file-text" />
                 <span>Documentation</span>
               </Link>
             </Menu.Item>


### PR DESCRIPTION
I don't looove the Documentation icon in the sidebar. Change to something a little more document-y.

Before:

<img width="260" alt="screen shot 2018-06-26 at 4 30 21 pm" src="https://user-images.githubusercontent.com/549258/41944751-43ed8e38-795e-11e8-9127-b1f6171b05f0.png">


After:

<img width="255" alt="screen shot 2018-06-26 at 4 26 47 pm" src="https://user-images.githubusercontent.com/549258/41944732-25bdce1e-795e-11e8-9982-1c2ebdcdd484.png">


Other choices at https://ant.design/components/icon/