### PR TITLE
proxy: Add TLS label in `transparency::retry_reconnect_errors` test

### DIFF
--- a/proxy/tests/transparency.rs
+++ b/proxy/tests/transparency.rs
@@ -946,7 +946,7 @@ fn retry_reconnect_errors() {
     // all the other threads currently running...
     assert_eventually_contains!(
         metrics.get("/metrics"),
-        "tcp_open_total{direction=\"inbound\",peer=\"src\"} 1"
+        "tcp_open_total{direction=\"inbound\",peer=\"src\",tls=\"disabled\"} 1"
     );
 
     drop(tx); // start `listen` now


### PR DESCRIPTION
This PR fixes the `transparency::retry_reconnect_errors` test didn't
 expect the newly-added `tls=` field in metrics labels. This wasn't 
caught earlier as the test is tagged as flaky and not run on CI. This 
branch adds it to the expected labels.