### PR TITLE
proxy: Handle connection close during TLS detection

### DIFF
--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -227,12 +227,12 @@ impl Future for ConditionallyUpgradeServerToTls {
                     match try_ready!(poll_match) {
                         tls::conditional_accept::Match::Matched => {
                             trace!("upgrading accepted connection to TLS");
-                            let upgrade = inner.take().expect("polled after ready").into();
+                            let upgrade = inner.take().unwrap().into();
                             ConditionallyUpgradeServerToTls::UpgradeToTls(upgrade)
                         },
                         tls::conditional_accept::Match::NotMatched => {
                             trace!("passing through accepted connection without TLS");
-                            let conn = inner.take().expect("polled after ready").into();
+                            let conn = inner.take().unwrap().into();
                             return Ok(Async::Ready(conn));
                         },
                         tls::conditional_accept::Match::Incomplete => {

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -254,7 +254,7 @@ impl ConditionallyUpgradeServerToTlsInner {
     ///
     /// The buffer is matched for a TLS client hello message.
     ///
-    /// `None` is returned if the underlying socket has closed.
+    /// `NotMatched` is returned if the underlying socket has closed.
     fn poll_match_client_hello(&mut self) -> Poll<tls::conditional_accept::Match, io::Error> {
         let sz = try_ready!(self.socket.read_buf(&mut self.peek_buf));
         if sz == 0 {

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -225,10 +225,6 @@ impl Future for ConditionallyUpgradeServerToTls {
                         .poll_match_client_hello();
 
                     match try_ready!(poll_match) {
-                        tls::conditional_accept::Match::Incomplete => {
-                            // Keep reading until a NotReady is encountered.
-                            continue;
-                        },
                         tls::conditional_accept::Match::Matched => {
                             trace!("upgrading accepted connection to TLS");
                             let upgrade = inner.take().unwrap().into_tls_upgrade();
@@ -238,6 +234,9 @@ impl Future for ConditionallyUpgradeServerToTls {
                             trace!("passing through accepted connection without TLS");
                             let conn = inner.take().unwrap().into_plaintext();
                             return Ok(Async::Ready(conn));
+                        },
+                        tls::conditional_accept::Match::Incomplete => {
+                            continue;
                         },
                     }
                 },

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -255,7 +255,7 @@ impl ConditionallyUpgradeServerToTlsInner {
     /// The buffer is matched for a TLS client hello message.
     ///
     /// An error is returned if the underlying socket has closed.
-    fn poll_match_client_hello(&mut self) -> Poll<tls:;conditional_accept::Match, io::Error> {
+    fn poll_match_client_hello(&mut self) -> Poll<tls::conditional_accept::Match, io::Error> {
         let sz = try_ready!(self.socket.read_buf(&mut self.peek_buf));
         if sz == 0 {
             return Err(io::ErrorKind::BrokenPipe.into());

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -251,11 +251,11 @@ impl Future for ConditionallyUpgradeServerToTls {
 }
 
 impl ConditionallyUpgradeServerToTlsInner {
-    /// Polls the underliyng socket for more data and buffers it.
+    /// Polls the underlying socket for more data and buffers it.
     ///
     /// The buffer is matched for a TLS client hello message.
     ///
-    /// An error is returned if the underlying socket has closed.
+    /// `None` is returned if the underlying socket has closed.
     fn poll_match_client_hello(&mut self) -> Poll<Option<tls::conditional_accept::Match>, io::Error> {
         let sz = try_ready!(self.socket.read_buf(&mut self.peek_buf));
         if sz == 0 {

--- a/proxy/src/connection.rs
+++ b/proxy/src/connection.rs
@@ -219,25 +219,20 @@ impl Future for ConditionallyUpgradeServerToTls {
         loop {
             *self = match self {
                 ConditionallyUpgradeServerToTls::Plaintext(ref mut inner) => {
-                    let r = {
-                        let inner = inner.as_mut().unwrap();
-                        try_ready!(inner.socket.read_buf(&mut inner.peek_buf));
-                        tls::conditional_accept::match_client_hello(
-                            inner.peek_buf.as_ref(), &inner.tls.identity)
-                    };
-                    match r {
+                    let poll_match = inner
+                        .as_mut()
+                        .expect("polled after ready")
+                        .poll_match_client_hello();
+
+                    match try_ready!(poll_match) {
                         tls::conditional_accept::Match::Matched => {
                             trace!("upgrading accepted connection to TLS");
-                            let inner = inner.take().expect("Polled after ready");
-                            let upgrade_to_tls = tls::Connection::accept(
-                                inner.socket, inner.peek_buf.freeze(), inner.tls.config);
-                            ConditionallyUpgradeServerToTls::UpgradeToTls(upgrade_to_tls)
+                            let upgrade = inner.take().expect("polled after ready").into();
+                            ConditionallyUpgradeServerToTls::UpgradeToTls(upgrade)
                         },
                         tls::conditional_accept::Match::NotMatched => {
                             trace!("passing through accepted connection without TLS");
-                            let inner = inner.take().expect("Polled after ready");
-                            let conn = Connection::plain_with_peek_buf(
-                                inner.socket, inner.peek_buf, tls::ReasonForNoTls::NotProxyTls);
+                            let conn = inner.take().expect("polled after ready").into();
                             return Ok(Async::Ready(conn));
                         },
                         tls::conditional_accept::Match::Incomplete => {
@@ -251,6 +246,39 @@ impl Future for ConditionallyUpgradeServerToTls {
                 }
             }
         }
+    }
+}
+
+impl ConditionallyUpgradeServerToTlsInner {
+    /// Polls the underliyng socket for more data and buffers it.
+    ///
+    /// The buffer is matched for a TLS client hello message.
+    ///
+    /// An error is returned if the underlying socket has closed.
+    fn poll_match_client_hello(&mut self) -> Poll<tls:;conditional_accept::Match, io::Error> {
+        let sz = try_ready!(self.socket.read_buf(&mut self.peek_buf));
+        if sz == 0 {
+            return Err(io::ErrorKind::BrokenPipe.into());
+        }
+
+        let buf = self.peek_buf.as_ref();
+        Ok(tls::conditional_accept::match_client_hello(buf, &self.tls.identity).into())
+    }
+}
+
+impl Into<tls::UpgradeServerToTls> for ConditionallyUpgradeServerToTlsInner {
+    fn into(self) -> tls::UpgradeServerToTls {
+        tls::Connection::accept(self.socket, self.peek_buf.freeze(), self.tls.config)
+    }
+}
+
+impl Into<Connection> for ConditionallyUpgradeServerToTlsInner {
+    fn into(self) -> Connection {
+        Connection::plain_with_peek_buf(
+            self.socket,
+            self.peek_buf,
+            tls::ReasonForNoTls::NotProxyTls
+        )
     }
 }
 


### PR DESCRIPTION
During protocol detection, we buffer data to detect a TLS Client Hello
message. If the client disconnects while this detection occurs, we do
not properly handle the disconnect, and the proxy may busy loop.

To fix this, we must handle the case where `read(2)` returns 0 by
creating a `Connection` with the already-closed socket.

While doing this, I've moved some of the implementation of
`ConditionallyUpgradeServerToTls::poll` into helpers on
`ConditionallyUpgradeServerToTlsInner` so that the poll method is easier
to read, hiding the inner details from the polling logic.