### PR TITLE
proxy: Fix out-of-control inotify CPU use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)",
+ "inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/mio)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -461,12 +461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "inotify"
 version = "0.5.2-dev"
-source = "git+https://github.com/inotify-rs/inotify#901abf4e076e2c96bc4d485d235b7f732bf01b36"
+source = "git+https://github.com/hawkw/inotify?branch=eliza/mio#548eafc423f8506fcbee38ae82d9071b2bd0abbd"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1584,7 +1587,7 @@ dependencies = [
 "checksum hyper 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f31c3ce511142fac936539abd3315bdc303a6e501fac5b77e0824310d542d081"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
-"checksum inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)" = "<none>"
+"checksum inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/mio)" = "<none>"
 "checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec4e18c0a0d4340870c14284293632d8421f419008371422dd327892b88877c"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -62,8 +62,7 @@ untrusted = "0.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-# We can use the `crates.io` version of `inotify` once 0.5.2 has been released.
-inotify = { git = "https://github.com/inotify-rs/inotify" }
+inotify = { git = "https://github.com/hawkw/inotify", branch = "eliza/mio" }
 procinfo = "0.4.2"
 
 [dev-dependencies]


### PR DESCRIPTION
The `inotify-rs` library's `EventStream` implementation currently 
calls `task::current().notify()` in a hot loop when a poll returns
`WouldBlock`, causing the task to constantly burn CPU. 

This branch updates the `inotify-rs` dependency to point at a branch
of `inotify-rs` I had previously written. That branch  rewrites the 
`EventStream` to use `mio` to  register interest in the `inotify` file 
descriptor instead, fixing the out-of-control polling. 

When inotify-rs/inotify#105 is merged upstream, we can go back to 
depending on the master version of the library.

Fixes #1261

Signed-off-by: Eliza Weisman <eliza@buoyant.io>