### PR TITLE
Fix issue with injected resource name, add test

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -16,6 +16,7 @@ import (
 	batchV1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	k8sMeta "k8s.io/apimachinery/pkg/api/meta"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
@@ -463,11 +464,16 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 	// serialization of the modified object.
 	output := bytes
 	if podSpec != nil {
+		metaAccessor, err := k8sMeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+
 		// The namespace isn't necessarily in the input so it has to be substituted
 		// at runtime. The proxy recognizes the "$NAME" syntax for this variable
 		// but not necessarily other variables.
 		identity := k8s.TLSIdentity{
-			Name:                objectMeta.Name,
+			Name:                metaAccessor.GetName(),
 			Kind:                k8s.GetOwnerTypeFromLabels(k8sLabels),
 			Namespace:           "$" + PodNamespaceEnvVarName,
 			ControllerNamespace: controlPlaneNamespace,

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -10,19 +10,26 @@ import (
 )
 
 func TestInjectYAML(t *testing.T) {
-	testInjectOptions := newInjectOptions()
-	testInjectOptions.conduitVersion = "testinjectversion"
+	defaultOptions := newInjectOptions()
+	defaultOptions.conduitVersion = "testinjectversion"
+
+	tlsOptions := newInjectOptions()
+	tlsOptions.conduitVersion = "testinjectversion"
+	tlsOptions.tls = "optional"
+
 	testCases := []struct {
-		inputFileName  string
-		goldenFileName string
+		inputFileName     string
+		goldenFileName    string
+		testInjectOptions *injectOptions
 	}{
-		{"inject_emojivoto_deployment.input.yml", "inject_emojivoto_deployment.golden.yml"},
-		{"inject_emojivoto_list.input.yml", "inject_emojivoto_list.golden.yml"},
-		{"inject_emojivoto_deployment_hostNetwork_false.input.yml", "inject_emojivoto_deployment_hostNetwork_false.golden.yml"},
-		{"inject_emojivoto_deployment_hostNetwork_true.input.yml", "inject_emojivoto_deployment_hostNetwork_true.golden.yml"},
-		{"inject_emojivoto_deployment_controller_name.input.yml", "inject_emojivoto_deployment_controller_name.golden.yml"},
-		{"inject_emojivoto_statefulset.input.yml", "inject_emojivoto_statefulset.golden.yml"},
-		{"inject_emojivoto_pod.input.yml", "inject_emojivoto_pod.golden.yml"},
+		{"inject_emojivoto_deployment.input.yml", "inject_emojivoto_deployment.golden.yml", defaultOptions},
+		{"inject_emojivoto_list.input.yml", "inject_emojivoto_list.golden.yml", defaultOptions},
+		{"inject_emojivoto_deployment_hostNetwork_false.input.yml", "inject_emojivoto_deployment_hostNetwork_false.golden.yml", defaultOptions},
+		{"inject_emojivoto_deployment_hostNetwork_true.input.yml", "inject_emojivoto_deployment_hostNetwork_true.golden.yml", defaultOptions},
+		{"inject_emojivoto_deployment_controller_name.input.yml", "inject_emojivoto_deployment_controller_name.golden.yml", defaultOptions},
+		{"inject_emojivoto_statefulset.input.yml", "inject_emojivoto_statefulset.golden.yml", defaultOptions},
+		{"inject_emojivoto_pod.input.yml", "inject_emojivoto_pod.golden.yml", defaultOptions},
+		{"inject_emojivoto_deployment.input.yml", "inject_emojivoto_deployment_tls.golden.yml", tlsOptions},
 	}
 
 	for i, tc := range testCases {
@@ -36,7 +43,7 @@ func TestInjectYAML(t *testing.T) {
 
 			output := new(bytes.Buffer)
 
-			err = InjectYAML(read, output, testInjectOptions)
+			err = InjectYAML(read, output, tc.testInjectOptions)
 			if err != nil {
 				t.Errorf("Unexpected error injecting YAML: %v\n", err)
 			}

--- a/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        conduit.io/created-by: conduit/cli undefined
+        conduit.io/proxy-version: testinjectversion
+      creationTimestamp: null
+      labels:
+        app: web-svc
+        conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: web
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - env:
+        - name: CONDUIT_PROXY_LOG
+          value: warn,conduit_proxy=info
+        - name: CONDUIT_PROXY_BIND_TIMEOUT
+          value: 10s
+        - name: CONDUIT_PROXY_CONTROL_URL
+          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+        - name: CONDUIT_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: CONDUIT_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: CONDUIT_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: CONDUIT_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: CONDUIT_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONDUIT_PROXY_TLS_TRUST_ANCHORS
+          value: /var/conduit-io/trust-anchors/trust-anchors.pem
+        - name: CONDUIT_PROXY_TLS_CERT
+          value: /var/conduit-io/identity/certificate.crt
+        - name: CONDUIT_PROXY_TLS_PRIVATE_KEY
+          value: /var/conduit-io/identity/private-key.p8
+        - name: CONDUIT_PROXY_TLS_POD_IDENTITY
+          value: web.deployment.$CONDUIT_PROXY_POD_NAMESPACE.conduit-managed.conduit.svc.cluster.local
+        - name: CONDUIT_PROXY_CONTROLLER_NAMESPACE
+          value: conduit
+        - name: CONDUIT_PROXY_TLS_CONTROLLER_IDENTITY
+          value: controller.deployment.conduit.conduit-managed.conduit.svc.cluster.local
+        image: gcr.io/runconduit/proxy:testinjectversion
+        imagePullPolicy: IfNotPresent
+        name: conduit-proxy
+        ports:
+        - containerPort: 4143
+          name: conduit-proxy
+        - containerPort: 4191
+          name: conduit-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/conduit-io/trust-anchors
+          name: conduit-trust-anchors
+          readOnly: true
+        - mountPath: /var/conduit-io/identity
+          name: conduit-secrets
+          readOnly: true
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/runconduit/proxy-init:testinjectversion
+        imagePullPolicy: IfNotPresent
+        name: conduit-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - configMap:
+          name: conduit-ca-bundle
+          optional: true
+        name: conduit-trust-anchors
+      - name: conduit-secrets
+        secret:
+          optional: true
+          secretName: web-deployment-tls-conduit-io
+status: {}
+---


### PR DESCRIPTION
I noticed that the inject output with `--tls optional` appears to be missing the service name when formulating the TLS identity string. For instance:

```
$ bin/conduit inject --tls optional cli/cmd/testdata/inject_emojivoto_deployment.input.yml | grep -EA1 '(secretName|CONDUIT_PROXY_TLS_POD_IDENTITY)'
        - name: CONDUIT_PROXY_TLS_POD_IDENTITY
          value: .deployment.$CONDUIT_PROXY_POD_NAMESPACE.conduit-managed.conduit.svc.cluster.local
--
          secretName: -deployment-tls-conduit-io
status: {}
```

This is a result of the object template spec (`objectMeta`) not being the full meta from the original object (`obj`). I've updated the inject code to instead use `k8s.io/apimachinery/pkg/api/meta.Accessor` on `obj` itself, which properly returns the object's name. Compare to:

```
$ bin/go-run cli inject --tls optional cli/cmd/testdata/inject_emojivoto_deployment.input.yml | grep -EA1 '(secretName|CONDUIT_PROXY_TLS_POD_IDENTITY)'
        - name: CONDUIT_PROXY_TLS_POD_IDENTITY
          value: web.deployment.$CONDUIT_PROXY_POD_NAMESPACE.conduit-managed.conduit.svc.cluster.local
--
          secretName: web-deployment-tls-conduit-io
status: {}
```

I've also added a test that verifies the expected inject output when TLS is enabled.