### PR TITLE
cli: tap: Use safe accessors

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -277,7 +277,7 @@ func renderTapEvent(event *common.TapEvent) string {
 			ev.ResponseInit.GetId().GetStream(),
 			flow,
 			ev.ResponseInit.GetHttpStatus(),
-			ev.ResponseInit.GetSinceRequestInit().Nanos/1000,
+			ev.ResponseInit.GetSinceRequestInit().GetNanos()/1000,
 			isSecured,
 		)
 

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -262,8 +262,8 @@ func renderTapEvent(event *common.TapEvent) string {
 	switch ev := event.GetHttp().GetEvent().(type) {
 	case *common.TapEvent_Http_RequestInit_:
 		return fmt.Sprintf("req id=%d:%d %s :method=%s :authority=%s :path=%s secured=%s",
-			ev.RequestInit.Id.Base,
-			ev.RequestInit.Id.Stream,
+			ev.RequestInit.GetId().GetBase(),
+			ev.RequestInit.GetId().GetStream(),
 			flow,
 			ev.RequestInit.GetMethod().GetRegistered().String(),
 			ev.RequestInit.GetAuthority(),
@@ -273,8 +273,8 @@ func renderTapEvent(event *common.TapEvent) string {
 
 	case *common.TapEvent_Http_ResponseInit_:
 		return fmt.Sprintf("rsp id=%d:%d %s :status=%d latency=%dµs secured=%s",
-			ev.ResponseInit.Id.Base,
-			ev.ResponseInit.Id.Stream,
+			ev.ResponseInit.GetId().GetBase(),
+			ev.ResponseInit.GetId().GetStream(),
 			flow,
 			ev.ResponseInit.GetHttpStatus(),
 			ev.ResponseInit.GetSinceRequestInit().Nanos/1000,
@@ -285,32 +285,32 @@ func renderTapEvent(event *common.TapEvent) string {
 		switch eos := ev.ResponseEnd.GetEos().GetEnd().(type) {
 		case *common.Eos_GrpcStatusCode:
 			return fmt.Sprintf("end id=%d:%d %s grpc-status=%s duration=%dµs response-length=%dB secured=%s",
-				ev.ResponseEnd.Id.Base,
-				ev.ResponseEnd.Id.Stream,
+				ev.ResponseEnd.GetId().GetBase(),
+				ev.ResponseEnd.GetId().GetStream(),
 				flow,
 				codes.Code(eos.GrpcStatusCode),
-				millisSinceInit(ev.ResponseEnd),
+				ev.ResponseEnd.GetSinceResponseInit().GetNanos()/1000,
 				ev.ResponseEnd.GetResponseBytes(),
 				isSecured,
 			)
 
 		case *common.Eos_ResetErrorCode:
 			return fmt.Sprintf("end id=%d:%d %s reset-error=%+v duration=%dµs response-length=%dB secured=%s",
-				ev.ResponseEnd.Id.Base,
-				ev.ResponseEnd.Id.Stream,
+				ev.ResponseEnd.GetId().GetBase(),
+				ev.ResponseEnd.GetId().GetStream(),
 				flow,
 				eos.ResetErrorCode,
-				millisSinceInit(ev.ResponseEnd),
+				ev.ResponseEnd.GetSinceResponseInit().GetNanos()/1000,
 				ev.ResponseEnd.GetResponseBytes(),
 				isSecured,
 			)
 
 		default:
 			return fmt.Sprintf("end id=%d:%d %s duration=%dµs response-length=%dB secured=%s",
-				ev.ResponseEnd.Id.Base,
-				ev.ResponseEnd.Id.Stream,
+				ev.ResponseEnd.GetId().GetBase(),
+				ev.ResponseEnd.GetId().GetStream(),
 				flow,
-				millisSinceInit(ev.ResponseEnd),
+				ev.ResponseEnd.GetSinceResponseInit().GetNanos()/1000,
 				ev.ResponseEnd.GetResponseBytes(),
 				isSecured,
 			)
@@ -319,12 +319,4 @@ func renderTapEvent(event *common.TapEvent) string {
 	default:
 		return fmt.Sprintf("unknown %s", flow)
 	}
-}
-
-func millisSinceInit(end *common.TapEvent_Http_ResponseEnd) int32 {
-	var latency int32
-	if init := end.GetSinceResponseInit(); init != nil {
-		latency = init.Nanos / 1000
-	}
-	return latency
 }

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -259,19 +259,19 @@ func renderTapEvent(event *common.TapEvent) string {
 		dst,
 	)
 
-	http := event.GetHttp()
-	httpEvent := http.Event
+	httpEvent := event.GetHttp().GetEvent()
 	switch ev := httpEvent.(type) {
 	case *common.TapEvent_Http_RequestInit_:
 		return fmt.Sprintf("req id=%d:%d %s :method=%s :authority=%s :path=%s secured=%s",
 			ev.RequestInit.Id.Base,
 			ev.RequestInit.Id.Stream,
 			flow,
-			ev.RequestInit.Method.GetRegistered().String(),
-			ev.RequestInit.Authority,
-			ev.RequestInit.Path,
+			ev.RequestInit.GetMethod().GetRegistered().String(),
+			ev.RequestInit.GetAuthority(),
+			ev.RequestInit.GetPath(),
 			isSecured,
 		)
+
 	case *common.TapEvent_Http_ResponseInit_:
 		return fmt.Sprintf("rsp id=%d:%d %s :status=%d latency=%dµs secured=%s",
 			ev.ResponseInit.Id.Base,
@@ -281,10 +281,10 @@ func renderTapEvent(event *common.TapEvent) string {
 			ev.ResponseInit.GetSinceRequestInit().Nanos/1000,
 			isSecured,
 		)
-	case *common.TapEvent_Http_ResponseEnd_:
 
-		if ev.ResponseEnd.Eos != nil {
-			switch eos := ev.ResponseEnd.Eos.End.(type) {
+	case *common.TapEvent_Http_ResponseEnd_:
+		if ev.ResponseEnd.GetEos() != nil {
+			switch eos := ev.ResponseEnd.GetEos().GetEnd().(type) {
 			case *common.Eos_GrpcStatusCode:
 				return fmt.Sprintf("end id=%d:%d %s grpc-status=%s duration=%dµs response-length=%dB secured=%s",
 					ev.ResponseEnd.Id.Base,


### PR DESCRIPTION
The `tap` command is prone to segmentation faults due to use of `nil`
values. This is because we don't use the safe `Get*()` field accessors.

This change fixes several unsafe field access paths.

Fixes #47