### PR TITLE
Fix authority stat queries when a --from flag is used

### DIFF
--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -291,7 +291,9 @@ func promGroupByLabelNames(resource *pb.Resource) model.LabelNames {
 func promDstGroupByLabelNames(resource *pb.Resource) model.LabelNames {
 	names := model.LabelNames{dstNamespaceLabel}
 
-	if resource.Type != k8s.Namespaces {
+	if isNonK8sResourceQuery(resource.GetType()) {
+		names = append(names, promResourceType(resource))
+	} else if resource.Type != k8s.Namespaces {
 		names = append(names, "dst_"+promResourceType(resource))
 	}
 	return names


### PR DESCRIPTION
Previously, we were only checking to make sure we didn't add `dst_authorities` in the query labels in `promDstQueryLabels` but we weren't checking the groupBy labels in `promDstGroupByLabelNames` - this caused us to try to query for `dst_authorities` when a `--from` query was sent. There are no `dst_authorities`, so there would be no named results.

Before:
```
$ go run cli/main.go stat au --kubeconfig ~/.kube/config --api-addr localhost:8085 -n emojivoto --from deploy/web
NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
            -    90.75%   2.9rps           1ms          19ms          27ms    0%
```

After:
```
$ go run cli/main.go stat au --kubeconfig ~/.kube/config --api-addr localhost:8085 -n emojivoto --from deploy/web
NAME                        MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
emoji-svc.emojivoto:8080         -   100.00%   2.0rps           1ms           5ms          38ms    0%
voting-svc.emojivoto:8080        -    68.85%   1.0rps           1ms           9ms          10ms    0%
```

Fixes #1280

