### PR TITLE
Re-run install integration test w/TLS enabled

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -31,8 +31,8 @@ function check_if_k8s_reachable(){
 }
 
 function run_test(){
-    printf "Running test [%s]\\n" "$(basename "$1")"
-    go test -v "$1" -conduit "$conduit_path" -conduit-namespace "$conduit_namespace" -integration-tests
+    printf "Running test [%s] %s\\n" "$(basename "$1")" "$2"
+    go test -v "$1" -conduit "$conduit_path" -conduit-namespace "$conduit_namespace" -integration-tests "$2"
 }
 
 conduit_path=$1
@@ -55,8 +55,17 @@ printf "==================RUNNING ALL TESTS==================\\n"
 printf "Testing Conduit version [%s] namespace [%s]\\n" "$conduit_version" "$conduit_namespace"
 
 exit_code=0
+
 run_test "$test_directory/install_test.go" || exit_code=$?
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?
 done
+run_test "$test_directory/install_test.go" "-enable-tls" || exit_code=$?
+
+if [ $exit_code -eq 0 ]; then
+    printf "\\n=== PASS: all tests passed\\n"
+else
+    printf "\\n=== FAIL: at least one test failed\\n"
+fi
+
 exit $exit_code

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -54,7 +54,13 @@ func TestVersionPreInstall(t *testing.T) {
 }
 
 func TestInstall(t *testing.T) {
-	out, err := TestHelper.ConduitRun("install", "--conduit-version", TestHelper.GetVersion())
+	cmd := []string{"install", "--conduit-version", TestHelper.GetVersion()}
+	if TestHelper.TLS() {
+		cmd = append(cmd, []string{"--tls", "optional"}...)
+		conduitDeployReplicas["ca-bundle-distributor"] = 1
+	}
+
+	out, err := TestHelper.ConduitRun(cmd...)
 	if err != nil {
 		t.Fatalf("conduit install command failed\n%s", out)
 	}
@@ -162,7 +168,12 @@ func TestDashboard(t *testing.T) {
 }
 
 func TestInject(t *testing.T) {
-	out, err := TestHelper.ConduitRun("inject", "testdata/smoke_test.yaml")
+	cmd := []string{"inject", "testdata/smoke_test.yaml"}
+	if TestHelper.TLS() {
+		cmd = append(cmd, []string{"--tls", "optional"}...)
+	}
+
+	out, err := TestHelper.ConduitRun(cmd...)
 	if err != nil {
 		t.Fatalf("conduit inject command failed\n%s", out)
 	}

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -19,6 +19,7 @@ type TestHelper struct {
 	conduit    string
 	version    string
 	namespace  string
+	tls        bool
 	httpClient http.Client
 	KubernetesHelper
 }
@@ -33,6 +34,7 @@ func NewTestHelper() *TestHelper {
 
 	conduit := flag.String("conduit", "", "path to the conduit binary to test")
 	namespace := flag.String("conduit-namespace", "conduit", "the namespace where conduit is installed")
+	tls := flag.Bool("enable-tls", false, "enable TLS in tests")
 	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
 	verbose := flag.Bool("verbose", false, "turn on debug logging")
 	flag.Parse()
@@ -60,9 +62,15 @@ func NewTestHelper() *TestHelper {
 		log.SetLevel(log.PanicLevel)
 	}
 
+	ns := *namespace
+	if *tls {
+		ns += "-tls"
+	}
+
 	testHelper := &TestHelper{
 		conduit:   *conduit,
-		namespace: *namespace,
+		namespace: ns,
+		tls:       *tls,
 	}
 
 	version, err := testHelper.ConduitRun("version", "--client", "--short")
@@ -101,6 +109,11 @@ func (h *TestHelper) GetConduitNamespace() string {
 // is prefixed with the conduit namespace.
 func (h *TestHelper) GetTestNamespace(testName string) string {
 	return h.namespace + "-" + testName
+}
+
+// TLS returns whether or not TLS is enabled for the given test.
+func (h *TestHelper) TLS() bool {
+	return h.tls
 }
 
 // CombinedOutput executes a shell command and returns the output.


### PR DESCRIPTION
This branch tweaks the `bin/test-run` script to re-run the conduit install test with `--tls optional` set. This allows us to validate that the conduit version/install/check/inject commands are working with TLS enabled. It doesn't validate that TLS is actually happening -- just that nothing breaks when the flag is set. We could eventually expand this approach to run all integration tests, but that will substantially increase the amount of time (and resources) that it takes to run tests, so I wanted to start small with just the install test.