### PR TITLE
Proxy: Use new destination service TLS identity scheme.

### DIFF
--- a/proto/proxy/destination.proto
+++ b/proto/proxy/destination.proto
@@ -86,20 +86,7 @@ message WeightedAddr {
 // Which strategy should be used for verifying TLS.
 message TlsIdentity {
   oneof strategy {
-    K8sPodNamespace k8s_pod_namespace = 1;
     K8sPodIdentity k8s_pod_identity = 2;
-  }
-
-  // Verify the certificate based on the Kubernetes pod name, and ensure
-  // that the pod is configured with the same Conduit control plane
-  // namespace as this proxy.
-  message K8sPodNamespace {
-    // The Kubernetes namespace of the pod's Conduit control plane.
-    string controller_ns = 1;
-    // The Kubernetes namespace that the pod is in.
-    string pod_ns = 2;
-    // The name of the pod.
-    string pod_name = 3;
   }
 
   // Verify the certificate based on the Kubernetes pod identity.

--- a/proxy/src/transport/tls/identity.rs
+++ b/proxy/src/transport/tls/identity.rs
@@ -22,7 +22,7 @@ impl Identity {
     {
         use conduit_proxy_controller_grpc::destination::tls_identity::Strategy;
         match pb.strategy {
-            Some(Strategy::K8sPodNamespace(i)) => {
+            Some(Strategy::K8sPodIdentity(i)) => {
                 // XXX: If we don't know the controller's namespace or we don't
                 // share the same controller then we won't be able to validate
                 // the certificate yet. TODO: Support cross-controller
@@ -30,15 +30,7 @@ impl Identity {
                 if controller_namespace != Some(i.controller_ns.as_ref()) {
                     return Ok(None);
                 }
-
-                let namespaces = Namespaces {
-                    pod: i.pod_ns,
-                    tls_controller: Some(i.controller_ns),
-                };
-                Self::try_from_pod_name(&namespaces, &i.pod_name).map(Some)
-            },
-            Some(Strategy::K8sPodIdentity(_i)) => {
-                Ok(None) // TODO: switch to K8sPodIdentity
+                Self::from_sni_hostname(i.pod_identity.as_bytes()).map(Some)
             },
             None => Ok(None), // No TLS.
         }


### PR DESCRIPTION
Signed-off-by: Brian Smith <brian@briansmith.org>