### PR TITLE
Set outbound capacity on proxy in Prometheus pod

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -224,6 +224,24 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		},
 	}
 
+	// Special case if the caller specifies that
+	// CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY be set on the pod.
+	// We key off of any container image in the pod. Ideally we would instead key
+	// off of something at the top-level of the PodSpec, but there is nothing
+	// easily identifiable at that level.
+	// This is currently only used by the Prometheus pod in the control-plane.
+	for _, container := range t.Containers {
+		if capacity, ok := options.proxyOutboundCapacity[container.Image]; ok {
+			sidecar.Env = append(sidecar.Env,
+				v1.EnvVar{
+					Name:  "CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY",
+					Value: fmt.Sprintf("%d", capacity),
+				},
+			)
+			break
+		}
+	}
+
 	if options.enableTLS() {
 		yes := true
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -42,6 +42,8 @@ type installOptions struct {
 	*proxyConfigOptions
 }
 
+const prometheusProxyOutboundCapacity = 10000
+
 func newInstallOptions() *installOptions {
 	return &installOptions{
 		controllerReplicas: 1,
@@ -64,6 +66,7 @@ func newCmdInstall() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			return render(*config, os.Stdout, options)
 		},
 	}
@@ -124,6 +127,10 @@ func render(config installConfig, w io.Writer, options *installOptions) error {
 	}
 	injectOptions := newInjectOptions()
 	injectOptions.proxyConfigOptions = options.proxyConfigOptions
+
+	// Special case for conduit-proxy running in the Prometheus pod.
+	injectOptions.proxyOutboundCapacity[config.PrometheusImage] = prometheusProxyOutboundCapacity
+
 	return InjectYAML(buf, w, injectOptions)
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -76,18 +76,19 @@ func newPublicAPIClient() (pb.ApiClient, error) {
 }
 
 type proxyConfigOptions struct {
-	conduitVersion   string
-	proxyImage       string
-	initImage        string
-	dockerRegistry   string
-	imagePullPolicy  string
-	proxyUID         int64
-	proxyLogLevel    string
-	proxyBindTimeout string
-	proxyAPIPort     uint
-	proxyControlPort uint
-	proxyMetricsPort uint
-	tls              string
+	conduitVersion        string
+	proxyImage            string
+	initImage             string
+	dockerRegistry        string
+	imagePullPolicy       string
+	proxyUID              int64
+	proxyLogLevel         string
+	proxyBindTimeout      string
+	proxyAPIPort          uint
+	proxyControlPort      uint
+	proxyMetricsPort      uint
+	proxyOutboundCapacity map[string]uint
+	tls                   string
 }
 
 const (
@@ -97,18 +98,19 @@ const (
 
 func newProxyConfigOptions() *proxyConfigOptions {
 	return &proxyConfigOptions{
-		conduitVersion:   version.Version,
-		proxyImage:       defaultDockerRegistry + "/proxy",
-		initImage:        defaultDockerRegistry + "/proxy-init",
-		dockerRegistry:   defaultDockerRegistry,
-		imagePullPolicy:  "IfNotPresent",
-		proxyUID:         2102,
-		proxyLogLevel:    "warn,conduit_proxy=info",
-		proxyBindTimeout: "10s",
-		proxyAPIPort:     8086,
-		proxyControlPort: 4190,
-		proxyMetricsPort: 4191,
-		tls:              "",
+		conduitVersion:        version.Version,
+		proxyImage:            defaultDockerRegistry + "/proxy",
+		initImage:             defaultDockerRegistry + "/proxy-init",
+		dockerRegistry:        defaultDockerRegistry,
+		imagePullPolicy:       "IfNotPresent",
+		proxyUID:              2102,
+		proxyLogLevel:         "warn,conduit_proxy=info",
+		proxyBindTimeout:      "10s",
+		proxyAPIPort:          8086,
+		proxyControlPort:      4190,
+		proxyMetricsPort:      4191,
+		proxyOutboundCapacity: map[string]uint{},
+		tls: "",
 	}
 }
 

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -503,6 +503,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY
+          value: "10000"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -506,6 +506,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY
+          value: "10000"
         image: gcr.io/runconduit/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: conduit-proxy


### PR DESCRIPTION
The `conduit-proxy` injected into the control-plane's Prometheus pod
makes requests to every other mesh-enabled pod in the cluster. For a
large number of pods (>300), this triggered
`conduit_proxy router at capacity` errors from the proxy, as the default
outbound capacity is set at 100.

This change increases `CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY` from 100
to 10000 on the `conduit-proxy` running in the Prometheus pod.

Relates to
https://github.com/runconduit/conduit/issues/1179#issuecomment-400800995

Signed-off-by: Andrew Seigner <siggy@buoyant.io>