### PR TITLE
Fix default SMTP port in docs

### DIFF
--- a/doc/adding-your-service.md
+++ b/doc/adding-your-service.md
@@ -47,7 +47,7 @@ For protocols where the server sends data before the client sends data over
 connections that aren't protected by TLS, Conduit cannot automatically recognize
 the protocol used on the connection. Two common examples of this type of
 protocol are MySQL and SMTP. If you are using Conduit to proxy plaintext MySQL
-or SMTP requests on their default ports (3306 and 22, respectively), then Conduit
+or SMTP requests on their default ports (3306 and 25, respectively), then Conduit
 is able to successfully identify these protocols based on the port. If you're
 using non-default ports, or if you're using a different server-speaks-first
 protocol, then you'll need to manually configure Conduit to recognize these
@@ -60,5 +60,5 @@ running `conduit inject`.
 ### For example, if your application makes requests to a MySQL database running on port 4406, use the command:
 #### `conduit inject deployment.yml --skip-outbound-ports=4406 | kubectl apply -f -`
 
-### Likewise if your application runs an SMTP server that accepts incoming requests on port 33, use the command:
-#### `conduit inject deployment.yml --skip-inbound-ports=33 | kubectl apply -f -`
+### Likewise if your application runs an SMTP server that accepts incoming requests on port 35, use the command:
+#### `conduit inject deployment.yml --skip-inbound-ports=35 | kubectl apply -f -`


### PR DESCRIPTION
I referenced the wrong default SMTP port in the docs update in #1279. This fixes it.