### PR TITLE
Use parent name instead of pod name in identity string

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -16,7 +16,6 @@ import (
 	batchV1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	k8sMeta "k8s.io/apimachinery/pkg/api/meta"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
@@ -465,17 +464,14 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 	// serialization of the modified object.
 	output := bytes
 	if podSpec != nil {
-		metaAccessor, err := k8sMeta.Accessor(obj)
-		if err != nil {
-			return nil, err
-		}
+		ownerKind, ownerName := k8s.GetOwnerKindAndName(k8sLabels)
 
 		// The namespace isn't necessarily in the input so it has to be substituted
 		// at runtime. The proxy recognizes the "$NAME" syntax for this variable
 		// but not necessarily other variables.
 		identity := k8s.TLSIdentity{
-			Name:                metaAccessor.GetName(),
-			Kind:                k8s.GetOwnerTypeFromLabels(k8sLabels),
+			Name:                ownerName,
+			Kind:                ownerKind,
 			Namespace:           "$" + PodNamespaceEnvVarName,
 			ControllerNamespace: controlPlaneNamespace,
 		}

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -158,10 +158,11 @@ func (l *endpointListener) toTlsIdentity(pod *coreV1.Pod) *pb.TlsIdentity {
 	}
 
 	controllerNs := pkgK8s.GetControllerNs(pod.ObjectMeta)
+	ownerKind, ownerName := pkgK8s.GetOwnerKindAndName(pod.Labels)
 
 	identity := pkgK8s.TLSIdentity{
-		Name:                pod.Name,
-		Kind:                pkgK8s.GetOwnerType(pod.ObjectMeta),
+		Name:                ownerName,
+		Kind:                ownerKind,
 		Namespace:           pod.Namespace,
 		ControllerNamespace: controllerNs,
 	}

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -164,7 +164,7 @@ func TestEndpointListener(t *testing.T) {
 		expectedConduitNamespace := "conduit-namespace"
 		expectedPodDeployment := "pod-deployment"
 		expectedTlsIdentity := &pb.TlsIdentity_K8SPodIdentity{
-			PodIdentity:  "pod1.deployment.this-namespace.conduit-managed.conduit-namespace.svc.cluster.local",
+			PodIdentity:  "pod-deployment.deployment.this-namespace.conduit-managed.conduit-namespace.svc.cluster.local",
 			ControllerNs: "conduit-namespace",
 		}
 

--- a/controller/gen/proxy/destination/destination.pb.go
+++ b/controller/gen/proxy/destination/destination.pb.go
@@ -360,7 +360,7 @@ func _TlsIdentity_OneofSizer(msg proto.Message) (n int) {
 // Verify the certificate based on the Kubernetes pod identity.
 type TlsIdentity_K8SPodIdentity struct {
 	// The pod_identity string is of the format:
-	// {pod_name}.{pod_type}.{pod_ns}.conduit-managed.{controller_ns}.svc.cluster.local
+	// {owner_name}.{owner_type}.{pod_ns}.conduit-managed.{controller_ns}.svc.cluster.local
 	PodIdentity string `protobuf:"bytes,1,opt,name=pod_identity,json=podIdentity" json:"pod_identity,omitempty"`
 	// The Kubernetes namespace of the pod's Conduit control plane.
 	ControllerNs string `protobuf:"bytes,2,opt,name=controller_ns,json=controllerNs" json:"controller_ns,omitempty"`

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -116,17 +116,13 @@ func GetControllerNs(objectMeta meta.ObjectMeta) string {
 	return objectMeta.Labels[ControllerNSLabel]
 }
 
-func GetOwnerType(objectMeta meta.ObjectMeta) string {
-	return GetOwnerTypeFromLabels(objectMeta.Labels)
-}
-
-func GetOwnerTypeFromLabels(labels map[string]string) string {
+func GetOwnerKindAndName(labels map[string]string) (string, string) {
 	for _, label := range podOwnerLabels {
-		if _, ok := labels[label]; ok {
-			return toOwnerLabel(label)
+		if v, ok := labels[label]; ok {
+			return toOwnerLabel(label), v
 		}
 	}
-	return ""
+	return "", ""
 }
 
 // toOwnerLabel converts a proxy label to a prometheus label, following the

--- a/proto/proxy/destination.proto
+++ b/proto/proxy/destination.proto
@@ -92,7 +92,7 @@ message TlsIdentity {
   // Verify the certificate based on the Kubernetes pod identity.
   message K8sPodIdentity {
     // The pod_identity string is of the format:
-    // {pod_name}.{pod_type}.{pod_ns}.conduit-managed.{controller_ns}.svc.cluster.local
+    // {owner_name}.{owner_type}.{pod_ns}.conduit-managed.{controller_ns}.svc.cluster.local
     string pod_identity = 1;
     // The Kubernetes namespace of the pod's Conduit control plane.
     string controller_ns = 2;


### PR DESCRIPTION
This fixes an issue where the inject command was formulating one identity string and the destination service was formulating a different identity string for the same pod. Now they should both be using the same string.