### PR TITLE
Unhide --tls flag in conduit CLI

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -158,5 +158,4 @@ func addProxyConfigFlags(cmd *cobra.Command, options *proxyConfigOptions) {
 	cmd.PersistentFlags().UintVar(&options.proxyControlPort, "control-port", options.proxyControlPort, "Proxy port to use for control")
 	cmd.PersistentFlags().UintVar(&options.proxyMetricsPort, "metrics-port", options.proxyMetricsPort, "Proxy port to serve metrics on")
 	cmd.PersistentFlags().StringVar(&options.tls, "tls", options.tls, "Enable TLS; valid settings: \"optional\"")
-	cmd.PersistentFlags().MarkHidden("tls")
 }


### PR DESCRIPTION
We had previously hidden the `--tls` flag in the CLI, before TLS was ready to go. Unhiding it now.

```
$ bin/conduit help install
Output Kubernetes configs to install Conduit.

Usage:
  conduit install [flags]

Flags:
      --api-port uint                 Port where the Conduit controller is running (default 8086)
  -v, --conduit-version string        Tag to be used for Conduit images (default "dev-693acdbf-kl")
      --control-port uint             Proxy port to use for control (default 4190)
      --controller-log-level string   Log level for the controller and web components (default "info")
      --controller-replicas uint      Replicas of the controller to deploy (default 1)
  -h, --help                          help for install
      --image-pull-policy string      Docker image pull policy (default "IfNotPresent")
      --init-image string             Conduit init container image name (default "gcr.io/runconduit/proxy-init")
      --metrics-port uint             Proxy port to serve metrics on (default 4191)
      --prometheus-replicas uint      Replicas of prometheus to deploy (default 1)
      --proxy-bind-timeout string     Timeout the proxy will use (default "10s")
      --proxy-image string            Conduit proxy container image name (default "gcr.io/runconduit/proxy")
      --proxy-log-level string        Log level for the proxy (default "warn,conduit_proxy=info")
      --proxy-uid int                 Run the proxy under this user ID (default 2102)
      --registry string               Docker registry to pull images from (default "gcr.io/runconduit")
      --tls string                    Enable TLS; valid settings: "optional"
      --web-replicas uint             Replicas of the web server to deploy (default 1)

Global Flags:
      --api-addr string            Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)
  -c, --conduit-namespace string   Namespace in which Conduit is installed (default "conduit")
      --kubeconfig string          Path to the kubeconfig file to use for CLI requests
      --verbose                    Turn on debug logging
```

Fixes #1017.