### PR TITLE
Fix owner types in TLS identity strings

### DIFF
--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -30,6 +30,7 @@ func TestInjectYAML(t *testing.T) {
 		{"inject_emojivoto_statefulset.input.yml", "inject_emojivoto_statefulset.golden.yml", defaultOptions},
 		{"inject_emojivoto_pod.input.yml", "inject_emojivoto_pod.golden.yml", defaultOptions},
 		{"inject_emojivoto_deployment.input.yml", "inject_emojivoto_deployment_tls.golden.yml", tlsOptions},
+		{"inject_emojivoto_pod.input.yml", "inject_emojivoto_pod_tls.golden.yml", tlsOptions},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    conduit.io/created-by: conduit/cli undefined
+    conduit.io/proxy-version: testinjectversion
+  creationTimestamp: null
+  labels:
+    app: vote-bot
+    conduit.io/control-plane-ns: conduit
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v3
+    name: vote-bot
+    resources: {}
+  - env:
+    - name: CONDUIT_PROXY_LOG
+      value: warn,conduit_proxy=info
+    - name: CONDUIT_PROXY_BIND_TIMEOUT
+      value: 10s
+    - name: CONDUIT_PROXY_CONTROL_URL
+      value: tcp://proxy-api.conduit.svc.cluster.local:8086
+    - name: CONDUIT_PROXY_CONTROL_LISTENER
+      value: tcp://0.0.0.0:4190
+    - name: CONDUIT_PROXY_METRICS_LISTENER
+      value: tcp://0.0.0.0:4191
+    - name: CONDUIT_PROXY_PRIVATE_LISTENER
+      value: tcp://127.0.0.1:4140
+    - name: CONDUIT_PROXY_PUBLIC_LISTENER
+      value: tcp://0.0.0.0:4143
+    - name: CONDUIT_PROXY_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: CONDUIT_PROXY_TLS_TRUST_ANCHORS
+      value: /var/conduit-io/trust-anchors/trust-anchors.pem
+    - name: CONDUIT_PROXY_TLS_CERT
+      value: /var/conduit-io/identity/certificate.crt
+    - name: CONDUIT_PROXY_TLS_PRIVATE_KEY
+      value: /var/conduit-io/identity/private-key.p8
+    - name: CONDUIT_PROXY_TLS_POD_IDENTITY
+      value: vote-bot.pod.$CONDUIT_PROXY_POD_NAMESPACE.conduit-managed.conduit.svc.cluster.local
+    - name: CONDUIT_PROXY_CONTROLLER_NAMESPACE
+      value: conduit
+    - name: CONDUIT_PROXY_TLS_CONTROLLER_IDENTITY
+      value: controller.deployment.conduit.conduit-managed.conduit.svc.cluster.local
+    image: gcr.io/runconduit/proxy:testinjectversion
+    imagePullPolicy: IfNotPresent
+    name: conduit-proxy
+    ports:
+    - containerPort: 4143
+      name: conduit-proxy
+    - containerPort: 4191
+      name: conduit-metrics
+    resources: {}
+    securityContext:
+      runAsUser: 2102
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /var/conduit-io/trust-anchors
+      name: conduit-trust-anchors
+      readOnly: true
+    - mountPath: /var/conduit-io/identity
+      name: conduit-secrets
+      readOnly: true
+  initContainers:
+  - args:
+    - --incoming-proxy-port
+    - "4143"
+    - --outgoing-proxy-port
+    - "4140"
+    - --proxy-uid
+    - "2102"
+    - --inbound-ports-to-ignore
+    - 4190,4191
+    image: gcr.io/runconduit/proxy-init:testinjectversion
+    imagePullPolicy: IfNotPresent
+    name: conduit-init
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      privileged: false
+    terminationMessagePolicy: FallbackToLogsOnError
+  volumes:
+  - configMap:
+      name: conduit-ca-bundle
+      optional: true
+    name: conduit-trust-anchors
+  - name: conduit-secrets
+    secret:
+      optional: true
+      secretName: vote-bot-pod-tls-conduit-io
+status: {}
+---

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -163,8 +163,7 @@ func (c *CertificateController) handlePodAdd(obj interface{}) {
 		c.queue.Add(pod.Namespace)
 
 		ownerKind, ownerName := c.k8sAPI.GetOwnerKindAndName(pod)
-		ownerLabel := pkgK8s.KindToPromLabel[ownerKind]
-		item := fmt.Sprintf("%s.%s.%s", ownerName, ownerLabel, pod.Namespace)
+		item := fmt.Sprintf("%s.%s.%s", ownerName, ownerKind, pod.Namespace)
 		log.Debugf("enqueuing secret write for %s", item)
 		c.queue.Add(item)
 	}

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -43,6 +43,7 @@ func main() {
 		k8sClient,
 		k8s.Endpoint,
 		k8s.Pod,
+		k8s.RS,
 		k8s.Svc,
 	)
 

--- a/controller/destination/server.go
+++ b/controller/destination/server.go
@@ -117,7 +117,7 @@ func (s *server) podsByIp(ip string) ([]*v1.Pod, error) {
 }
 
 func (s *server) streamResolutionUsingCorrectResolverFor(host string, port int, stream pb.Destination_GetServer) error {
-	listener := newEndpointListener(stream, s.podsByIp, s.enableTLS)
+	listener := newEndpointListener(stream, s.podsByIp, s.k8sAPI.GetOwnerKindAndName, s.enableTLS)
 
 	for _, resolver := range s.resolvers {
 		resolverCanResolve, err := resolver.canResolve(host, port)

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -79,31 +79,15 @@ const (
 	TLSPrivateKeyFileName = "private-key.p8"
 )
 
-var podOwnerLabels = []string{
+var proxyLabels = []string{
+	ControllerNSLabel,
 	ProxyDeploymentLabel,
 	ProxyReplicationControllerLabel,
 	ProxyReplicaSetLabel,
 	ProxyJobLabel,
 	ProxyDaemonSetLabel,
 	ProxyStatefulSetLabel,
-}
-
-var proxyLabels = append(podOwnerLabels, []string{
-	ControllerNSLabel,
 	k8sV1.DefaultDeploymentUniqueLabelKey,
-}...)
-
-// TODO: these labels include invalid DNS subdomain characters (_). Fix by
-// using Kubernetes canonical names instead, but that also requires updates
-// to inject and the destination service.
-var KindToPromLabel = map[string]string{
-	"Pod":                   "pod",
-	"Deployment":            toOwnerLabel(ProxyDeploymentLabel),
-	"ReplicationController": toOwnerLabel(ProxyReplicationControllerLabel),
-	"ReplicaSet":            toOwnerLabel(ProxyReplicaSetLabel),
-	"Job":                   toOwnerLabel(ProxyJobLabel),
-	"DaemonSet":             toOwnerLabel(ProxyDaemonSetLabel),
-	"StatefulSet":           toOwnerLabel(ProxyStatefulSetLabel),
 }
 
 // CreatedByAnnotationValue returns the value associated with
@@ -127,15 +111,6 @@ func GetOwnerLabels(objectMeta meta.ObjectMeta) map[string]string {
 
 func GetControllerNs(objectMeta meta.ObjectMeta) string {
 	return objectMeta.Labels[ControllerNSLabel]
-}
-
-func GetOwnerKindAndName(labels map[string]string) (string, string) {
-	for _, label := range podOwnerLabels {
-		if v, ok := labels[label]; ok {
-			return toOwnerLabel(label), v
-		}
-	}
-	return "", ""
 }
 
 // toOwnerLabel converts a proxy label to a prometheus label, following the

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -126,16 +126,18 @@ func toOwnerLabel(proxyLabel string) string {
 	return strings.Replace(stripped, "-", "_", -1)
 }
 
-// TLSIdentity is the identity of a pod template (Deployment, Pod,
+// TLSIdentity is the identity of a pod owner (Deployment, Pod,
 // ReplicationController, etc.).
 type TLSIdentity struct {
-	// The name of the pod template.
+	// Name is the name of the pod owner.
 	Name string
 
-	// Kind is the result of GetOwnerType(pod.ObjectMeta) for a pod template.
+	// Kind is the singular, lowercased Kubernetes resource type of the pod owner
+	// (deployment, daemonset, job, replicationcontroller, etc.).
 	Kind string
 
-	// Namespace is the pod template's namespace.
+	// Namespace is the pod's namespace. Kubernetes requires that pods and
+	// pod owners be in the same namespace.
 	Namespace string
 
 	// ControllerNamespace is the namespace of the controller for the pod.


### PR DESCRIPTION
When I implemented the controller-side TlsIdentity strategy in #1215, I used resource type strings corresponding to the resource type labels that we use in prometheus. This is problematic because some prometheus labels include underscores, which aren't valid DNS subdomain characters. In this branch, I'm switching all of our code that touches TlsIdentity strategies (inject, destination service, ca-distributor), to instead use the Kubernetes singular resource name. We should also consider separately updating the prometheus labels to match, and that's captured in #740.