### PR TITLE
Add Pod to injectable types

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -396,7 +396,6 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 		}
 
 		obj = &pod
-		k8sLabels[k8s.ProxyPodLabel] = pod.Name
 		podSpec = &pod.Spec
 		objectMeta = &pod.ObjectMeta
 

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -22,6 +22,7 @@ func TestInjectYAML(t *testing.T) {
 		{"inject_emojivoto_deployment_hostNetwork_true.input.yml", "inject_emojivoto_deployment_hostNetwork_true.golden.yml"},
 		{"inject_emojivoto_deployment_controller_name.input.yml", "inject_emojivoto_deployment_controller_name.golden.yml"},
 		{"inject_emojivoto_statefulset.input.yml", "inject_emojivoto_statefulset.golden.yml"},
+		{"inject_emojivoto_pod.input.yml", "inject_emojivoto_pod.golden.yml"},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -8,7 +8,6 @@ metadata:
   labels:
     app: vote-bot
     conduit.io/control-plane-ns: conduit
-    conduit.io/proxy-pod: vote-bot
   name: vote-bot
   namespace: emojivoto
 spec:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    conduit.io/created-by: conduit/cli undefined
+    conduit.io/proxy-version: testinjectversion
+  creationTimestamp: null
+  labels:
+    app: vote-bot
+    conduit.io/control-plane-ns: conduit
+    conduit.io/proxy-pod: vote-bot
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v3
+    name: vote-bot
+    resources: {}
+  - env:
+    - name: CONDUIT_PROXY_LOG
+      value: warn,conduit_proxy=info
+    - name: CONDUIT_PROXY_BIND_TIMEOUT
+      value: 10s
+    - name: CONDUIT_PROXY_CONTROL_URL
+      value: tcp://proxy-api.conduit.svc.cluster.local:8086
+    - name: CONDUIT_PROXY_CONTROL_LISTENER
+      value: tcp://0.0.0.0:4190
+    - name: CONDUIT_PROXY_METRICS_LISTENER
+      value: tcp://0.0.0.0:4191
+    - name: CONDUIT_PROXY_PRIVATE_LISTENER
+      value: tcp://127.0.0.1:4140
+    - name: CONDUIT_PROXY_PUBLIC_LISTENER
+      value: tcp://0.0.0.0:4143
+    - name: CONDUIT_PROXY_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: gcr.io/runconduit/proxy:testinjectversion
+    imagePullPolicy: IfNotPresent
+    name: conduit-proxy
+    ports:
+    - containerPort: 4143
+      name: conduit-proxy
+    - containerPort: 4191
+      name: conduit-metrics
+    resources: {}
+    securityContext:
+      runAsUser: 2102
+    terminationMessagePolicy: FallbackToLogsOnError
+  initContainers:
+  - args:
+    - --incoming-proxy-port
+    - "4143"
+    - --outgoing-proxy-port
+    - "4140"
+    - --proxy-uid
+    - "2102"
+    - --inbound-ports-to-ignore
+    - 4190,4191
+    image: gcr.io/runconduit/proxy-init:testinjectversion
+    imagePullPolicy: IfNotPresent
+    name: conduit-init
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      privileged: false
+    terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_pod.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.input.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vote-bot
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v3
+    name: vote-bot

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -51,6 +51,10 @@ const (
 	// StatefulSet that this proxy belongs to.
 	ProxyStatefulSetLabel = "conduit.io/proxy-stateful-set"
 
+	// ProxyPodLabel is injected into mesh-enabled apps, identifying the
+	// Pod that this proxy belongs to.
+	ProxyPodLabel = "conduit.io/proxy-pod"
+
 	/*
 	 * Annotations
 	 */
@@ -80,6 +84,7 @@ var proxyLabels = []string{
 	ProxyJobLabel,
 	ProxyDaemonSetLabel,
 	ProxyStatefulSetLabel,
+	ProxyPodLabel,
 	k8sV1.DefaultDeploymentUniqueLabelKey,
 }
 

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -51,10 +51,6 @@ const (
 	// StatefulSet that this proxy belongs to.
 	ProxyStatefulSetLabel = "conduit.io/proxy-stateful-set"
 
-	// ProxyPodLabel is injected into mesh-enabled apps, identifying the
-	// Pod that this proxy belongs to.
-	ProxyPodLabel = "conduit.io/proxy-pod"
-
 	/*
 	 * Annotations
 	 */
@@ -84,7 +80,6 @@ var proxyLabels = []string{
 	ProxyJobLabel,
 	ProxyDaemonSetLabel,
 	ProxyStatefulSetLabel,
-	ProxyPodLabel,
 	k8sV1.DefaultDeploymentUniqueLabelKey,
 }
 


### PR DESCRIPTION
For whatever reason, we've not enabled this yet. Because `PodTemplateSpec` and `Pod` aren't the same type, this splits the pieces we're actually injecting into separate functions (`PodSpec` and `ObjectMeta`).