### PR TITLE
proxy: Fix incorrect `tls="true"` labels on metrics after falling back to plaintext

### DIFF
--- a/proxy/src/bind.rs
+++ b/proxy/src/bind.rs
@@ -256,7 +256,7 @@ where
 
         // Map a socket address to a connection.
         let connect = self.sensors.connect(
-            transport::Connect::new(addr, tls),
+            transport::Connect::new(addr, tls, &client_ctx),
             &client_ctx,
         );
 

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -1,9 +1,12 @@
 use bytes::{Buf, BytesMut};
 use futures::{*, future::Either};
-use std;
-use std::cmp;
-use std::io;
-use std::net::SocketAddr;
+use std::{
+    self,
+    cmp,
+    io,
+    net::SocketAddr,
+    sync::Arc,
+};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::{TcpListener, TcpStream, ConnectFuture},
@@ -11,7 +14,7 @@ use tokio::{
 };
 
 use conditional::Conditional;
-use ctx::transport::TlsStatus;
+use ctx::{self, transport::TlsStatus};
 use config::Addr;
 use transport::{AddrInfo, BoxedIo, GetOriginalDst, tls};
 
@@ -21,9 +24,11 @@ pub struct BoundPort {
 }
 
 /// Initiates a client connection to the given address.
-pub fn connect(addr: &SocketAddr,
-               tls: tls::ConditionalConnectionConfig<tls::ClientConfig>)
-    -> Connecting
+pub fn connect(
+    addr: &SocketAddr,
+    tls: tls::ConditionalConnectionConfig<tls::ClientConfig>,
+    client_ctx: Option<&Arc<ctx::transport::Client>>,
+) -> Connecting
 {
     let state = ConnectingState::Plaintext {
         connect: TcpStream::connect(addr),
@@ -32,6 +37,7 @@ pub fn connect(addr: &SocketAddr,
     Connecting {
         addr: *addr,
         state,
+        client_ctx: client_ctx.cloned(),
     }
 }
 
@@ -51,6 +57,7 @@ struct ConditionallyUpgradeServerToTlsInner {
 pub struct Connecting {
     addr: SocketAddr,
     state: ConnectingState,
+    client_ctx: Option<Arc<ctx::transport::Client>>,
 }
 
 enum ConnectingState {
@@ -293,6 +300,12 @@ impl Future for Connecting {
                                     -> falling back to plaintext",
                                 self.addr, e,
                             );
+                            if let Some(ref ctx) = self.client_ctx {
+                                // Set the `tls_status` field on the client context
+                                // to "Handshake Failed" so that future telemetry
+                                // events will have the correct status label.
+                                ctx.set_handshake_failed();
+                            }
                             let connect = TcpStream::connect(&self.addr);
                             // TODO: emit a `HandshakeFailed` telemetry event.
                             let reason = tls::ReasonForNoTls::HandshakeFailed;

--- a/proxy/src/ctx/http.rs
+++ b/proxy/src/ctx/http.rs
@@ -86,7 +86,7 @@ impl Request {
         if self.server.proxy.is_outbound() {
             // If the request is in the outbound direction, then we opened the
             // client connection, so check if it was secured.
-            self.client.tls_status
+            self.client.tls_status()
         } else {
             // Otherwise, the request is inbound, so check if we accepted it
             // over TLS.

--- a/proxy/src/transparency/tcp.rs
+++ b/proxy/src/transparency/tcp.rs
@@ -69,7 +69,11 @@ impl Proxy {
             TlsStatus::from(&tls),
         );
         let c = Timeout::new(
-            transport::Connect::new(orig_dst, tls),
+            transport::Connect::new(
+                orig_dst,
+                tls,
+                &client_ctx,
+            ),
             self.connect_timeout,
         );
         let connect = self.sensors.connect(c, &client_ctx);


### PR DESCRIPTION
Currently, if the proxy falls back to plaintext when a TLS handshake
fails, request/response-level metrics for that connection are labeled
with `tls="true"` rather than `tls="handshake_failed"`. This is because
the client transport context, which is used for labelling the telemetry
events that generate these metrics, is constructed and passed to the
sensors before we know if the handshake was successful.

This branch fixes that issue by introducing some limited interior
mutability to `ctx::transport::Client`, allowing the context's TLS
status to be changed after it is constructed. While I don't think shared
mutable state is a good pattern, here it is limited to one specific
case, and this seems much less bad than the other solutions to this
problem, such as creating a side channel from the `Connecting` future
back to the call site to pass the resultant status.

I initially was going to implement this interior mutability by putting a
`Cell` around the `Client` context's `tls_status` field, but `Cell`
isn't `Sync`, and the context type has to be `Sync`. Then, I considered
using a `Mutex`, but that also did not seem ideal, as there was only one
case where we have to mutate the status and several where we wanted to
read from it. Therefore, I didn't want to have the readers always have
to block on the mutex. Instead, I added an additional `AtomicBool` field
which is set if the handshake failed, and hid the `tls_status` field
behind an accessor method that checks the `AtomicBool` prior to
accessing the `tls_status` and returns `HandshakeFailed` if the bool is
set. This way, muitiple  concurrent readers of the TLS status don't all
have to block on a mutex, but the `Connecting` future can still modify
the `tls_status` when the handshake fails, and the generated metrics
will have the correct stauts.

Fixes #1240.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>