### PR TITLE
Change CLI and web TLS indicators from Secured to TLS

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -156,7 +156,7 @@ const padding = 3
 type rowStats struct {
 	requestRate float64
 	successRate float64
-	secured     float64
+	tlsPercent  float64
 	latencyP50  uint64
 	latencyP95  uint64
 	latencyP99  uint64
@@ -215,7 +215,7 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 				statTables[resourceKey][key].rowStats = &rowStats{
 					requestRate: getRequestRate(*r),
 					successRate: getSuccessRate(*r),
-					secured:     getPercentSecured(*r),
+					tlsPercent:  getPercentTls(*r),
 					latencyP50:  r.Stats.LatencyMsP50,
 					latencyP95:  r.Stats.LatencyMsP95,
 					latencyP99:  r.Stats.LatencyMsP99,
@@ -262,7 +262,7 @@ func printStatTable(stats map[string]*row, resourceType string, w *tabwriter.Wri
 		"LATENCY_P50",
 		"LATENCY_P95",
 		"LATENCY_P99",
-		"SECURED\t", // trailing \t is required to format last column
+		"TLS\t", // trailing \t is required to format last column
 	}...)
 
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
@@ -296,7 +296,7 @@ func printStatTable(stats map[string]*row, resourceType string, w *tabwriter.Wri
 				stats[key].latencyP50,
 				stats[key].latencyP95,
 				stats[key].latencyP99,
-				stats[key].secured * 100,
+				stats[key].tlsPercent * 100,
 			}...)
 
 			fmt.Fprintf(w, templateString, values...)
@@ -373,7 +373,7 @@ func getSuccessRate(r pb.StatTable_PodGroup_Row) float64 {
 	return float64(success) / float64(success+failure)
 }
 
-func getPercentSecured(r pb.StatTable_PodGroup_Row) float64 {
+func getPercentTls(r pb.StatTable_PodGroup_Row) float64 {
 	reqTotal := r.Stats.SuccessCount + r.Stats.FailureCount
 	if reqTotal == 0 {
 		return 0.0

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -20,8 +20,8 @@ func TestStat(t *testing.T) {
 
 		mockClient.StatSummaryResponseToReturn = &response
 
-		expectedOutput := `NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   SECURED
-emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms      100%
+		expectedOutput := `NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
+emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms   100%
 `
 
 		options := newStatOptions()

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -20,7 +20,7 @@ func TestStat(t *testing.T) {
 
 		mockClient.StatSummaryResponseToReturn = &response
 
-		expectedOutput := `NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
+		expectedOutput := `NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99    TLS
 emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms   100%
 `
 

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -29,7 +29,7 @@ type rowStat struct {
 	p50Latency string
 	p95Latency string
 	p99Latency string
-	secured    string
+	tlsPercent string
 }
 
 //////////////////////
@@ -186,7 +186,7 @@ func parseRows(out string, expectedRowCount int) (map[string]*rowStat, error) {
 			p50Latency: fields[4],
 			p95Latency: fields[5],
 			p99Latency: fields[6],
-			secured:    fields[7],
+			tlsPercent: fields[7],
 		}
 	}
 
@@ -230,11 +230,11 @@ func validateRowStats(name, expectedMeshCount string, rowStats map[string]*rowSt
 			name, stat.p99Latency)
 	}
 
-	// this should be 100.00% when control plane is secure by default
-	expectedSecuredRate := "0%"
-	if stat.secured != expectedSecuredRate {
-		return fmt.Errorf("Expected secured rate [%s] for [%s], got [%s]",
-			expectedSecuredRate, name, stat.secured)
+	// this should be 100.00% when control plane is TLSed by default
+	expectedTlsRate := "0%"
+	if stat.tlsPercent != expectedTlsRate {
+		return fmt.Errorf("Expected tls rate [%s] for [%s], got [%s]",
+			expectedTlsRate, name, stat.tlsPercent)
 	}
 
 	return nil

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -133,8 +133,8 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       render: metricToFormatter["LATENCY"]
     },
     {
-      title: formatTitle("Secured", "Percentage of TLS Traffic"),
-      key: "securedTraffic",
+      title: formatTitle("TLS", "Percentage of TLS Traffic"),
+      key: "tlsTraffic",
       dataIndex: "tlsRequestPercent",
       className: "numeric",
       sorter: (a, b) => numericSort(a.tlsRequestPercent.get(), b.tlsRequestPercent.get()),


### PR DESCRIPTION
Previously, we had "Secured" columns in the web and CLI for the percentage of traffic that is TLSed. Change this to "TLS"