### PR TITLE
proxy: Replace >=100,000 ms latency buckets with 1, 2, 3, 4, and 5 ms 

### DIFF
--- a/proxy/src/telemetry/metrics/latency.rs
+++ b/proxy/src/telemetry/metrics/latency.rs
@@ -30,7 +30,6 @@ pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(30_000),
     Bucket::Le(40_000),
     Bucket::Le(50_000),
-    Bucket::Le(60_000),
     // A final upper bound.
     Bucket::Inf,
 ]);

--- a/proxy/src/telemetry/metrics/latency.rs
+++ b/proxy/src/telemetry/metrics/latency.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use super::histogram::{Bounds, Bucket, Histogram};
 
 /// The maximum value (inclusive) for each latency bucket in
-/// tenths of a millisecond.
+/// milliseconds.
 pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(1),
     Bucket::Le(2),
@@ -30,11 +30,7 @@ pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(30_000),
     Bucket::Le(40_000),
     Bucket::Le(50_000),
-    Bucket::Le(100_000),
-    Bucket::Le(200_000),
-    Bucket::Le(300_000),
-    Bucket::Le(400_000),
-    Bucket::Le(500_000),
+    Bucket::Le(60_000),
     // A final upper bound.
     Bucket::Inf,
 ]);

--- a/proxy/src/telemetry/metrics/latency.rs
+++ b/proxy/src/telemetry/metrics/latency.rs
@@ -5,33 +5,31 @@ use super::histogram::{Bounds, Bucket, Histogram};
 /// The maximum value (inclusive) for each latency bucket in
 /// tenths of a millisecond.
 pub const BOUNDS: &Bounds = &Bounds(&[
-    // The controller telemetry server creates 5 sets of 5 linear buckets
-    // each:
-    // prometheus.LinearBuckets(1, 1, 5),
+    Bucket::Le(1),
+    Bucket::Le(2),
+    Bucket::Le(3),
+    Bucket::Le(4),
+    Bucket::Le(5),
     Bucket::Le(10),
     Bucket::Le(20),
     Bucket::Le(30),
     Bucket::Le(40),
     Bucket::Le(50),
-    // prometheus.LinearBuckets(10, 10, 5),
     Bucket::Le(100),
     Bucket::Le(200),
     Bucket::Le(300),
     Bucket::Le(400),
     Bucket::Le(500),
-    // prometheus.LinearBuckets(100, 100, 5),
     Bucket::Le(1_000),
     Bucket::Le(2_000),
     Bucket::Le(3_000),
     Bucket::Le(4_000),
     Bucket::Le(5_000),
-    // prometheus.LinearBuckets(1000, 1000, 5),
     Bucket::Le(10_000),
     Bucket::Le(20_000),
     Bucket::Le(30_000),
     Bucket::Le(40_000),
     Bucket::Le(50_000),
-    // prometheus.LinearBuckets(10000, 10000, 5),
     Bucket::Le(100_000),
     Bucket::Le(200_000),
     Bucket::Le(300_000),
@@ -44,10 +42,6 @@ pub const BOUNDS: &Bounds = &Bounds(&[
 /// A duration in milliseconds.
 #[derive(Debug, Default, Clone)]
 pub struct Ms(Duration);
-
-// /// A duration in microseconds.
-// #[derive(Debug, Default, Clone)]
-// pub struct Us(pub Duration);
 
 impl Into<u64> for Ms {
     fn into(self) -> u64 {
@@ -67,16 +61,3 @@ impl Default for Histogram<Ms> {
         Histogram::new(BOUNDS)
     }
 }
-
-// impl Into<u64> for Us {
-//     fn into(self) -> u64 {
-//         self.0.as_secs().saturating_mul(1_000_000)
-//             .saturating_add(u64::from(self.0.subsec_nanos()) / 1_000)
-//     }
-// }
-
-// impl Default for Histogram<Us> {
-//     fn default() -> Self {
-//         Histogram::new(&BOUNDS)
-//     }
-// }


### PR DESCRIPTION
This branch adds buckets for latencies below 10 ms to the proxy's latency
histograms, and removes the buckets for 100, 200, 300, 400, and 500 
seconds, so the largest non-infinity bucket is 50,000 ms. It also removes
comments that claimed that these buckets were the same as those created
by the control plane, as this is no longer true (the metrics are now scraped
by Prometheus from the proxy directly).

Closes #1208

Signed-off-by: Eliza Weisman <eliza@buoyant.io>